### PR TITLE
Added verbose option to helm apps install

### DIFF
--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -28,8 +28,10 @@ func MakeInstallCertManager() *cobra.Command {
 	certManager.Flags().StringP("namespace", "n", "cert-manager", "The namespace to install cert-manager")
 	certManager.Flags().Bool("update-repo", true, "Update the helm repo")
 	certManager.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
+	certManager.Flags().Bool("verbose", false, "Verbose output")
 
 	certManager.RunE = func(command *cobra.Command, args []string) error {
+		verbose, _ := command.Flags().GetBool("verbose")
 		wait, _ := command.Flags().GetBool("wait")
 		const certManagerVersion = "v0.12.0"
 		kubeConfigPath := getDefaultKubeconfig()
@@ -68,7 +70,7 @@ func MakeInstallCertManager() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("jetstack", "https://charts.jetstack.io", helm3)
+		err = addHelmRepo("jetstack", "https://charts.jetstack.io", helm3, verbose)
 		if err != nil {
 			return err
 		}
@@ -76,7 +78,7 @@ func MakeInstallCertManager() *cobra.Command {
 		updateRepo, _ := certManager.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos(helm3, verbose)
 			if err != nil {
 				return err
 			}
@@ -93,7 +95,7 @@ func MakeInstallCertManager() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "jetstack/cert-manager", certManagerVersion, helm3)
+		err = fetchChart(chartPath, "jetstack/cert-manager", certManagerVersion, helm3, verbose)
 		if err != nil {
 			return err
 		}
@@ -120,13 +122,14 @@ func MakeInstallCertManager() *cobra.Command {
 				"values.yaml",
 				"v0.12.0",
 				overrides,
-				wait)
+				wait,
+				verbose)
 
 			if err != nil {
 				return err
 			}
 		} else {
-			err = templateChart(chartPath, "cert-manager", namespace, outputPath, "values.yaml", nil)
+			err = templateChart(chartPath, "cert-manager", namespace, outputPath, "values.yaml", nil, verbose)
 			if err != nil {
 				return err
 			}

--- a/cmd/apps/chart_app.go
+++ b/cmd/apps/chart_app.go
@@ -38,10 +38,12 @@ before using the generic helm chart installer command.`,
 	chartCmd.Flags().String("values-file", "", "Give the values.yaml file to use from the upstream chart repo")
 	chartCmd.Flags().String("repo-name", "", "Chart name")
 	chartCmd.Flags().String("repo-url", "", "Chart repo")
+	chartCmd.Flags().Bool("verbose", false, "Verbose output")
 
 	chartCmd.Flags().StringArray("set", []string{}, "Set individual values in the helm chart")
 
 	chartCmd.RunE = func(command *cobra.Command, args []string) error {
+		verbose, _ := command.Flags().GetBool("verbose")
 		chartRepoName, _ := command.Flags().GetString("repo-name")
 		chartRepoURL, _ := command.Flags().GetString("repo-url")
 
@@ -88,13 +90,13 @@ before using the generic helm chart installer command.`,
 		}
 
 		if len(chartRepoURL) > 0 {
-			err = addHelmRepo(chartPrefix, chartRepoURL, false)
+			err = addHelmRepo(chartPrefix, chartRepoURL, false, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
-		err = updateHelmRepos(false)
+		err = updateHelmRepos(false, verbose)
 		if err != nil {
 			return err
 		}
@@ -114,7 +116,7 @@ before using the generic helm chart installer command.`,
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, chartRepoName, defaultVersion, false)
+		err = fetchChart(chartPath, chartRepoName, defaultVersion, false, verbose)
 		if err != nil {
 			return err
 		}
@@ -135,7 +137,7 @@ before using the generic helm chart installer command.`,
 			}
 		}
 
-		err = templateChart(chartPath, chartName, namespace, outputPath, "values.yaml", setMap)
+		err = templateChart(chartPath, chartName, namespace, outputPath, "values.yaml", setMap, verbose)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -24,11 +24,13 @@ func MakeInstallCronConnector() *cobra.Command {
 
 	command.Flags().StringP("namespace", "n", "openfaas", "The namespace used for installation")
 	command.Flags().Bool("update-repo", true, "Update the helm repo")
+	command.Flags().Bool("verbose", false, "Verbose output")
 
 	command.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set key=value)")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
+		verbose, _ := command.Flags().GetBool("verbose")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -62,20 +64,20 @@ func MakeInstallCronConnector() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false)
+		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false, verbose)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos(false, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "openfaas/cron-connector", defaultVersion, false)
+		err = fetchChart(chartPath, "openfaas/cron-connector", defaultVersion, false, verbose)
 
 		if err != nil {
 			return err
@@ -105,7 +107,8 @@ func MakeInstallCronConnector() *cobra.Command {
 			ns,
 			outputPath,
 			"values.yaml",
-			overrides)
+			overrides,
+			verbose)
 
 		if err != nil {
 			return err

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -30,9 +30,11 @@ schedule workloads to any Kubernetes cluster`,
 	crossplane.Flags().StringP("namespace", "n", "crossplane-system", "The namespace used for installation")
 	crossplane.Flags().Bool("update-repo", true, "Update the helm repo")
 	crossplane.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
+	crossplane.Flags().Bool("verbose", false, "Verbose output")
 
 	crossplane.RunE = func(command *cobra.Command, args []string) error {
 		wait, _ := command.Flags().GetBool("wait")
+		verbose, _ := command.Flags().GetBool("verbose")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -76,7 +78,7 @@ schedule workloads to any Kubernetes cluster`,
 			return err
 		}
 
-		err = addHelmRepo("crossplane-alpha", "https://charts.crossplane.io/alpha", helm3)
+		err = addHelmRepo("crossplane-alpha", "https://charts.crossplane.io/alpha", helm3, verbose)
 		if err != nil {
 			return err
 		}
@@ -84,7 +86,7 @@ schedule workloads to any Kubernetes cluster`,
 		updateRepo, _ := crossplane.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos(helm3, verbose)
 			if err != nil {
 				return err
 			}
@@ -92,7 +94,7 @@ schedule workloads to any Kubernetes cluster`,
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "crossplane-alpha/crossplane", defaultVersion, helm3)
+		err = fetchChart(chartPath, "crossplane-alpha/crossplane", defaultVersion, helm3, verbose)
 		if err != nil {
 			return err
 		}
@@ -107,14 +109,14 @@ schedule workloads to any Kubernetes cluster`,
 			}
 
 			err := helm3Upgrade(outputPath, "crossplane-alpha/crossplane",
-				namespace, "values.yaml", "", map[string]string{}, wait)
+				namespace, "values.yaml", "", map[string]string{}, wait, verbose)
 			if err != nil {
 				return err
 			}
 
 		} else {
 			outputPath := path.Join(chartPath, "crossplane-alpha/crossplane")
-			err = templateChart(chartPath, "crossplane", namespace, outputPath, "values.yaml", map[string]string{})
+			err = templateChart(chartPath, "crossplane", namespace, outputPath, "values.yaml", map[string]string{}, verbose)
 			if err != nil {
 				return err
 			}

--- a/cmd/apps/grafana_app.go
+++ b/cmd/apps/grafana_app.go
@@ -28,12 +28,14 @@ func MakeInstallGrafana() *cobra.Command {
 	grafana.Flags().StringP("namespace", "n", "grafana", "The namespace to install grafana")
 	grafana.Flags().Bool("update-repo", true, "Update the helm repo")
 	grafana.Flags().Bool("persistence", false, "Make grafana persistent")
+	grafana.Flags().Bool("verbose", false, "Verbose output")
 
 	grafana.RunE = func(command *cobra.Command, args []string) error {
 
 		const chartVersion = "5.0.4"
 
 		// Get all flags
+		verbose, _ := command.Flags().GetBool("verbose")
 		wait, _ := command.Flags().GetBool("wait")
 		persistence, _ := command.Flags().GetBool("persistence")
 		namespace, _ := command.Flags().GetString("namespace")
@@ -56,7 +58,7 @@ func MakeInstallGrafana() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", true)
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", true, verbose)
 		if err != nil {
 			return err
 		}
@@ -65,7 +67,7 @@ func MakeInstallGrafana() *cobra.Command {
 		updateRepo, _ := grafana.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(true)
+			err = updateHelmRepos(true, verbose)
 			if err != nil {
 				return err
 			}
@@ -84,7 +86,7 @@ func MakeInstallGrafana() *cobra.Command {
 
 		// download the chart
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/grafana", chartVersion, true)
+		err = fetchChart(chartPath, "stable/grafana", chartVersion, true, verbose)
 		if err != nil {
 			return err
 		}
@@ -108,7 +110,8 @@ func MakeInstallGrafana() *cobra.Command {
 			"values.yaml",
 			chartVersion,
 			overrides,
-			wait)
+			wait,
+			verbose)
 
 		if err != nil {
 			return err

--- a/cmd/apps/jenkins_app.go
+++ b/cmd/apps/jenkins_app.go
@@ -32,10 +32,12 @@ func MakeInstallJenkins() *cobra.Command {
 	jenkins.Flags().Bool("persistence", false, "Enable persistence")
 	jenkins.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set persistence.enabled=true)")
+	jenkins.Flags().Bool("verbose", false, "Verbose output")
 
 	jenkins.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
 		wait, _ := command.Flags().GetBool("wait")
+		verbose, _ := command.Flags().GetBool("verbose")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -70,20 +72,20 @@ func MakeInstallJenkins() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", true)
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", true, verbose)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(true)
+			err = updateHelmRepos(true, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/jenkins", defaultVersion, true)
+		err = fetchChart(chartPath, "stable/jenkins", defaultVersion, true, verbose)
 
 		if err != nil {
 			return err
@@ -109,7 +111,8 @@ func MakeInstallJenkins() *cobra.Command {
 			"values.yaml",
 			defaultVersion,
 			overrides,
-			wait)
+			wait,
+			verbose)
 
 		if err != nil {
 			return err

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -31,9 +31,11 @@ func MakeInstallKafkaConnector() *cobra.Command {
 	command.Flags().String("broker-host", "kafka", "The host for the Kafka broker")
 	command.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set key=value)")
+	command.Flags().Bool("verbose", false, "Verbose output")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
+		verbose, _ := command.Flags().GetBool("verbose")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -66,20 +68,20 @@ func MakeInstallKafkaConnector() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false)
+		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", false, verbose)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos(false, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "openfaas/kafka-connector", defaultVersion, false)
+		err = fetchChart(chartPath, "openfaas/kafka-connector", defaultVersion, false, verbose)
 
 		if err != nil {
 			return err
@@ -125,7 +127,8 @@ func MakeInstallKafkaConnector() *cobra.Command {
 			ns,
 			outputPath,
 			"values.yaml",
-			overrides)
+			overrides,
+			verbose)
 
 		if err != nil {
 			return err

--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -29,9 +29,11 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 	kubeStateMetrics.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
 	kubeStateMetrics.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
 	kubeStateMetrics.Flags().StringArray("set", []string{}, "Set individual values in the helm chart")
+	kubeStateMetrics.Flags().Bool("verbose", false, "Verbose output")
 
 	kubeStateMetrics.RunE = func(command *cobra.Command, args []string) error {
 		wait, _ := command.Flags().GetBool("wait")
+		verbose, _ := command.Flags().GetBool("verbose")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -69,13 +71,13 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 			return err
 		}
 
-		err = updateHelmRepos(helm3)
+		err = updateHelmRepos(helm3, verbose)
 		if err != nil {
 			return err
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/kube-state-metrics", defaultVersion, helm3)
+		err = fetchChart(chartPath, "stable/kube-state-metrics", defaultVersion, helm3, verbose)
 
 		if err != nil {
 			return err
@@ -104,7 +106,8 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 				"values.yaml",
 				defaultVersion,
 				setMap,
-				wait)
+				wait,
+				verbose)
 
 			if err != nil {
 				return err
@@ -118,7 +121,8 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 				namespace,
 				outputPath,
 				"values.yaml",
-				setMap)
+				setMap,
+				verbose)
 
 			if err != nil {
 				return err

--- a/cmd/apps/kubernetes_exec.go
+++ b/cmd/apps/kubernetes_exec.go
@@ -14,7 +14,7 @@ import (
 	execute "github.com/alexellis/go-execute/pkg/v1"
 )
 
-func fetchChart(path, chart, version string, helm3 bool) error {
+func fetchChart(path, chart, version string, helm3 bool, verbose bool) error {
 	versionStr := ""
 
 	if len(version) > 0 {
@@ -39,7 +39,7 @@ func fetchChart(path, chart, version string, helm3 bool) error {
 	task := execute.ExecTask{
 		Command:     fmt.Sprintf("%s fetch %s --untar=true --untardir %s%s", env.LocalBinary("helm", subdir), chart, path, versionStr),
 		Env:         os.Environ(),
-		StreamStdio: true,
+		StreamStdio: verbose,
 	}
 	res, err := task.Execute()
 
@@ -61,7 +61,7 @@ func getNodeArchitecture() string {
 	return arch
 }
 
-func helm3Upgrade(basePath, chart, namespace, values, version string, overrides map[string]string, wait bool) error {
+func helm3Upgrade(basePath, chart, namespace, values, version string, overrides map[string]string, wait bool, verbose bool) error {
 
 	chartName := chart
 	if index := strings.Index(chartName, "/"); index > -1 {
@@ -99,7 +99,7 @@ func helm3Upgrade(basePath, chart, namespace, values, version string, overrides 
 		Args:        args,
 		Env:         os.Environ(),
 		Cwd:         basePath,
-		StreamStdio: true,
+		StreamStdio: verbose,
 	}
 
 	fmt.Printf("Command: %s %s\n", task.Command, task.Args)
@@ -120,7 +120,7 @@ func helm3Upgrade(basePath, chart, namespace, values, version string, overrides 
 	return nil
 }
 
-func templateChart(basePath, chart, namespace, outputPath, values string, overrides map[string]string) error {
+func templateChart(basePath, chart, namespace, outputPath, values string, overrides map[string]string, verbose bool) error {
 
 	rmErr := os.RemoveAll(outputPath)
 
@@ -150,7 +150,7 @@ func templateChart(basePath, chart, namespace, outputPath, values string, overri
 			env.LocalBinary("helm", ""), chart, chart, namespace, outputPath, valuesStr, overridesStr),
 		Env:         os.Environ(),
 		Cwd:         basePath,
-		StreamStdio: true,
+		StreamStdio: verbose,
 	}
 
 	res, err := task.Execute()
@@ -170,7 +170,7 @@ func templateChart(basePath, chart, namespace, outputPath, values string, overri
 	return nil
 }
 
-func addHelmRepo(name, url string, helm3 bool) error {
+func addHelmRepo(name, url string, helm3 bool, verbose bool) error {
 	subdir := ""
 	if helm3 {
 		subdir = "helm3"
@@ -179,7 +179,7 @@ func addHelmRepo(name, url string, helm3 bool) error {
 	task := execute.ExecTask{
 		Command:     fmt.Sprintf("%s repo add %s %s", env.LocalBinary("helm", subdir), name, url),
 		Env:         os.Environ(),
-		StreamStdio: true,
+		StreamStdio: verbose,
 	}
 	res, err := task.Execute()
 
@@ -193,7 +193,7 @@ func addHelmRepo(name, url string, helm3 bool) error {
 	return nil
 }
 
-func updateHelmRepos(helm3 bool) error {
+func updateHelmRepos(helm3 bool, verbose bool) error {
 	subdir := ""
 	if helm3 {
 		subdir = "helm3"
@@ -201,7 +201,7 @@ func updateHelmRepos(helm3 bool) error {
 	task := execute.ExecTask{
 		Command:     fmt.Sprintf("%s repo update", env.LocalBinary("helm", subdir)),
 		Env:         os.Environ(),
-		StreamStdio: true,
+		StreamStdio: verbose,
 	}
 
 	res, err := task.Execute()

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -27,9 +27,11 @@ func MakeInstallMetricsServer() *cobra.Command {
 
 	metricsServer.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
 	metricsServer.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
+	metricsServer.Flags().Bool("verbose", false, "Verbose output")
 
 	metricsServer.RunE = func(command *cobra.Command, args []string) error {
 		wait, _ := command.Flags().GetBool("wait")
+		verbose, _ := command.Flags().GetBool("verbose")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -67,13 +69,13 @@ func MakeInstallMetricsServer() *cobra.Command {
 			return err
 		}
 
-		err = updateHelmRepos(helm3)
+		err = updateHelmRepos(helm3, verbose)
 		if err != nil {
 			return err
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/metrics-server", defaultVersion, helm3)
+		err = fetchChart(chartPath, "stable/metrics-server", defaultVersion, helm3, verbose)
 
 		if err != nil {
 			return err
@@ -99,7 +101,8 @@ func MakeInstallMetricsServer() *cobra.Command {
 				"values.yaml",
 				defaultVersion,
 				overrides,
-				wait)
+				wait,
+				verbose)
 
 			if err != nil {
 				return err
@@ -113,7 +116,8 @@ func MakeInstallMetricsServer() *cobra.Command {
 				namespace,
 				outputPath,
 				"values.yaml",
-				overrides)
+				overrides,
+				verbose)
 
 			if err != nil {
 				return err

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -37,10 +37,12 @@ func MakeInstallMinio() *cobra.Command {
 	minio.Flags().Bool("persistence", false, "Enable persistence")
 	minio.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set persistence.enabled=true)")
+	minio.Flags().Bool("verbose", false, "Verbose output")
 
 	minio.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
 		wait, _ := command.Flags().GetBool("wait")
+		verbose, _ := command.Flags().GetBool("verbose")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -84,20 +86,20 @@ func MakeInstallMinio() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", helm3)
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", helm3, verbose)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos(helm3, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/minio", defaultVersion, helm3)
+		err = fetchChart(chartPath, "stable/minio", defaultVersion, helm3, verbose)
 
 		if err != nil {
 			return err
@@ -154,7 +156,8 @@ func MakeInstallMinio() *cobra.Command {
 				"values.yaml",
 				defaultVersion,
 				overrides,
-				wait)
+				wait,
+				verbose)
 
 			if err != nil {
 				return err
@@ -168,7 +171,8 @@ func MakeInstallMinio() *cobra.Command {
 				ns,
 				outputPath,
 				"values.yaml",
-				overrides)
+				overrides,
+				verbose)
 
 			if err != nil {
 				return err

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -30,10 +30,12 @@ func MakeInstallMongoDB() *cobra.Command {
 	command.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set=mongodbUsername=admin)")
 	command.Flags().Bool("persistence", false, "Create and bind a persistent volume, not recommended for development")
+	command.Flags().Bool("verbose", false, "Verbose output")
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 
 		wait, _ := command.Flags().GetBool("wait")
+		verbose, _ := command.Flags().GetBool("verbose")
 		kubeConfigPath := getDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -73,7 +75,7 @@ func MakeInstallMongoDB() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com/", helm3)
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com/", helm3, verbose)
 		if err != nil {
 			return fmt.Errorf("unable to add repo %s", err)
 		}
@@ -81,7 +83,7 @@ func MakeInstallMongoDB() *cobra.Command {
 		updateRepo, _ := command.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos(helm3, verbose)
 			if err != nil {
 				return fmt.Errorf("unable to update repos %s", err)
 			}
@@ -89,7 +91,7 @@ func MakeInstallMongoDB() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "stable/mongodb", defaultVersion, helm3)
+		err = fetchChart(chartPath, "stable/mongodb", defaultVersion, helm3, verbose)
 
 		if err != nil {
 			return fmt.Errorf("unable fetch chart %s", err)
@@ -111,7 +113,7 @@ func MakeInstallMongoDB() *cobra.Command {
 		}
 
 		err = helm3Upgrade(outputPath, "stable/mongodb",
-			namespace, "values.yaml", defaultVersion, overrides, wait)
+			namespace, "values.yaml", defaultVersion, overrides, wait, verbose)
 		if err != nil {
 			return fmt.Errorf("unable to mongodb chart with helm %s", err)
 		}

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -31,6 +31,7 @@ flag and the nginx-ingress docs for more info`,
 	nginx.Flags().Bool("update-repo", true, "Update the helm repo")
 	nginx.Flags().Bool("host-mode", false, "If we should install nginx-ingress in host mode.")
 	nginx.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
+	nginx.Flags().Bool("verbose", false, "Verbose output")
 
 	nginx.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
@@ -40,7 +41,7 @@ flag and the nginx-ingress docs for more info`,
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
 		}
 
-		updateRepo, _ := nginx.Flags().GetBool("update-repo")
+		updateRepo, _ := command.Flags().GetBool("update-repo")
 
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 		helm3, _ := command.Flags().GetBool("helm3")
@@ -48,7 +49,7 @@ flag and the nginx-ingress docs for more info`,
 		if helm3 {
 			fmt.Println("Using helm3")
 		}
-
+		verbose, _ := command.Flags().GetBool("verbose")
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err
@@ -71,20 +72,20 @@ flag and the nginx-ingress docs for more info`,
 			return err
 		}
 
-		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", helm3)
+		err = addHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", helm3, verbose)
 		if err != nil {
 			return err
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos(helm3, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/nginx-ingress", defaultVersion, helm3)
+		err = fetchChart(chartPath, "stable/nginx-ingress", defaultVersion, helm3, verbose)
 
 		if err != nil {
 			return err
@@ -128,7 +129,8 @@ flag and the nginx-ingress docs for more info`,
 				"values.yaml",
 				defaultVersion,
 				overrides,
-				wait)
+				wait,
+				verbose)
 
 			if err != nil {
 				return err
@@ -141,7 +143,8 @@ flag and the nginx-ingress docs for more info`,
 				ns,
 				outputPath,
 				"values.yaml",
-				overrides)
+				overrides,
+				verbose)
 
 			if err != nil {
 				return err

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -27,7 +27,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		Use:          "openfaas",
 		Short:        "Install openfaas",
 		Long:         `Install openfaas`,
-		Example:      `  arkade install openfaas --loadbalancer`,
+		Example:      `  arkade install openfaas --load-balancer`,
 		SilenceUsage: true,
 	}
 
@@ -49,12 +49,14 @@ func MakeInstallOpenFaaS() *cobra.Command {
 	openfaas.Flags().Bool("ingress-operator", false, "Get custom domains and Ingress records via the ingress-operator component")
 
 	openfaas.Flags().Bool("helm3", true, "Use helm3, if set to false uses helm2")
+	openfaas.Flags().Bool("verbose", false, "Verbose output")
 
 	openfaas.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set=gateway.replicas=2)")
 
 	openfaas.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
 		wait, _ := command.Flags().GetBool("wait")
+		verbose, _ := command.Flags().GetBool("verbose")
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
 		}
@@ -92,7 +94,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", helm3)
+		err = addHelmRepo("openfaas", "https://openfaas.github.io/faas-netes/", helm3, verbose)
 		if err != nil {
 			return err
 		}
@@ -100,7 +102,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		updateRepo, _ := openfaas.Flags().GetBool("update-repo")
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos(helm3, verbose)
 			if err != nil {
 				return err
 			}
@@ -142,7 +144,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 
 		chartPath := path.Join(os.TempDir(), "charts")
 
-		err = fetchChart(chartPath, "openfaas/openfaas", defaultVersion, helm3)
+		err = fetchChart(chartPath, "openfaas/openfaas", defaultVersion, helm3, verbose)
 		if err != nil {
 			return err
 		}
@@ -215,7 +217,8 @@ func MakeInstallOpenFaaS() *cobra.Command {
 				"values"+valuesSuffix+".yaml",
 				"",
 				overrides,
-				wait)
+				wait,
+				verbose)
 
 			if err != nil {
 				return err
@@ -227,7 +230,8 @@ func MakeInstallOpenFaaS() *cobra.Command {
 				namespace,
 				outputPath,
 				"values"+valuesSuffix+".yaml",
-				overrides)
+				overrides,
+				verbose)
 
 			if err != nil {
 				return err

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -31,12 +31,14 @@ func MakeInstallPostgresql() *cobra.Command {
 	postgresql.Flags().String("namespace", "default", "Kubernetes namespace for the application")
 
 	postgresql.Flags().Bool("persistence", false, "Enable persistence")
+	postgresql.Flags().Bool("verbose", false, "Verbose output")
 
 	postgresql.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set persistence.enabled=true)")
 
 	postgresql.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath := getDefaultKubeconfig()
+		verbose, _ := command.Flags().GetBool("verbose")
 
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
@@ -76,14 +78,14 @@ func MakeInstallPostgresql() *cobra.Command {
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(false)
+			err = updateHelmRepos(false, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "stable/postgresql", defaultVersion, false)
+		err = fetchChart(chartPath, "stable/postgresql", defaultVersion, false, verbose)
 
 		if err != nil {
 			return err
@@ -115,7 +117,8 @@ func MakeInstallPostgresql() *cobra.Command {
 			ns,
 			outputPath,
 			"values.yaml",
-			overrides)
+			overrides,
+			verbose)
 
 		if err != nil {
 			return err

--- a/cmd/apps/traefik2_app.go
+++ b/cmd/apps/traefik2_app.go
@@ -34,10 +34,12 @@ func MakeInstallTraefik2() *cobra.Command {
 		"Use custom flags or override existing flags \n(example --set key=value)")
 	traefik2.Flags().Bool("wait", false, "Wait for the chart to be installed")
 	traefik2.Flags().Bool("ingress-provider", true, "Add Traefik's ingressprovider along with the CRD provider")
+	traefik2.Flags().Bool("verbose", false, "Verbose output")
 
 	traefik2.RunE = func(command *cobra.Command, args []string) error {
 
 		kubeConfigPath := getDefaultKubeconfig()
+		verbose, _ := command.Flags().GetBool("verbose")
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
 		}
@@ -60,20 +62,20 @@ func MakeInstallTraefik2() *cobra.Command {
 			return err
 		}
 
-		err = addHelmRepo("traefik", "https://containous.github.io/traefik-helm-chart", helm3)
+		err = addHelmRepo("traefik", "https://containous.github.io/traefik-helm-chart", helm3, verbose)
 		if err != nil {
 			return fmt.Errorf("Unable to add repo %s", err)
 		}
 
 		if updateRepo {
-			err = updateHelmRepos(helm3)
+			err = updateHelmRepos(helm3, verbose)
 			if err != nil {
 				return err
 			}
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = fetchChart(chartPath, "traefik/traefik", "", helm3)
+		err = fetchChart(chartPath, "traefik/traefik", "", helm3, verbose)
 		if err != nil {
 			return fmt.Errorf("Unable fetch chart: %s", err)
 		}
@@ -115,7 +117,8 @@ func MakeInstallTraefik2() *cobra.Command {
 			"values.yaml",
 			"",
 			overrides,
-			wait)
+			wait,
+			verbose)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: kadern0 <kaderno@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Helm Install without streaming stdout to console.
## Description
<!--- Describe your changes in detail -->
Added 'verbose' option to arkade install apps that make use of helm. Set to false by default
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 Fixes #53 
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested installation of the apps one by one.
Examples:

```
./arkade install docker-registry --namespace default
Using kubeconfig: /home/kaderno/.kube/config
Client: x86_64, Linux
2020/05/02 08:33:33 User dir established as: /home/kaderno/.arkade/
Node architecture: "amd64"
Chart path:  /tmp/charts
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install docker-registry stable/docker-registry --namespace default --values /tmp/charts/docker-registry/values.yaml --set persistence.enabled=false --set secrets.htpasswd=admin:$2a$10$EI/UQhDWz13JOHk0FHo0c.vdZer5VFwiFmDPaxTjaY5MTvxrvIjQ6
]
=======================================================================
= docker-registry has been installed.                                 =
=======================================================================

# Your docker-registry has been configured

kubectl logs deploy/docker-registry

export IP="192.168.0.11" # Set to WiFI/ethernet adapter
export PASSWORD="" # See below
kubectl port-forward svc/docker-registry --address 0.0.0.0 5000 &

docker login $IP:5000 --username admin --password $PASSWORD
docker tag alpine:3.11 $IP:5000/alpine:3.11
docker push $IP:5000/alpine:3.11

# Find out more at:
# https://github.com/helm/charts/tree/master/stable/registry

Thanks for using arkade!
Registry credentials: admin E9L170aIP35GS80mp42S
export PASSWORD=E9L170aIP35GS80mp42S
```
```
 ./arkade install docker-registry --namespace default --verbose
Using kubeconfig: /home/kaderno/.kube/config
Client: x86_64, Linux
2020/05/02 08:34:04 User dir established as: /home/kaderno/.arkade/
"stable" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "arm-stable" chart repository
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "bitnami-redis" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
Node architecture: "amd64"
Chart path:  /tmp/charts
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install docker-registry stable/docker-registry --namespace default --values /tmp/charts/docker-registry/values.yaml --set persistence.enabled=false --set secrets.htpasswd=admin:$2a$10$SP797laHjxNl1JRqmEwOY..cJ6qAU2hfI6wsVssNKiy/C4BnltgHi
]
Release "docker-registry" has been upgraded. Happy Helming!
NAME: docker-registry
LAST DEPLOYED: Sat May  2 08:34:16 2020
NAMESPACE: default
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
1. Get the application URL by running these commands:
  export POD_NAME=$(kubectl get pods --namespace default -l "app=docker-registry,release=docker-registry" -o jsonpath="{.items[0].metadata.name}")
  echo "Visit http://127.0.0.1:8080 to use your application"
  kubectl -n default port-forward $POD_NAME 8080:5000
=======================================================================
= docker-registry has been installed.                                 =
=======================================================================

# Your docker-registry has been configured

kubectl logs deploy/docker-registry

export IP="192.168.0.11" # Set to WiFI/ethernet adapter
export PASSWORD="" # See below
kubectl port-forward svc/docker-registry --address 0.0.0.0 5000 &

docker login $IP:5000 --username admin --password $PASSWORD
docker tag alpine:3.11 $IP:5000/alpine:3.11
docker push $IP:5000/alpine:3.11

# Find out more at:
# https://github.com/helm/charts/tree/master/stable/registry

Thanks for using arkade!
Registry credentials: admin 71XY2Y48513kMM8Ph5eb
export PASSWORD=71XY2Y48513kMM8Ph5eb
```


```
./arkade install nginx-ingress --namespace default
Using kubeconfig: /home/kaderno/.kube/config
Using helm3
Client: x86_64, Linux
2020/05/02 08:17:59 User dir established as: /home/kaderno/.arkade/
Node architecture: "amd64"
Chart path:  /tmp/charts
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install nginx-ingress stable/nginx-ingress --namespace default --values /tmp/charts/nginx-ingress/values.yaml --set defaultBackend.enabled=false]
=======================================================================
= nginx-ingress has been installed.                                   =
=======================================================================

# If you're using a local environment such as "minikube" or "KinD",
# then try the inlets operator with "arkade install inlets-operator"

# If you're using a managed Kubernetes service, then you'll find
# your LoadBalancer's IP under "EXTERNAL-IP" via:

kubectl get svc nginx-ingress-controller

# Find out more at:
# https://github.com/helm/charts/tree/master/stable/nginx-ingress

Thanks for using arkade!
```
```
./arkade install nginx-ingress --namespace default --verbose
Using kubeconfig: /home/kaderno/.kube/config
Using helm3
Client: x86_64, Linux
2020/05/02 08:18:17 User dir established as: /home/kaderno/.arkade/
"stable" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "arm-stable" chart repository
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "stable" chart repository
...Successfully got an update from the "bitnami-redis" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
Node architecture: "amd64"
Chart path:  /tmp/charts
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install nginx-ingress stable/nginx-ingress --namespace default --values /tmp/charts/nginx-ingress/values.yaml --set defaultBackend.enabled=false]
Release "nginx-ingress" has been upgraded. Happy Helming!
NAME: nginx-ingress
LAST DEPLOYED: Sat May  2 08:18:27 2020
NAMESPACE: default
STATUS: deployed
REVISION: 14
TEST SUITE: None
NOTES:
The nginx-ingress controller has been installed.
It may take a few minutes for the LoadBalancer IP to be available.
You can watch the status by running 'kubectl --namespace default get services -o wide -w nginx-ingress-controller'

An example Ingress that makes use of the controller:

  apiVersion: extensions/v1beta1
  kind: Ingress
  metadata:
    annotations:
      kubernetes.io/ingress.class: nginx
    name: example
    namespace: foo
  spec:
    rules:
      - host: www.example.com
        http:
          paths:
            - backend:
                serviceName: exampleService
                servicePort: 80
              path: /
    # This section is only required if TLS is to be enabled for the Ingress
    tls:
        - hosts:
            - www.example.com
          secretName: example-tls

If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:

  apiVersion: v1
  kind: Secret
  metadata:
    name: example-tls
    namespace: foo
  data:
    tls.crt: <base64 encoded cert>
    tls.key: <base64 encoded key>
  type: kubernetes.io/tls
=======================================================================
= nginx-ingress has been installed.                                   =
=======================================================================

# If you're using a local environment such as "minikube" or "KinD",
# then try the inlets operator with "arkade install inlets-operator"

# If you're using a managed Kubernetes service, then you'll find
# your LoadBalancer's IP under "EXTERNAL-IP" via:

kubectl get svc nginx-ingress-controller

# Find out more at:
# https://github.com/helm/charts/tree/master/stable/nginx-ingress

Thanks for using arkade!
```
```
./arkade install kube-state-metrics --namespace default --helm3
Using kubeconfig: /home/kaderno/.kube/config
Node architecture: "amd64"
Using helm3
Client: "x86_64", "Linux"
2020/05/02 08:19:59 User dir established as: /home/kaderno/.arkade/
Chart path:  /tmp/charts
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install kube-state-metrics stable/kube-state-metrics --namespace default --values /tmp/charts/kube-state-metrics/values.yaml]
=======================================================================
=             kube-state-metrics has been installed.                  =
=======================================================================

# Port-forward
kubectl port-forward -n default service/kube-state-metrics 9000:8080 &

# Then access via:
http://localhost:9000/metrics

# Find out more at:
# https://github.com/kubernetes/kube-state-metrics

Thanks for using arkade!
```
```
./arkade install kube-state-metrics --namespace default --helm3 --verbose
Using kubeconfig: /home/kaderno/.kube/config
Node architecture: "amd64"
Using helm3
Client: "x86_64", "Linux"
2020/05/02 08:20:12 User dir established as: /home/kaderno/.arkade/
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "arm-stable" chart repository
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "bitnami-redis" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
Chart path:  /tmp/charts
VALUES values.yaml
Command: /home/kaderno/.arkade/bin/helm3/helm [upgrade --install kube-state-metrics stable/kube-state-metrics --namespace default --values /tmp/charts/kube-state-metrics/values.yaml]
Release "kube-state-metrics" has been upgraded. Happy Helming!
NAME: kube-state-metrics
LAST DEPLOYED: Sat May  2 08:20:20 2020
NAMESPACE: default
STATUS: deployed
REVISION: 12
TEST SUITE: None
NOTES:
kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
The exposed metrics can be found here:
https://github.com/kubernetes/kube-state-metrics/blob/master/docs/README.md#exposed-metrics

The metrics are exported on the HTTP endpoint /metrics on the listening port.
In your case, kube-state-metrics.default.svc.cluster.local:8080/metrics

They are served either as plaintext or protobuf depending on the Accept header.
They are designed to be consumed either by Prometheus itself or by a scraper that is compatible with scraping a Prometheus client endpoint.
=======================================================================
=             kube-state-metrics has been installed.                  =
=======================================================================

# Port-forward
kubectl port-forward -n default service/kube-state-metrics 9000:8080 &

# Then access via:
http://localhost:9000/metrics

# Find out more at:
# https://github.com/kubernetes/kube-state-metrics

Thanks for using arkade!

```


<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [X] I have tested this on arm, or have added code to prevent deployment
