### PR TITLE
Adding prometheus-operator chart

### DIFF
--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -113,7 +113,7 @@ func MakeInstallMongoDB() *cobra.Command {
 		err = helm3Upgrade(outputPath, "stable/mongodb",
 			namespace, "values.yaml", defaultVersion, overrides, wait)
 		if err != nil {
-			return fmt.Errorf("unable to mongodb chart with helm %s", err)
+			return fmt.Errorf("unable to install mongodb chart with helm %s", err)
 		}
 		fmt.Println(mongoDBPostInstallMsg)
 		return nil

--- a/cmd/apps/prometheus_operator.go
+++ b/cmd/apps/prometheus_operator.go
@@ -1,0 +1,142 @@
+package apps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallPrometheusOperator() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "prometheus-operator",
+		Short:        "Install prometheus operator",
+		Long:         "Install prometheus operator",
+		SilenceUsage: true,
+	}
+
+	command.Flags().StringArray("set", []string{},
+		"Use custom flags or override existing flags \n(example --set=defaultRules.create=false)")
+	command.Flags().String("namespace", "default", "Namespace for the app")
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+		wait, _ := command.Flags().GetBool("wait")
+		kubeConfigPath := getDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		namespace, _ := command.Flags().GetString("namespace")
+
+		arch := getNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		userPath, err := config.InitUserDir()
+		if err != nil {
+			return err
+		}
+
+		clientArch, clientOS := env.GetClientArch()
+
+		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
+
+		log.Printf("User dir established as: %s\n", userPath)
+
+		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
+
+		helm3 := true
+
+		// persistence, _ := command.Flags().GetBool("persistence")
+
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
+		if err != nil {
+			return err
+		}
+
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com/", helm3)
+		if err != nil {
+			return fmt.Errorf("unable to add repo %s", err)
+		}
+
+		updateRepo, _ := command.Flags().GetBool("update-repo")
+
+		if updateRepo {
+			err = updateHelmRepos(helm3)
+			if err != nil {
+				return fmt.Errorf("unable to update repos %s", err)
+			}
+		}
+
+		chartPath := path.Join(os.TempDir(), "charts")
+
+		err = fetchChart(chartPath, "stable/prometheus-operator", defaultVersion, helm3)
+
+		if err != nil {
+			return fmt.Errorf("unable fetch chart %s", err)
+		}
+
+		overrides := map[string]string{}
+		overrides["prometheusOperator.createCustomResource"] = "false"
+
+		outputPath := path.Join(chartPath, "prometheus-operator")
+
+		customFlags, err := command.Flags().GetStringArray("set")
+		if err != nil {
+			return fmt.Errorf("error with --set usage: %s", err)
+		}
+
+		if err := mergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		err = helm3Upgrade(outputPath, "stable/prometheus-operator",
+			namespace, "values.yaml", defaultVersion, overrides, wait)
+		if err != nil {
+			return fmt.Errorf("unable to install prometheus-operator chart with helm %s", err)
+		}
+		fmt.Println(prometheusOperatorInstallMsg)
+		return nil
+	}
+
+	return command
+}
+
+const prometheusOperatorInstallMsg = `=======================================================================
+=                  Prometheus Operator has been installed.                        =
+=======================================================================` +
+	"\n\n" + pkg.ThanksForUsing
+
+var PrometheusOperatorInfoMsg = `
+# Grafana can be access via port-forwarding on port 80 from within your cluster using below command:
+
+kubectl port-forward svc/prometheus-operator-grafana 8888:80
+
+Grafana can now be accessed at localhost:8888
+
+
+# To get the grafan password run
+
+export GRAFANA_ADMIN_PASSWORD=$(kubectl get secret --namespace {{namespace}} prometheus-operator-grafana -o jsonpath="{.data.admin-password}" | base64 --decode)
+
+# Prometheus UI can be access via port-forwarding on port 9090 from within your cluster using below command:
+
+kubectl port-forward svc/prometheus-operated 8000:9090
+
+Grafana can now be accessed at localhost:8000
+
+# Alert Manager can be access via port-forwarding on port 9093 from within your cluster using below command:
+
+kubectl port-forward svc/alertmanager-operated 8080:9093
+
+Grafana can now be accessed at localhost:8080
+
+# More on GitHub : https://github.com/helm/charts/tree/master/stable/prometheus-operator`

--- a/cmd/apps/prometheus_operator.go
+++ b/cmd/apps/prometheus_operator.go
@@ -40,6 +40,10 @@ func MakeInstallPrometheusOperator() *cobra.Command {
 		arch := getNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
+		if arch != IntelArch {
+			return fmt.Errorf(`only Intel, i.e. PC architecture is supported for this app`)
+		}
+
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -98,6 +98,9 @@ arkade info --help`,
 		case "portainer":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.PortainerInfoMsg)
+		case "prometheus-operator":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.PrometheusOperatorInfoMsg)
 		default:
 			return fmt.Errorf("no info available for app: %s", appName)
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -15,11 +15,11 @@ func MakeInstall() *cobra.Command {
 	var command = &cobra.Command{
 		Use:   "install",
 		Short: "Install Kubernetes apps from helm charts or YAML files",
-		Long: `Install Kubernetes apps from helm charts or YAML files using the "install" 
+		Long: `Install Kubernetes apps from helm charts or YAML files using the "install"
 command. Helm 3 is used by default unless you pass --helm3=false, then helm 2
 will be used to generate YAML files which are applied without tiller.
 
-You can also find the post-install message for each app with the "info" 
+You can also find the post-install message for each app with the "info"
 command.`,
 		Example: `  arkade install
   arkade install openfaas --helm3 --gateways=2
@@ -63,6 +63,7 @@ command.`,
 	command.AddCommand(apps.MakeInstallGrafana())
 	command.AddCommand(apps.MakeInstallArgoCD())
 	command.AddCommand(apps.MakeInstallPortainer())
+	command.AddCommand(apps.MakeInstallPrometheusOperator())
 
 	command.AddCommand(MakeInfo())
 
@@ -90,5 +91,6 @@ func getApps() []string {
 		"docker-registry-ingress",
 		"traefik2",
 		"grafana",
+		"prometheus-operator",
 	}
 }


### PR DESCRIPTION
- Adding prometheus operator chart
- Installed using local binary and tested on k3d cluster.

Signed-off-by: Alok Kumar <rajalokan@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added prometheus-operator chart

## Motivation and Context
This adds a new support for `prometheus-operator`
Fixes #4 

## How Has This Been Tested?
- Make changes
- Create new build using `make build` 
- Use the new arkade binary to install `prometheus-operator`. I was able to get grafana dashboard ( however login was not working. Due to persistence may be ? )
- Any other things needed ?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] New application can be installed on ARM platform.
- [ ] New application shows an error message if the architecture is not supported.
Not tested yet. 