### PR TITLE
Added helm3 option to minio app

### DIFF
--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -30,12 +30,14 @@ func MakeInstallMinio() *cobra.Command {
 	minio.Flags().String("secret-key", "", "Provide a secret key to override the pre-generated value")
 	minio.Flags().Bool("distributed", false, "Deploy Minio in Distributed Mode")
 	minio.Flags().String("namespace", "default", "Kubernetes namespace for the application")
+	minio.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 	minio.Flags().Bool("persistence", false, "Enable persistence")
 	minio.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set persistence.enabled=true)")
 
 	minio.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
+		wait, _ := command.Flags().GetBool("wait")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -43,6 +45,11 @@ func MakeInstallMinio() *cobra.Command {
 		updateRepo, _ := minio.Flags().GetBool("update-repo")
 
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+		helm3, _ := command.Flags().GetBool("helm3")
+
+		if helm3 {
+			fmt.Println("Using helm3")
+		}
 
 		userPath, err := config.InitUserDir()
 		if err != nil {
@@ -62,20 +69,25 @@ func MakeInstallMinio() *cobra.Command {
 			return fmt.Errorf("please use the helm chart if you'd like to change the namespace to %s", ns)
 		}
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, false)
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
+		if err != nil {
+			return err
+		}
+
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", helm3)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos(helm3)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/minio", defaultVersion, false)
+		err = fetchChart(chartPath, "stable/minio", defaultVersion, helm3)
 
 		if err != nil {
 			return err
@@ -87,13 +99,20 @@ func MakeInstallMinio() *cobra.Command {
 		accessKey, _ := minio.Flags().GetString("access-key")
 		secretKey, _ := minio.Flags().GetString("secret-key")
 
+		gen, err := password.NewGenerator(&password.GeneratorInput{
+			Symbols: "+/",
+		})
+		if err != nil {
+			return err
+		}
+
 		if len(accessKey) == 0 {
 			fmt.Printf("Access Key not provided, one will be generated for you\n")
-			accessKey, err = password.Generate(20, 10, 0, false, true)
+			accessKey, err = gen.Generate(20, 10, 0, false, true)
 		}
 		if len(secretKey) == 0 {
 			fmt.Printf("Secret Key not provided, one will be generated for you\n")
-			secretKey, err = password.Generate(40, 10, 5, false, true)
+			secretKey, err = gen.Generate(40, 10, 5, false, true)
 		}
 
 		if err != nil {
@@ -118,23 +137,38 @@ func MakeInstallMinio() *cobra.Command {
 			return err
 		}
 
-		outputPath := path.Join(chartPath, "minio/rendered")
+		if helm3 {
+			outputPath := path.Join(chartPath, "minio")
 
-		err = templateChart(chartPath,
-			"minio",
-			ns,
-			outputPath,
-			"values.yaml",
-			overrides)
+			err := helm3Upgrade(outputPath, "stable/minio", ns,
+				"values.yaml",
+				defaultVersion,
+				overrides,
+				wait)
 
-		if err != nil {
-			return err
-		}
+			if err != nil {
+				return err
+			}
 
-		err = kubectl("apply", "-R", "-f", outputPath)
+		} else {
+			outputPath := path.Join(chartPath, "minio/rendered")
 
-		if err != nil {
-			return err
+			err = templateChart(chartPath,
+				"minio",
+				ns,
+				outputPath,
+				"values.yaml",
+				overrides)
+
+			if err != nil {
+				return err
+			}
+
+			err = kubectl("apply", "-R", "-f", outputPath)
+
+			if err != nil {
+				return err
+			}
 		}
 
 		fmt.Println(minioInstallMsg)


### PR DESCRIPTION
Signed-off-by: kadern0 <kaderno@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Added
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #7 


## How Has This Been Tested?
Run:
```
 ./arkade install minio --set persistence.enabled=false
Using kubeconfig: /home/kaderno/.kube/config
Using helm3
Client: x86_64, Linux
2020/03/10 20:24:48 User dir established as: /home/kaderno/.arkade/
"stable" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
Access Key not provided, one will be generated for you
Secret Key not provided, one will be generated for you
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install minio stable/minio --namespace default --values /tmp/charts/minio/values.yaml --set accessKey=87WG8If4g821crqV19P3 --set secretKey=LaoCw33dc7eW9Nzf4ZoYHkDE9525cTVT1VfWpEuw --set persistence.enabled=false]
Release "minio" has been upgraded. Happy Helming!
NAME: minio
LAST DEPLOYED: Tue Mar 10 20:24:57 2020
NAMESPACE: default
STATUS: deployed
REVISION: 35
TEST SUITE: None
NOTES:
Minio can be accessed via port 9000 on the following DNS name from within your cluster:
minio.default.svc.cluster.local

To access Minio from localhost, run the below commands:

  1. export POD_NAME=$(kubectl get pods --namespace default -l "release=minio" -o jsonpath="{.items[0].metadata.name}")

  2. kubectl port-forward $POD_NAME 9000 --namespace default

Read more about port forwarding here: http://kubernetes.io/docs/user-guide/kubectl/kubectl_port-forward/

You can now access Minio server on http://localhost:9000. Follow the below steps to connect to Minio server with mc client:

  1. Download the Minio mc client - https://docs.minio.io/docs/minio-client-quickstart-guide

  2. mc config host add minio-local http://localhost:9000 87WG8If4g821crqV19P3 LaoCw33dc7eW9Nzf4ZoYHkDE9525cTVT1VfWpEuw S3v4

  3. mc ls minio-local

Alternately, you can use your browser or the Minio SDK to access the server - https://docs.minio.io/categories/17
=======================================================================
= Minio has been installed.                                           =
=======================================================================

# Forward the minio port to your machine
kubectl port-forward -n default svc/minio 9000:9000 &

# Get the access and secret key to gain access to minio
ACCESSKEY=$(kubectl get secret -n default minio -o jsonpath="{.data.accesskey}" | base64 --decode; echo)
SECRETKEY=$(kubectl get secret -n default minio -o jsonpath="{.data.secretkey}" | base64 --decode; echo)

# Get the Minio Client
curl -SLf https://dl.min.io/client/mc/release/linux-amd64/mc \
  && chmod +x mc

# Add a host
mc config host add minio http://127.0.0.1:9000 $ACCESSKEY $SECRETKEY

# List buckets
mc ls minio

# Find out more at: https://min.io

Thanks for using arkade!
```

```
 kubectl get po
NAME                                             READY   STATUS    RESTARTS   AGE
minio-66c9b9f79b-49wp7                           1/1     Running   0          89s
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

