### PR TITLE
Add Tekton App

### DIFF
--- a/cmd/apps/tekton_app.go
+++ b/cmd/apps/tekton_app.go
@@ -1,0 +1,70 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+
+	"github.com/alexellis/arkade/pkg"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallTekton() *cobra.Command {
+	var tekton = &cobra.Command{
+		Use:          "tekton",
+		Short:        "Install Tekton pipelines and dashboard",
+		Long:         `Install Tekton pipelines and dashboard`,
+		Example:      `  arkade install tekton`,
+		SilenceUsage: true,
+	}
+
+	tekton.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath := getDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		arch := getNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(`only Intel and AMD (i.e. PC) architecture is supported for this app`)
+		}
+
+		fmt.Println("Installing Tekton pipelines...")
+		_, err := kubectlTask("apply", "-f",
+			"https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Installing Tekton dashboard...")
+		_, err = kubectlTask("apply", "-f",
+			"https://github.com/tektoncd/dashboard/releases/download/v0.5.1/tekton-dashboard-release.yaml")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(TektonInstallMsg)
+
+		return nil
+	}
+
+	return tekton
+}
+
+const TektonInfoMsg = `For more information on accessing the
+Tekton dashboard: https://github.com/tektoncd/dashboard
+
+Want to launch a Tekton pipeline and see it in action?
+Get one here: https://github.com/tektoncd/pipeline/tree/master/examples`
+
+const TektonInstallMsg = `=======================================================================
+= Tekton pipelines and dashboard have been installed. =
+=======================================================================` +
+	"\n\n" + TektonInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -89,6 +89,9 @@ arkade info --help`,
 		case "traefik2":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.Traefik2InfoMsg)
+		case "tekton":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.TektonInfoMsg)
 		case "grafana":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.GrafanaInfoMsg)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -63,6 +63,7 @@ command.`,
 	command.AddCommand(apps.MakeInstallGrafana())
 	command.AddCommand(apps.MakeInstallArgoCD())
 	command.AddCommand(apps.MakeInstallPortainer())
+	command.AddCommand(apps.MakeInstallTekton())
 
 	command.AddCommand(MakeInfo())
 
@@ -90,5 +91,6 @@ func getApps() []string {
 		"docker-registry-ingress",
 		"traefik2",
 		"grafana",
+		"tekton",
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add Tekton installation target, which includes both pipelines and the dashboard.

## Description
<!--- Describe your changes in detail -->
Followed the format for other applications, and added a Tekton installation target using the kubectl library from the repository.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Tekton pipelines is a rapidly growing CI/CD pipelines service in k8s. This will add installation support for it.

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/alexellis/arkade/issues/49


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The code was formatted, vetted, and then ```go test -v ./...``` was ran against it.

After a successful ```make build```, it was manually tested via a Minikube cluster on Ubuntu 19.10 (amd64).
Here is some STDOUT that shows it in action.

```bash
nick at thinkpad in ~/git/arkade
% k version
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.4", GitCommit:"8d8aa39598534325ad77120c120a22b3a990b5ea", GitTreeState:"clean", BuildDate:"2020-03-12T21:03:42Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:07:13Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
```
Cluster before installation.

```bash
nick at thinkpad in ~/git/arkade
% k get pods -A
NAMESPACE     NAME                          READY   STATUS    RESTARTS   AGE
kube-system   coredns-6955765f44-8mc67      1/1     Running   1          5d15h
kube-system   coredns-6955765f44-hgtb6      1/1     Running   1          5d15h
kube-system   etcd-m01                      1/1     Running   1          5d15h
kube-system   kube-apiserver-m01            1/1     Running   1          5d15h
kube-system   kube-controller-manager-m01   1/1     Running   1          5d15h
kube-system   kube-proxy-28czt              1/1     Running   1          5d15h
kube-system   kube-scheduler-m01            1/1     Running   1          5d15h
kube-system   storage-provisioner           1/1     Running   2          5d15h
```

Arkade with no args.

```bash
nick at thinkpad in ~/git/arkade
% ./arkade 
            _             _      
  __ _ _ __| | ____ _  __| | ___ 
 / _` | '__| |/ / _` |/ _` |/ _ \
| (_| | |  |   < (_| | (_| |  __/
 \__,_|_|  |_|\_\__,_|\__,_|\___|

Get Kubernetes apps the easy way

Usage:
  arkade [flags]
  arkade [command]

Available Commands:
  help        Help about any command
  info        Find info about a Kubernetes app
  install     Install Kubernetes apps from helm charts or YAML files
  update      Print update instructions
  version     Print the version

Flags:
  -h, --help   help for arkade

Use "arkade [command] --help" for more information about a command.
```

Invoking the info subcommand with Tekton.

```bash
nick at thinkpad in ~/git/arkade
% ./arkade info tekton
Info for app: tekton
For more information on accessing the
Tekton dashboard: https://github.com/tektoncd/dashboard

Want to launch a Tekton pipeline and see it in action?
Get one here: https://github.com/tektoncd/pipeline/tree/master/examples
```

Invoking the install subcommand with Tekton.

```bash
nick at thinkpad in ~/git/arkade
% ./arkade install tekton
Using kubeconfig: /home/nick/.kube/config
Node architecture: "amd64"
Installing Tekton pipelines...
Installing Tekton dashboard...
=======================================================================
= Tekton pipelines and dashboard have been installed. =
=======================================================================

For more information on accessing the
Tekton dashboard: https://github.com/tektoncd/dashboard

Want to launch a Tekton pipeline and see it in action?
Get one here: https://github.com/tektoncd/pipeline/tree/master/examples

Thanks for using arkade!
```

The cluster with Tekton installed.

```bash
nick at thinkpad in ~/git/arkade
% k get pods -A
NAMESPACE          NAME                                         READY   STATUS    RESTARTS   AGE
kube-system        coredns-6955765f44-8mc67                     1/1     Running   1          5d15h
kube-system        coredns-6955765f44-hgtb6                     1/1     Running   1          5d15h
kube-system        etcd-m01                                     1/1     Running   1          5d15h
kube-system        kube-apiserver-m01                           1/1     Running   1          5d15h
kube-system        kube-controller-manager-m01                  1/1     Running   1          5d15h
kube-system        kube-proxy-28czt                             1/1     Running   1          5d15h
kube-system        kube-scheduler-m01                           1/1     Running   1          5d15h
kube-system        storage-provisioner                          1/1     Running   2          5d15h
tekton-pipelines   tekton-dashboard-6d9f5b4fc5-87p9w            0/1     Running   0          14s
tekton-pipelines   tekton-pipelines-controller-7dd68f58-5d4v4   1/1     Running   0          15s
tekton-pipelines   tekton-pipelines-webhook-5b579966f4-nbcl2    1/1     Running   0          15s
```

Here is an example of a TaskRun in action.

```bash
nick at thinkpad in ~/git/arkade
% kubectl apply -f example.yaml 
taskrun.tekton.dev/example-taskrun created
nick at thinkpad in ~/git/arkade
% k logs -n default example-taskrun-pod-kmv2l 
Hello world!
nick at thinkpad in ~/git/arkade
% k get pods -n default 
NAME                                                      READY   STATUS      RESTARTS   AGE
example-taskrun-pod-kmv2l                                 0/1     Completed   0          25s
```

This is "example.yaml", which invokes a TaskRun using a nested Task spec. TaskRuns are invocations of stored Tasks.

```bash
nick at thinkpad in ~/git/arkade
% cat example.yaml 

apiVersion: tekton.dev/v1alpha1
kind: TaskRun
metadata:
  name: example-taskrun
spec:
  taskSpec:
    steps:
      - name: ubuntu
        image: ubuntu:bionic
        command:
          - echo
        args:
          - "Hello world!"
```

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Testing Environment

**Does this affect other areas of the code?**
This lives on its own, fortunately.
It relies on one global variable from ```istio_app.go```, but it is a plugin to the existing Arkade skaffolding.

Here are some details on the env (Ubuntu 19.10 amd64)...

```bash
% kubectl version
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.4", GitCommit:"8d8aa39598534325ad77120c120a22b3a990b5ea", GitTreeState:"clean", BuildDate:"2020-03-12T21:03:42Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.3", GitCommit:"06ad960bfd03b39c8310aaf92d1e7c12ce618213", GitTreeState:"clean", BuildDate:"2020-02-11T18:07:13Z", GoVersion:"go1.13.6", Compiler:"gc", Platform:"linux/amd64"}
```

```bash
% go version
go version go1.14 linux/amd64
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I do not think my code requires a documentation change (following Grafana's lead) and I did not add any new tests.

Thank you in advance for looking this over.

