### PR TITLE
Use GOARCH and GOOS

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,33 +1,14 @@
 package env
 
 import (
-	"log"
 	"os"
 	"path"
-	"strings"
-
-	execute "github.com/alexellis/go-execute/pkg/v1"
+	"runtime"
 )
 
 // GetClientArch returns a pair of arch and os
 func GetClientArch() (string, string) {
-	task := execute.ExecTask{Command: "uname", Args: []string{"-m"}, StreamStdio: false}
-	res, err := task.Execute()
-	if err != nil {
-		log.Println(err)
-	}
-
-	arch := strings.TrimSpace(res.Stdout)
-
-	taskOS := execute.ExecTask{Command: "uname", Args: []string{"-s"}, StreamStdio: false}
-	resOS, errOS := taskOS.Execute()
-	if errOS != nil {
-		log.Println(errOS)
-	}
-
-	os := strings.TrimSpace(resOS.Stdout)
-
-	return arch, os
+	return runtime.GOARCH, runtime.GOOS
 }
 
 func LocalBinary(name, subdir string) string {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Uses go-native way to get arch and os instead of executing commands

## Motivation and Context
Less code, faster, probably supports windows

## How Has This Been Tested?
I've compiled and run arkade
