### PR TITLE
Added architecture check to allow only x86-64 installations

### DIFF
--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -44,6 +44,13 @@ func MakeInstallMongoDB() *cobra.Command {
 
 		namespace, _ := command.Flags().GetString("namespace")
 
+		arch := getNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(`only Intel, i.e. PC architecture is supported for this app`)
+		}
+
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -45,6 +45,13 @@ func MakeInstallPostgresql() *cobra.Command {
 
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
+		arch := getNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(`only Intel, i.e. PC architecture is supported for this app`)
+		}
+
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added architecture check to prevent installation on non Intel nodes as it would fail.

## Description
Added same check as Istio app. 

## Motivation and Context
Fixes #51 


## How Has This Been Tested?
```
 ./arkade install mongodb
Using kubeconfig: /home/kaderno/.kube/config
Node architecture: "arm"
Error: only Intel, i.e. PC architecture is supported for this app

 ./arkade install postgresql
Using kubeconfig: /home/kaderno/.kube/config
Node architecture: "arm"
Error: only Intel, i.e. PC architecture is supported for this app
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

