### PR TITLE
Fixes #43: Add redis app

### DIFF
--- a/cmd/apps/redis_app.go
+++ b/cmd/apps/redis_app.go
@@ -1,0 +1,133 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/arkade/pkg/k8s"
+	"github.com/alexellis/arkade/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallRedis() *cobra.Command {
+	var redis = &cobra.Command{
+		Use:          "redis",
+		Short:        "Install redis",
+		Long:         "Install redis",
+		Example:      "arkade install redis",
+		SilenceUsage: true,
+	}
+
+	redis.Flags().StringP("namespace", "n", "redis", "The namespace to install redis")
+	redis.Flags().Bool("update-repo", true, "Update the helm repo")
+
+	redis.RunE = func(command *cobra.Command, args []string) error {
+
+		const chartVersion = "10.5.7"
+		namespace, _ := command.Flags().GetString("namespace")
+		wait, _ := command.Flags().GetBool("wait")
+		updateRepo, _ := command.Flags().GetBool("update-repo")
+
+		userPath, err := config.InitUserDir()
+		if err != nil {
+			return err
+		}
+
+		clientArch, clientOS := env.GetClientArch()
+
+		log.Printf("Client: %s, %s\n", clientArch, clientOS)
+		log.Printf("User dir established as: %s\n", userPath)
+
+		// exit on arm
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(`only Intel, i.e. PC architecture is supported for this app`)
+		}
+
+		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
+			return err
+		}
+
+		overrides := map[string]string{
+			"serviceAccount.create": "true",
+			"rbac.create":           "true",
+		}
+
+		customFlags, _ := command.Flags().GetStringArray("set")
+
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		redisAppOptions := types.DefaultInstallOptions().
+			WithNamespace(namespace).
+			WithHelmPath(path.Join(userPath, ".helm")).
+			WithHelmRepo("bitnami-redis/redis").
+			WithHelmURL("https://charts.bitnami.com/bitnami").
+			WithOverrides(overrides).
+			WithWait(wait).
+			WithHelmUpdateRepo(updateRepo)
+
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, true)
+		if err != nil {
+			return err
+		}
+
+		_, err = apps.MakeInstallRedis(redisAppOptions)
+		if err != nil {
+			return err
+		}
+
+		println(redisInstallMsg)
+		return nil
+	}
+
+	return redis
+}
+
+const redisInstallMsg = `=======================================================================
+=                       redis has been installed                      =
+=======================================================================
+` + RedisInfoMsg + pkg.ThanksForUsing
+
+const RedisInfoMsg = `
+# Redis can be accessed via port 6379 on the following DNS names from within your cluster:
+
+# redis-master.redis.svc.cluster.local for read/write operations
+# redis-slave.redis.svc.cluster.local for read-only operations
+
+
+# To get your password run:
+
+  export REDIS_PASSWORD=$(kubectl get secret --namespace redis redis -o jsonpath="{.data.redis-password}" | base64 --decode)
+
+# To connect to your Redis server:
+
+# 1. Run a Redis pod that you can use as a client:
+
+  kubectl run --namespace redis redis-client --rm --tty -i --restart='Never' \
+   --env REDIS_PASSWORD=$REDIS_PASSWORD \
+   --image docker.io/bitnami/redis:5.0.7-debian-10-r48 -- bash
+
+# 2. Connect using the Redis CLI:
+  redis-cli -h redis-master -a $REDIS_PASSWORD
+  redis-cli -h redis-slave -a $REDIS_PASSWORD
+
+# To connect to your database from outside the cluster execute the following commands:
+
+  kubectl port-forward --namespace redis svc/redis-master 6379:6379 &
+  redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
+
+`

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -113,6 +113,9 @@ arkade info --help`,
 		case "nats-connector":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.NATSConnectorInfoMsg)
+		case "redis":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.RedisInfoMsg)
 		default:
 			return fmt.Errorf("no info available for app: %s", appName)
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -69,6 +69,8 @@ command.`,
 	command.AddCommand(apps.MakeInstallLoki())
 	command.AddCommand(apps.MakeInstallNATSConnector())
 	command.AddCommand(apps.MakeInstallNfsProvisioner())
+	command.AddCommand(apps.MakeInstallRedis())
+
 	command.AddCommand(MakeInfo())
 
 	return command
@@ -101,5 +103,6 @@ func getApps() []string {
 		"loki",
 		"nats-connector",
 		"nfs-client-provisioner",
+		"redis",
 	}
 }

--- a/pkg/apps/redis.go
+++ b/pkg/apps/redis.go
@@ -1,0 +1,32 @@
+package apps
+
+import (
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/arkade/pkg/k8s"
+	"github.com/alexellis/arkade/pkg/types"
+)
+
+func MakeInstallRedis(options *types.InstallerOptions) (*types.InstallerOutput, error) {
+	result := &types.InstallerOutput{}
+
+	k8s.KubectlTask("create", "namespace", options.Namespace)
+
+	err := helm.AddHelmRepo(options.Helm.Repo.Name, options.Helm.Repo.URL, options.Helm.UpdateRepo, options.Helm.Helm3)
+	if err != nil {
+		return result, err
+	}
+
+	if err := helm.FetchChart(options.Helm.Repo.Name, options.Helm.Repo.Version, options.Helm.Helm3); err != nil {
+		return result, err
+	}
+
+	if err := helm.Helm3Upgrade(options.Helm.Repo.Name, options.Namespace,
+		"values.yaml",
+		options.Helm.Repo.Version,
+		options.Helm.Overrides,
+		options.Helm.Wait); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -58,6 +58,11 @@ func (o *InstallerOptions) WithHelmURL(s string) *InstallerOptions {
 	return o
 }
 
+func (o *InstallerOptions) WithHelmUpdateRepo(update bool) *InstallerOptions {
+	o.Helm.UpdateRepo = update
+	return o
+}
+
 func (o *InstallerOptions) WithOverrides(overrides map[string]string) *InstallerOptions {
 	o.Helm.Overrides = overrides
 	return o


### PR DESCRIPTION
Fixes #43: Add redis app

- Helm3 only
- No arm support

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the bitnami redis chart as app.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#43 
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
non ARM:
```
arkade install redis
export REDIS_PASSWORD=$(kubectl get secret --namespace redis redis -o jsonpath="{.data.redis-password}" | base64 --decode)
kubectl run --namespace redis redis-client --rm --tty -i --restart='Never' --env REDIS_PASSWORD=$REDIS_PASSWORD --image docker.io/bitnami/redis:5.0.7-debian-10-r48 -- bash
redis-cli -a $REDIS_PASSWORD redis-master
# here you should be connected to the master
```
ARM:
```
arkade install redis
> Node architecture: "arm64"
> Error: only Intel, i.e. PC architecture is supported for this app
```
<!--- Include details of your testing environment, and the tests you ran to -->
Intel: k3d on amd64 host
ARM: k3sup on raspi
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.