### PR TITLE
Fix Installer to create ark alias

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -6,7 +6,7 @@
 #########################
 
 export VERIFY_CHECKSUM=0
-export ALIAS="ark"
+export ALIAS_NAME="ark"
 export OWNER=alexellis
 export REPO=arkade
 export SUCCESS_CMD="$REPO version"


### PR DESCRIPTION
The ALIAS var in get.sh was not being used. It was looking for
ALIAS_NAME, so I have updated to that.

This was tested with `sudo sh get.sh`.

Alias was created correctly


Fixes #1 

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>