### PR TITLE
Added nfs-client-provisioner app

### DIFF
--- a/cmd/apps/loki_app.go
+++ b/cmd/apps/loki_app.go
@@ -83,7 +83,7 @@ func MakeInstallLoki() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallLoki(lokiOptions)
+		_, err = apps.MakeInstallChart(lokiOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/nfs_app.go
+++ b/cmd/apps/nfs_app.go
@@ -1,0 +1,168 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/arkade/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallNfsProvisioner() *cobra.Command {
+	var nfsProvisionerApp = &cobra.Command{
+		Use:          "nfs-client-provisioner",
+		Short:        "Install nfs client provisioner",
+		Long:         "Install nfs client provisioner to create dynamic persistent volumes",
+		Example:      "arkade install nfs-client-provisioner --nfs-server=x.x.x.x --nfs-path=/exported/path",
+		SilenceUsage: true,
+	}
+
+	nfsProvisionerApp.Flags().StringP("namespace", "n", "default", "The namespace to install nfs-client (default: default")
+	nfsProvisionerApp.Flags().String("nfs-server", "", "IP or hostname of the NFS server ")
+	nfsProvisionerApp.Flags().String("nfs-path", "", "Basepath of the mount point to be used")
+	nfsProvisionerApp.Flags().Bool("update-repo", true, "Update the helm repo")
+	nfsProvisionerApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set =true)")
+
+	nfsProvisionerApp.RunE = func(command *cobra.Command, args []string) error {
+		helm3 := true
+
+		namespace, _ := nfsProvisionerApp.Flags().GetString("namespace")
+		userPath, err := config.InitUserDir()
+		if err != nil {
+			return err
+		}
+
+		clientArch, clientOS := env.GetClientArch()
+
+		log.Printf("Client: %s, %s\n", clientArch, clientOS)
+
+		log.Printf("User dir established as: %s\n", userPath)
+
+		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
+			return err
+		}
+
+		nfsServer, _ := command.Flags().GetString("nfs-server")
+		nfsPath, _ := command.Flags().GetString("nfs-path")
+
+		if len(nfsServer) == 0 {
+			return fmt.Errorf("--nfs-server required")
+		}
+
+		if len(nfsPath) == 0 {
+			return fmt.Errorf("--nfs-path required")
+		}
+
+		overrides := map[string]string{}
+
+		overrides["nfs.server"] = nfsServer
+		overrides["nfs.path"] = nfsPath
+
+		switch clientArch {
+		case "arm", "armhf", "arm64", "aarch64":
+			overrides["image.repository"] = "quay.io/external_storage/nfs-client-provisioner-arm"
+		}
+		customFlags, _ := command.Flags().GetStringArray("set")
+
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		nfsProvisionerOptions := types.DefaultInstallOptions().
+			WithNamespace(namespace).
+			WithHelmPath(path.Join(userPath, ".helm")).
+			WithHelmRepo("stable/nfs-client-provisioner").
+			WithHelmURL("https://kubernetes-charts.storage.googleapis.com").
+			WithOverrides(overrides)
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeconfigPath, _ := command.Flags().GetString("kubeconfig")
+			nfsProvisionerOptions.WithKubeconfigPath(kubeconfigPath)
+		}
+
+		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
+
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS, helm3)
+		if err != nil {
+			return err
+		}
+
+		_, err = apps.MakeInstallChart(nfsProvisionerOptions)
+		if err != nil {
+			return err
+		}
+
+		println(nfsClientInstallMsg)
+		return nil
+	}
+
+	return nfsProvisionerApp
+}
+
+const NfsClientProvisioneriInfoMsg = `# Test your NFS provisioner:
+
+cat <<EOF | kubectl apply -f -
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "nfs-client"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi
+EOF
+
+# Create pod:
+
+cat <<EOF | kubectl apply -f -
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: test-pod
+    image: gcr.io/google_containers/busybox:1.24
+    command:
+      - "/bin/sh"
+    args:
+      - "-c"
+      - "touch /mnt/SUCCESS && exit 0 || exit 1"
+    volumeMounts:
+      - name: nfs-pvc
+        mountPath: "/mnt"
+  restartPolicy: "Never"
+  volumes:
+    - name: nfs-pvc
+      persistentVolumeClaim:
+        claimName: test-claim
+EOF
+
+# Now check your NFS Server for the file SUCCESS.
+
+kubectl delete -f deploy/test-pod.yaml -f deploy/test-claim.yaml
+
+# Now check the folder has been deleted.
+
+
+
+`
+
+const nfsClientInstallMsg = `=======================================================================
+= nfs-client-provisioner has been installed.                                   =
+=======================================================================` +
+	"\n\n" + NfsClientProvisioneriInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -68,7 +68,7 @@ command.`,
 	command.AddCommand(apps.MakeInstallJenkins())
 	command.AddCommand(apps.MakeInstallLoki())
 	command.AddCommand(apps.MakeInstallNATSConnector())
-
+	command.AddCommand(apps.MakeInstallNfsProvisioner())
 	command.AddCommand(MakeInfo())
 
 	return command
@@ -100,5 +100,6 @@ func getApps() []string {
 		"jenkins",
 		"loki",
 		"nats-connector",
+		"nfs-client-provisioner",
 	}
 }

--- a/pkg/apps/chart_app.go
+++ b/pkg/apps/chart_app.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexellis/arkade/pkg/types"
 )
 
-func MakeInstallLoki(options *types.InstallerOptions) (*types.InstallerOutput, error) {
+func MakeInstallChart(options *types.InstallerOptions) (*types.InstallerOutput, error) {
 	result := &types.InstallerOutput{}
 	err := helm.AddHelmRepo(options.Helm.Repo.Name, options.Helm.Repo.URL, options.Helm.UpdateRepo, options.Helm.Helm3)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: kadern0 <kaderno@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Fixes #121 
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Installed helm chart directly against minikube to test the installation. After that I installed it using arkade:

```
./arkade install nfs-client-provisioner --nfs-server=192.168.0.116 --nfs-path=/exports/
2020/06/17 19:00:46 Client: x86_64, Linux
2020/06/17 19:00:46 User dir established as: /home/pcaderno/.arkade/
"stable/nfs-client-provisioner" has been added to your repositories

VALUES values.yaml
Command: /home/pcaderno/.arkade/bin/helm3/helm [upgrade --install nfs-client-provisioner stable/nfs-client-provisioner --namespace default --values /tmp/charts/nfs-client-provisioner/values.yaml --set nfs.server=192.168.0.116 --set nfs.path=/exports/]
Release "nfs-client-provisioner" does not exist. Installing it now.
NAME: nfs-client-provisioner
LAST DEPLOYED: Wed Jun 17 19:00:53 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
=======================================================================
= nfs-client-provisioner has been installed.                                   =
=======================================================================

# Test your NFS provisioner:

cat <<EOF | kubectl apply -f -
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: test-claim
  annotations:
    volume.beta.kubernetes.io/storage-class: "nfs-client"
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 1Mi
EOF

# Create pod:

cat <<EOF | kubectl apply -f -
kind: Pod
apiVersion: v1
metadata:
  name: test-pod
spec:
  containers:
  - name: test-pod
    image: gcr.io/google_containers/busybox:1.24
    command:
      - "/bin/sh"
    args:
      - "-c"
      - "touch /mnt/SUCCESS && exit 0 || exit 1"
    volumeMounts:
      - name: nfs-pvc
        mountPath: "/mnt"
  restartPolicy: "Never"
  volumes:
    - name: nfs-pvc
      persistentVolumeClaim:
        claimName: test-claim
EOF

# Now check your NFS Server for the file SUCCESS.

kubectl delete -f deploy/test-pod.yaml -f deploy/test-claim.yaml

# Now check the folder has been deleted.

Thanks for using arkade!

```
```
kubectl get storageclass

NAME                 PROVISIONER                            RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
nfs-client           cluster.local/nfs-client-provisioner   Delete          Immediate           true                   9s
standard (default)   k8s.io/minikube-hostpath               Delete          Immediate           false                  69m

```
Manually created the PVC
```
cat <<EOF | kubectl apply -f -
> kind: PersistentVolumeClaim
> apiVersion: v1
> metadata:
>   name: test-claim
>   annotations:
>     volume.beta.kubernetes.io/storage-class: "nfs-client"
> spec:
>   accessModes:
>     - ReadWriteMany
>   resources:
>     requests:
>       storage: 1Mi
> EOF
persistentvolumeclaim/test-claim created

# verify the PVC
kubectl get pvc
NAME         STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
test-claim   Pending                                      nfs-client     6s

# Describe the PVC
kubectl describe pvc test-claim
Name:          test-claim
Namespace:     default
StorageClass:  nfs-client
Status:        Pending
Volume:        
Labels:        <none>
Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                 {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{"volume.beta.kubernetes.io/storage-class":"nfs-client"},"name...
               volume.beta.kubernetes.io/storage-class: nfs-client
               volume.beta.kubernetes.io/storage-provisioner: cluster.local/nfs-client-provisioner
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      
Access Modes:  
VolumeMode:    Filesystem
Mounted By:    <none>
Events:
  Type    Reason                Age                From                         Message
  ----    ------                ----               ----                         -------
  Normal  ExternalProvisioning  14s (x7 over 82s)  persistentvolume-controller  waiting for a volume to be created, either by external provisioner "cluster.local/nfs-client-provisioner" or manually created by system administrator

```
I reached exactly the same status as I did with the helm chart itself. I guess the permissions on the nfs share I have don't allow clients to create folders, but didn't want to expend much time messing with NFS.

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [X] I have tested this on arm, or have added code to prevent deployment
