### PR TITLE
Add nats connector app

### DIFF
--- a/cmd/apps/nats_connector.go
+++ b/cmd/apps/nats_connector.go
@@ -1,0 +1,102 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"log"
+	"os"
+	"path"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/arkade/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallNATSConnector() *cobra.Command {
+	var natsConnectorApp = &cobra.Command{
+		Use:          "nats-connector",
+		Short:        "Install OpenFaaS connector for NATS",
+		Long:         "Install OpenFaaS connector for NATS to invoke OpenFaaS functions using NATS.",
+		Example:      "arkade install nats-connector",
+		SilenceUsage: true,
+	}
+
+	natsConnectorApp.Flags().StringP("namespace", "n", "default", "The namespace to install NATS connector (default: default")
+	natsConnectorApp.Flags().Bool("update-repo", true, "Update the helm repo")
+	natsConnectorApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set topics=nats-test,)")
+
+	natsConnectorApp.RunE = func(command *cobra.Command, args []string) error {
+		helm3 := true
+
+		namespace, _ := natsConnectorApp.Flags().GetString("namespace")
+		userPath, err := config.InitUserDir()
+		if err != nil {
+			return err
+		}
+
+		clientArch, clientOS := env.GetClientArch()
+
+		log.Printf("Client: %s, %s\n", clientArch, clientOS)
+
+		log.Printf("User dir established as: %s\n", userPath)
+
+		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
+			return err
+		}
+
+		overrides := map[string]string{}
+
+		customFlags, _ := command.Flags().GetStringArray("set")
+
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		natsConnectorOptions := types.DefaultInstallOptions().
+			WithNamespace(namespace).
+			WithHelmPath(path.Join(userPath, ".helm")).
+			WithHelmRepo("openfaas/nats-connector").
+			WithHelmURL("https://openfaas.github.io/faas-netes/").
+			WithOverrides(overrides)
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeconfigPath, _ := command.Flags().GetString("kubeconfig")
+			natsConnectorOptions.WithKubeconfigPath(kubeconfigPath)
+		}
+
+		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
+
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
+		if err != nil {
+			return err
+		}
+
+		_, err = apps.MakeInstallNATSConnector(natsConnectorOptions)
+		if err != nil {
+			return err
+		}
+
+		println(NATSConnectorInstallMsg)
+		return nil
+	}
+
+	return natsConnectorApp
+}
+
+const NATSConnectorInfoMsg = `# View the connector logs:
+
+kubectl logs deploy/nats-connector -n openfaas -f
+
+# Find out more on the project homepage:
+https://github.com/openfaas/faas-netes/tree/master/chart/nats-connector
+`
+
+const NATSConnectorInstallMsg = `=======================================================================
+= nats-connector has been installed.                                   =
+=======================================================================` +
+	"\n\n" + NATSConnectorInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -110,6 +110,9 @@ arkade info --help`,
 		case "loki":
 			fmt.Printf("Info for app: %s\n", appName)
 			fmt.Println(apps.LokiInfoMsg)
+		case "nats-connector":
+			fmt.Printf("Info for app: %s\n", appName)
+			fmt.Println(apps.NATSConnectorInfoMsg)
 		default:
 			return fmt.Errorf("no info available for app: %s", appName)
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -67,6 +67,7 @@ command.`,
 	command.AddCommand(apps.MakeInstallTekton())
 	command.AddCommand(apps.MakeInstallJenkins())
 	command.AddCommand(apps.MakeInstallLoki())
+	command.AddCommand(apps.MakeInstallNATSConnector())
 
 	command.AddCommand(MakeInfo())
 
@@ -98,5 +99,6 @@ func getApps() []string {
 		"tekton",
 		"jenkins",
 		"loki",
+		"nats-connector",
 	}
 }

--- a/pkg/apps/nats_connector.go
+++ b/pkg/apps/nats_connector.go
@@ -1,0 +1,28 @@
+package apps
+
+import (
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/arkade/pkg/types"
+)
+
+func MakeInstallNATSConnector(options *types.InstallerOptions) (*types.InstallerOutput, error) {
+	result := &types.InstallerOutput{}
+	err := helm.AddHelmRepo(options.Helm.Repo.Name, options.Helm.Repo.URL, options.Helm.UpdateRepo, options.Helm.Helm3)
+	if err != nil {
+		return result, err
+	}
+
+	if err := helm.FetchChart(options.Helm.Repo.Name, options.Helm.Repo.Version, options.Helm.Helm3); err != nil {
+		return result, err
+	}
+
+	if err := helm.Helm3Upgrade(options.Helm.Repo.Name, options.Namespace,
+		"values.yaml",
+		options.Helm.Repo.Version,
+		options.Helm.Overrides,
+		options.Helm.Wait); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #112 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my local desktop with k3d

```
./bin/arkade-darwin install nats-connector -n openfaas
2020/06/17 14:18:31 Client: x86_64, Darwin
2020/06/17 14:18:31 User dir established as: /Users/viveks/.arkade/
map[]
"openfaas/nats-connector" has been added to your repositories

VALUES values.yaml
Command: /Users/viveks/.arkade/bin/helm3/helm [upgrade --install nats-connector openfaas/nats-connector --namespace openfaas --values /var/folders/tw/6ww2mtms12ndnypdycqfy_q40000gy/T/charts/nats-connector/values.yaml]
Release "nats-connector" does not exist. Installing it now.
NAME: nats-connector
LAST DEPLOYED: Wed Jun 17 14:18:38 2020
NAMESPACE: openfaas
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thanks for installing nats-connector. Please follow the instructions below to get you started.

You can watch the Connector logs to see it invoke your functions:

$ kubectl logs -n openfaas deploy/nats-connector -f
=======================================================================
= nats-connector has been installed.                                   =
=======================================================================

# View the connector logs:

kubectl logs deploy/nats-connector -n openfaas -f

# Find out more on the project homepage:
https://github.com/openfaas/faas-netes/tree/master/chart/nats-connector


Thanks for using arkade!
➜  arkade git:(nats-connector) kubectl logs -n openfaas deploy/nats-connector -f
==============================================================================
NATS Connector for OpenFaaS

Gateway URL: http://gateway.openfaas:8080
NATS URL: nats://nats:4222
Topics: 30s
Upstream timeout: [nats-test]
Topic-map rebuild interval: 5s
Async invocation: "false"
==============================================================================

2020/06/17 08:48:39 Configured topics: [nats-test]
2020/06/17 08:48:39 Binding to topic: "nats-test"
2020/06/17 08:48:39 Subscription: nats-test ready

➜  arkade git:(nats-connector) export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"
➜  arkade git:(nats-connector) faas-cli deploy --name receive-message --image openfaas/receive-message:latest --fprocess='./handler' --annotation topic="nats-test"
➜  arkade git:(nats-connector) kubectl port-forward -n openfaas svc/gateway 8080:8080 &
[1] 63950
➜  arkade git:(nats-connector) Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080

➜  arkade git:(nats-connector) faas-cli deploy --name receive-message --image openfaas/receive-message:latest --fprocess='./handler' --annotation topic="nats-test"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Handling connection for 8080

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/receive-message

➜  arkade git:(nats-connector) faas-cli deploy --name publish-message --image openfaas/publish-message:latest --fprocess='./handler' --env nats_url=nats://nats.openfaas:4222
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Handling connection for 8080

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/publish-message

➜  arkade git:(nats-connector) faas-cli invoke publish-message <<< "test message"
Handling connection for 8080
Sent "test message"%                                                                                                                                                              ➜  arkade git:(nats-connector) kubectl logs -n openfaas deploy/nats-connector -f
==============================================================================
NATS Connector for OpenFaaS

Gateway URL: http://gateway.openfaas:8080
NATS URL: nats://nats:4222
Topics: 30s
Upstream timeout: [nats-test]
Topic-map rebuild interval: 5s
Async invocation: "false"
==============================================================================

2020/06/17 08:48:39 Configured topics: [nats-test]
2020/06/17 08:48:39 Binding to topic: "nats-test"
2020/06/17 08:48:39 Subscription: nats-test ready
2020/06/17 08:50:03 Topic: nats-test, message: "test message"
2020/06/17 08:50:03 Invoke function: figlet.openfaas-fn
2020/06/17 08:50:03 Invoke function: receive-message.openfaas-fn
2020/06/17 08:50:03 connector-sdk got result: [200] nats-test => figlet.openfaas-fn (372) bytes
2020/06/17 08:50:03 connector-sdk got result: [200] nats-test => receive-message.openfaas-fn (28) bytes
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
