### PR TITLE
Fixes #31: add --wait global option to the install command

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -25,6 +25,7 @@ command.`,
 	}
 
 	command.PersistentFlags().String("kubeconfig", "kubeconfig", "Local path for your kubeconfig file")
+	command.PersistentFlags().Bool("wait", false, "If we should wait for the resource to be ready before returning (helm3 only, default false)")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 


### PR DESCRIPTION
This PR Fixes #31. Add the --wait global option to the install command, which was
accidentally removed in an older PR.

Signed-off-by: Markus Hartmann <markush1986@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the --wait option which was deleted in an older PR:

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this change the --wait option do not work.
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

go build
./arkade install openfaas --wait

--> in the logs is the helm command with --wait appended

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

