### PR TITLE
Added arm support

### DIFF
--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -1,6 +1,3 @@
-// Copyright (c) arkade author(s) 2020. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 package apps
 
 import (
@@ -48,6 +45,9 @@ func MakeInstallMetricsServer() *cobra.Command {
 			return fmt.Errorf(`to override the "kube-system", install via tiller`)
 		}
 
+		arch := getNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
 		helm3, _ := command.Flags().GetBool("helm3")
 
 		if helm3 {
@@ -78,6 +78,15 @@ func MakeInstallMetricsServer() *cobra.Command {
 
 		overrides := map[string]string{}
 		overrides["args"] = `{--kubelet-insecure-tls,--kubelet-preferred-address-types=InternalIP\,ExternalIP\,Hostname}`
+		switch arch {
+		case "arm":
+			overrides["image.repository"] = `gcr.io/google_containers/metrics-server-arm`
+			break
+		case "arm64", "aarch64":
+			overrides["image.repository"] = `gcr.io/google_containers/metrics-server-arm64`
+			break
+		}
+
 		fmt.Println("Chart path: ", chartPath)
 
 		if helm3 {


### PR DESCRIPTION
Signed-off-by: kadern0 <kaderno@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

Added ARM support for metrics-server helm chart

## Description
<!--- Describe your changes in detail -->
I've used the same architecture check as in other apps, and then depending on the architecture, the `image.repository` will be overwritten. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #50 


## How Has This Been Tested?
```
./arkade install metrics-server --namespace kube-system
Using kubeconfig: /home/kaderno/.kube/config
Node architecture: "arm"
Using helm3
Client: "x86_64", "Linux"
2020/03/14 19:04:55 User dir established as: /home/kaderno/.arkade/
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "inlets" chart repository
...Unable to get an update from the "kadern0" chart repository (https://kadern0.github.io/helm-chart/):
	failed to fetch https://kadern0.github.io/helm-chart/index.yaml : 404 Not Found
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
Chart path:  /tmp/charts
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install metrics-server stable/metrics-server --namespace kube-system --values /tmp/charts/metrics-server/values.yaml --set args={--kubelet-insecure-tls,--kubelet-preferred-address-types=InternalIP\,ExternalIP\,Hostname} --set image.repository=gcr.io/google_containers/metrics-server-arm]
Release "metrics-server" has been upgraded. Happy Helming!
NAME: metrics-server
LAST DEPLOYED: Sat Mar 14 19:05:01 2020
NAMESPACE: kube-system
STATUS: deployed
REVISION: 7
NOTES:
The metric server has been deployed. 

In a few minutes you should be able to list metrics using the following
command:

  kubectl get --raw "/apis/metrics.k8s.io/v1beta1/nodes"
=======================================================================
= metrics-server has been installed.                                  =
=======================================================================

# It can take a few minutes for the metrics-server to collect data
# from the cluster. Try these commands and wait a few moments if
# no data is showing.

# Check pod usage

kubectl top pod

# Check node usage

kubectl top node


# Find out more at:
# https://github.com/helm/charts/tree/master/stable/metrics-server
```
And it seems to be working fine:
```
kubectl top node
NAME       CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%   
master     382m         9%     570Mi           14%       
worker-2   114m         2%     209Mi           5%        
worker-3   77m          1%     213Mi           5%        
worker-4   86m          2%     187Mi           4%        
kaderno@kaderno-XPS-13-9360:~/go/src/github.com/alexellis/arkade$ kubectl top pod
NAME                      CPU(cores)   MEMORY(bytes)   
postgresql-postgresql-0   0m           0Mi             
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

