### PR TITLE
Fix download of Helm on Git Bash

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -17,7 +17,7 @@ import (
 )
 
 const helmVersion = "v2.16.0"
-const helm3Version = "v3.1.1"
+const helm3Version = "v3.1.2"
 
 func TryDownloadHelm(userPath, clientArch, clientOS string, helm3 bool) (string, error) {
 	helmVal := "helm"
@@ -49,6 +49,9 @@ func GetHelmURL(arch, os, version string) string {
 		archSuffix = "arm"
 	} else if strings.HasPrefix(arch, "aarch64") {
 		archSuffix = "arm64"
+	}
+	if strings.Contains(strings.ToLower(os), "mingw") {
+		osSuffix = "windows"
 	}
 
 	return fmt.Sprintf("https://get.helm.sh/helm-%s-%s-%s.tar.gz", version, osSuffix, archSuffix)

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -1,0 +1,17 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package helm
+
+import "testing"
+
+func Test_GetHelmURL_GitBash(t *testing.T) {
+	arch := "amd64"
+	os := "mingw64_nt-10.0-18362"
+
+	got := GetHelmURL(arch, os, helm3Version)
+	want := "https://get.helm.sh/helm-v3.1.2-windows-amd64.tar.gz"
+	if got != want {
+		t.Fatalf("want: %s, but got: %s", want, got)
+	}
+}


### PR DESCRIPTION
Fixes: #92

Tested with a unit test, with similar logic to the get.sh
script.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
