### PR TITLE
Fixes #54: Add cli completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,236 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/spf13/cobra"
+)
+
+var shell string
+
+func MakeCompletion() *cobra.Command {
+	var completionCmd = &cobra.Command{
+		Use:   "completion SHELL",
+		Short: "Generates shell completion",
+		Long: `Generates shell auto completion for Bash or ZSH.
+
+You can enable completion using the following:
+source <(arkade completion)
+
+To configure your bash/zsh shell to load completions for each session, add to your bashrc/zshrc
+
+# ~/.bashrc or ~/.zshrc
+source <(arkade completion)
+`,
+		Example: `  arkade completion --shell bash
+  arkade completion --shell zsh`,
+		RunE: runCompletion,
+	}
+
+	completionCmd.Flags().StringVar(&shell, "shell", "", "Outputs shell completion, must be bash or zsh")
+
+	return completionCmd
+}
+
+func runCompletion(cmd *cobra.Command, args []string) (err error) {
+	if shell == "" {
+		re := regexp.MustCompile(`.*/`)
+		shell = re.ReplaceAllString(os.Getenv("SHELL"), "")
+	}
+
+	switch shell {
+	case "bash":
+		err = bashCompletion(cmd)
+		if err != nil {
+			return err
+		}
+		return nil
+
+	case "zsh":
+		err = generateZshCompletion(cmd)
+		if err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("%q shell not supported, must be bash or zsh", shell)
+	}
+}
+
+func bashCompletion(cmd *cobra.Command) error {
+	err := cmd.Parent().GenBashCompletion(os.Stdout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateZshCompletion(cmd *cobra.Command) error {
+	zshHead := "#compdef arkade\n"
+
+	out := os.Stdout
+
+	_, err := out.Write([]byte(zshHead))
+	if err != nil {
+		return err
+	}
+
+	zshInitialization := `
+__arkade_bash_source() {
+	alias shopt=':'
+	alias _expand=_bash_expand
+	alias _complete=_bash_comp
+	emulate -L sh
+	setopt kshglob noshglob braceexpand
+	source "$@"
+}
+__arkade_type() {
+	# -t is not supported by zsh
+	if [ "$1" == "-t" ]; then
+		shift
+		# fake Bash 4 to disable "complete -o nospace". Instead
+		# "compopt +-o nospace" is used in the code to toggle trailing
+		# spaces. We don't support that, but leave trailing spaces on
+		# all the time
+		if [ "$1" = "__arkade_compopt" ]; then
+			echo builtin
+			return 0
+		fi
+	fi
+	type "$@"
+}
+__arkade_compgen() {
+	local completions w
+	completions=( $(compgen "$@") ) || return $?
+	# filter by given word as prefix
+	while [[ "$1" = -* && "$1" != -- ]]; do
+		shift
+		shift
+	done
+	if [[ "$1" == -- ]]; then
+		shift
+	fi
+	for w in "${completions[@]}"; do
+		if [[ "${w}" = "$1"* ]]; then
+			echo "${w}"
+		fi
+	done
+}
+__arkade_compopt() {
+	true # don't do anything. Not supported by bashcompinit in zsh
+}
+__arkade_ltrim_colon_completions()
+{
+	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
+		# Remove colon-word prefix from COMPREPLY items
+		local colon_word=${1%${1##*:}}
+		local i=${#COMPREPLY[*]}
+		while [[ $((--i)) -ge 0 ]]; do
+			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
+		done
+	fi
+}
+__arkade_get_comp_words_by_ref() {
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
+	words=("${COMP_WORDS[@]}")
+	cword=("${COMP_CWORD[@]}")
+}
+__arkade_filedir() {
+	local RET OLD_IFS w qw
+	__arkade_debug "_filedir $@ cur=$cur"
+	if [[ "$1" = \~* ]]; then
+		# somehow does not work. Maybe, zsh does not call this at all
+		eval echo "$1"
+		return 0
+	fi
+	OLD_IFS="$IFS"
+	IFS=$'\n'
+	if [ "$1" = "-d" ]; then
+		shift
+		RET=( $(compgen -d) )
+	else
+		RET=( $(compgen -f) )
+	fi
+	IFS="$OLD_IFS"
+	IFS="," __arkade_debug "RET=${RET[@]} len=${#RET[@]}"
+	for w in ${RET[@]}; do
+		if [[ ! "${w}" = "${cur}"* ]]; then
+			continue
+		fi
+		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
+			qw="$(__arkade_quote "${w}")"
+			if [ -d "${w}" ]; then
+				COMPREPLY+=("${qw}/")
+			else
+				COMPREPLY+=("${qw}")
+			fi
+		fi
+	done
+}
+__arkade_quote() {
+	if [[ $1 == \'* || $1 == \"* ]]; then
+		# Leave out first character
+		printf %q "${1:1}"
+	else
+	printf %q "$1"
+	fi
+}
+autoload -U +X bashcompinit && bashcompinit
+# use word boundary patterns for BSD or GNU sed
+LWORD='[[:<:]]'
+RWORD='[[:>:]]'
+if sed --help 2>&1 | grep -q GNU; then
+	LWORD='\<'
+	RWORD='\>'
+fi
+__arkade_convert_bash_to_zsh() {
+	sed \
+	-e 's/declare -F/whence -w/' \
+	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
+	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
+	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
+	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
+	-e "s/${LWORD}_filedir${RWORD}/__arkade_filedir/g" \
+	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__arkade_get_comp_words_by_ref/g" \
+	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__arkade_ltrim_colon_completions/g" \
+	-e "s/${LWORD}compgen${RWORD}/__arkade_compgen/g" \
+	-e "s/${LWORD}compopt${RWORD}/__arkade_compopt/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
+	-e "s/\\\$(type${RWORD}/\$(__arkade_type/g" \
+	<<'BASH_COMPLETION_EOF'
+`
+	_, err = out.Write([]byte(zshInitialization))
+	if err != nil {
+		return err
+	}
+
+	buf := new(bytes.Buffer)
+	cmd.Parent().GenBashCompletion(buf)
+
+	_, err = out.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	zshTail := `
+BASH_COMPLETION_EOF
+}
+__arkade_bash_source <(__arkade_convert_bash_to_zsh)
+_complete arkade 2>/dev/null
+`
+	_, err = out.Write([]byte(zshTail))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 	rootCmd.AddCommand(cmd.MakeUpdate())
 	rootCmd.AddCommand(cmd.MakeGet())
 	rootCmd.AddCommand(cmd.MakeUninstall())
+	rootCmd.AddCommand(cmd.MakeCompletion())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION

Fixes #54

Enables completion for the cli options

## Description
This change enables cli completion feature, for both bash and zsh, by the use of the tab key (given all requirement are met, see  https://docs.openfaas.com/cli/completion)

## Motivation and Context
Enhance cli user experience by hinting cli options and completing them once they are uniquely idenfied. 

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested manually in both bash and zsh shells.
```
$ arkade help completion
Generates shell auto completion for Bash or ZSH.

Please follow the instructions in the link below to activate the shell auto completion in your environment:
https://docs.openfaas.com/cli/completion/

Usage:
  arkade completion SHELL [flags]

Flags:
  -h, --help           help for completion
      --shell string   Outputs shell completion, must be bash or zsh
$ . <(arkade completion --shell bash)

$ arkade in
info     install

$ arkade install
cert-manager             crossplane               grafana                  istio                    linkerd                  mongodb                  openfaas-ingress
chart                    docker-registry          info                     kafka-connector          metrics-server           nginx-ingress            postgresql
cron-connector           docker-registry-ingress  inlets-operator          kubernetes-dashboard     minio                    openfaas                 traefik2

$ arkade install docker-registry
docker-registry          docker-registry-ingress

$ arkade install docker-registry-ingress
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

