### PR TITLE
Issue 11

### DIFF
--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -1,0 +1,158 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallKubeStateMetrics() *cobra.Command {
+	var kubeStateMetrics = &cobra.Command{
+		Use:          "kube-state-metrics",
+		Short:        "Install kube-state-metrics",
+		Long:         `Install kube-state-metrics to generate and expose cluster-level metrics.`,
+		Example:      `  arkade install kube-state-metrics --namespace default --helm3 --set replicas=2`,
+		SilenceUsage: true,
+	}
+
+	kubeStateMetrics.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
+	kubeStateMetrics.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
+	kubeStateMetrics.Flags().StringArray("set", []string{}, "Set individual values in the helm chart")
+
+	kubeStateMetrics.RunE = func(command *cobra.Command, args []string) error {
+		wait, _ := command.Flags().GetBool("wait")
+		kubeConfigPath := getDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		userPath, err := config.InitUserDir()
+		if err != nil {
+			return err
+		}
+		namespace, _ := command.Flags().GetString("namespace")
+
+		arch := getNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(`only Intel, i.e. PC architecture is supported for this app`)
+		}
+
+		helm3, _ := command.Flags().GetBool("helm3")
+
+		if helm3 {
+			fmt.Println("Using helm3")
+		}
+
+		clientArch, clientOS := env.GetClientArch()
+		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
+		log.Printf("User dir established as: %s\n", userPath)
+		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
+
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
+		if err != nil {
+			return err
+		}
+
+		err = updateHelmRepos(helm3)
+		if err != nil {
+			return err
+		}
+
+		chartPath := path.Join(os.TempDir(), "charts")
+		err = fetchChart(chartPath, "stable/kube-state-metrics", defaultVersion, helm3)
+
+		if err != nil {
+			return err
+		}
+
+		setMap := map[string]string{}
+		setVals, _ := kubeStateMetrics.Flags().GetStringArray("set")
+
+		for _, setV := range setVals {
+			var k string
+			var v string
+
+			if index := strings.Index(setV, "="); index > -1 {
+				k = setV[:index]
+				v = setV[index+1:]
+				setMap[k] = v
+			}
+		}
+
+		fmt.Println("Chart path: ", chartPath)
+
+		if helm3 {
+			outputPath := path.Join(chartPath, "kube-state-metrics")
+
+			err := helm3Upgrade(outputPath, "stable/kube-state-metrics", namespace,
+				"values.yaml",
+				defaultVersion,
+				setMap,
+				wait)
+
+			if err != nil {
+				return err
+			}
+
+		} else {
+			outputPath := path.Join(chartPath, "kube-state-metrics/rendered")
+
+			err = templateChart(chartPath,
+				"kube-state-metrics",
+				namespace,
+				outputPath,
+				"values.yaml",
+				setMap)
+
+			if err != nil {
+				return err
+			}
+
+			applyRes, applyErr := kubectlTask("apply", "-n", namespace, "-R", "-f", outputPath)
+			if applyErr != nil {
+				return applyErr
+			}
+			if applyRes.ExitCode > 0 {
+				return fmt.Errorf("error applying templated YAML files, error: %s", applyRes.Stderr)
+			}
+
+		}
+
+		fmt.Println(`=======================================================================
+= kube-state-metrics has been installed.                                  =
+=======================================================================
+# Port-forward
+
+kubectl port-forward -n ` + namespace + ` service/kube-state-metrics 9000:8080 & http://localhost:9000/metrics
+
+` + KubeStateMetricsInfoMsg + `
+
+` + pkg.ThanksForUsing)
+
+		return nil
+	}
+
+	return kubeStateMetrics
+}
+
+const KubeStateMetricsInfoMsg = `
+
+# Find out more at:
+# https://github.com/kubernetes/kube-state-metrics
+`

--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -135,11 +135,15 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 		}
 
 		fmt.Println(`=======================================================================
-= kube-state-metrics has been installed.                                  =
+=             kube-state-metrics has been installed.                  =
 =======================================================================
 # Port-forward
 
-kubectl port-forward -n ` + namespace + ` service/kube-state-metrics 9000:8080 & http://localhost:9000/metrics
+kubectl port-forward -n ` + namespace + ` service/kube-state-metrics 9000:8080 &
+
+# Then access via:
+
+http://localhost:9000/metrics
 
 ` + KubeStateMetricsInfoMsg + `
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -68,6 +68,9 @@ arkade info --help`,
 		case "kafka-connector":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.KafkaConnectorInfoMsg)
+		case "kube-state-metrics":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.KubeStateMetricsInfoMsg)
 		case "minio":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.MinioInfoMsg)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -51,6 +51,7 @@ command.`,
 	command.AddCommand(apps.MakeInstallLinkerd())
 	command.AddCommand(apps.MakeInstallCronConnector())
 	command.AddCommand(apps.MakeInstallKafkaConnector())
+	command.AddCommand(apps.MakeInstallKubeStateMetrics())
 	command.AddCommand(apps.MakeInstallMinio())
 	command.AddCommand(apps.MakeInstallPostgresql())
 	command.AddCommand(apps.MakeInstallKubernetesDashboard())
@@ -83,6 +84,7 @@ func getApps() []string {
 		"minio",
 		"postgresql",
 		"kubernetes-dashboard",
+		"kube-state-metrics",
 		"istio",
 		"crossplane",
 		"mongodb",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated installation message.
## Description
<!--- Describe your changes in detail -->
Message now looks like this:
```
The metrics are exported on the HTTP endpoint /metrics on the listening port.
In your case, kube-state-metrics.default.svc.cluster.local:8080/metrics

They are served either as plaintext or protobuf depending on the Accept header.
They are designed to be consumed either by Prometheus itself or by a scraper that is compatible with scraping a Prometheus client endpoint.
=======================================================================
=             kube-state-metrics has been installed.                  =
=======================================================================
# Port-forward

kubectl port-forward -n default service/kube-state-metrics 9000:8080 &

# Then access via:

http://localhost:9000/metrics



# Find out more at:
# https://github.com/kubernetes/kube-state-metrics


Thanks for using arkade!
```
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
