### PR TITLE
Fixes #64  add license file for inlets operator

### DIFF
--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -28,6 +29,7 @@ func MakeInstallInletsOperator() *cobra.Command {
 
 	inletsOperator.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
 	inletsOperator.Flags().StringP("license", "l", "", "The license key if using inlets-pro")
+	inletsOperator.Flags().StringP("license-file", "f", "", "Text file containing license key, used for inlets-pro")
 	inletsOperator.Flags().StringP("provider", "p", "digitalocean", "Your infrastructure provider - 'packet', 'digitalocean', 'scaleway', 'gce' or 'ec2'")
 	inletsOperator.Flags().StringP("zone", "z", "us-central1-a", "The zone to provision the exit node (Used by GCE")
 	inletsOperator.Flags().String("project-id", "", "Project ID to be used (for GCE and Packet)")
@@ -159,6 +161,14 @@ func MakeInstallInletsOperator() *cobra.Command {
 
 		if val, _ := command.Flags().GetString("license"); len(val) > 0 {
 			overrides["inletsProLicense"] = val
+		}
+
+		if licenseFile, _ := command.Flags().GetString("license-file"); len(licenseFile) > 0 {
+			licenseKey, err := ioutil.ReadFile(licenseFile)
+			if err != nil {
+				return err
+			}
+			overrides["inletsProLicense"] = string(licenseKey)
 		}
 
 		if val, _ := command.Flags().GetString("pro-client-image"); len(val) > 0 {


### PR DESCRIPTION
Signed-off-by: Amal Alkhamees <amalkms5@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit  will solve issue #64  which will provide a license key file location as a command-line flag 


<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. add the new flag 
```
$ go run main.go install inlets-operator --help 
Install inlets-operator to get public IPs for your cluster

Usage:
  arkade install inlets-operator [flags]

Examples:
  arkade install inlets-operator --namespace default

Flags:
      --helm3                     Use helm3, if set to false uses helm2 (default true)
  -h, --help                      help for inlets-operator
  -l, --license string            The license key if using inlets-pro
  -f, --license-file string       Text file containing license key, used for inlets-pro
  -n, --namespace string          The namespace used for installation (default "default")
      --organization-id string    The organization id (Scaleway
      --pro-client-image string   Docker image for inlets-pro's client
      --project-id string         Project ID to be used (for GCE and Packet)
  -p, --provider string           Your infrastructure provider - 'packet', 'digitalocean', 'scaleway', 'gce' or 'ec2' (default "digitalocean")
  -r, --region string             The default region to provision the exit node (DigitalOcean, Packet and Scaleway (default "lon1")
  -s, --secret-key-file string    Text file containing secret key, used for providers like ec2
      --set stringArray           Use custom flags or override existing flags 
                                  (example --set=image=org/repo:tag)
  -t, --token-file string         Text file containing token or a service account JSON file
      --update-repo               Update the helm repo (default true)
  -z, --zone string               The zone to provision the exit node (Used by GCE (default "us-central1-a")

Global Flags:
      --kubeconfig string   Local path for your kubeconfig file (default "kubeconfig")
      --wait                If we should wait for the resource to be ready before returning (helm3 only, default false)
``` 
2. install inlets operator using license file
```
go run main.go install inlets-operator -f $HOME/license-file -t  $HOME/access-token
Using kubeconfig: /Users/amal/.kube/config
Using helm3
Node architecture: "amd64"
Client: "x86_64", "Darwin"
2020/04/03 16:09:30 User dir established as: /Users/amal/.arkade/
"inlets" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "inlets" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
VALUES values.yaml
Command: /Users/amal/.arkade/bin/helm3/helm [upgrade --install inlets-operator inlets/inlets-operator --namespace default --values /var/folders
/8k/67dz1kz565vdjbr8spnz5lnh0000gn/T/charts/inlets-operator/values.yaml --set provider=digitalocean --set region=lon1 --set inletsProLicense=dd
dddd]
Release "inlets-operator" does not exist. Installing it now.
NAME: inlets-operator
LAST DEPLOYED: Fri Apr  3 16:09:35 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Find the inlets-operator logs:

kubectl logs -n default deploy/inlets-operator
=======================================================================
= inlets-operator has been installed.                                  =
=======================================================================

# The default configuration is for DigitalOcean and your secret is
# stored as "inlets-access-key" in the "default" namespace.

# To get your first Public IP run the following:
kubectl run nginx-1 --image=nginx --port=80 --restart=Always
kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer

# Find your IP in the "EXTERNAL-IP" field, watch for "<pending>" to 
# change to an IP

kubectl get svc -w

# When you're done, remove the tunnel by deleting the service
kubectl delete svc/nginx-1

# Check the logs
kubectl logs deploy/inlets-operator -f

# Find out more at:
# https://github.com/inlets/inlets-operator

Thanks for using arkade!
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
