### PR TITLE
Support arkade get with tgz/zip archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ arkade will determine the correct URL to download a CLI tool of your choice taki
 arkade get kubectl
 arkade get faas-cli
 arkade get kubectx
+arkade get helm
 ```
 
 > This is a time saver compared to searching for download pages every time you need a tool.

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -4,17 +4,131 @@
 package cmd
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/alexellis/arkade/pkg/env"
 	"github.com/alexellis/arkade/pkg/get"
 	"github.com/spf13/cobra"
 )
+
+// TODO: Untar logic is copied from helm.go. Need to refactor this later on.
+
+// Untar reads the gzip-compressed tar file from r and writes it into dir.
+func Untar(r io.Reader, dir string) error {
+	return untar(r, dir)
+}
+
+func untar(r io.Reader, dir string) (err error) {
+	t0 := time.Now()
+	nFiles := 0
+	madeDir := map[string]bool{}
+	defer func() {
+		td := time.Since(t0)
+		if err == nil {
+			log.Printf("extracted tarball into %s: %d files, %d dirs (%v)", dir, nFiles, len(madeDir), td)
+		} else {
+			log.Printf("error extracting tarball into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
+		}
+	}()
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("requires gzip-compressed body: %v", err)
+	}
+	tr := tar.NewReader(zr)
+	loggedChtimesError := false
+	for {
+		f, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Printf("tar reading error: %v", err)
+			return fmt.Errorf("tar error: %v", err)
+		}
+		if !validRelPath(f.Name) {
+			return fmt.Errorf("tar contained invalid name error %q", f.Name)
+		}
+		baseFile := filepath.Base(f.Name)
+		abs := path.Join(dir, baseFile)
+		fmt.Println(abs, f.Name)
+
+		fi := f.FileInfo()
+		mode := fi.Mode()
+		switch {
+		case mode.IsDir():
+
+			break
+
+		case mode.IsRegular():
+
+			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
+			if err != nil {
+				return err
+			}
+			n, err := io.Copy(wf, tr)
+			if closeErr := wf.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				return fmt.Errorf("error writing to %s: %v", abs, err)
+			}
+			if n != f.Size {
+				return fmt.Errorf("only wrote %d bytes to %s; expected %d", n, abs, f.Size)
+			}
+			modTime := f.ModTime
+			if modTime.After(t0) {
+				// Clamp modtimes at system time. See
+				// golang.org/issue/19062 when clock on
+				// buildlet was behind the gitmirror server
+				// doing the git-archive.
+				modTime = t0
+			}
+			if !modTime.IsZero() {
+				if err := os.Chtimes(abs, modTime, modTime); err != nil && !loggedChtimesError {
+					// benign error. Gerrit doesn't even set the
+					// modtime in these, and we don't end up relying
+					// on it anywhere (the gomote push command relies
+					// on digests only), so this is a little pointless
+					// for now.
+					log.Printf("error changing modtime: %v (further Chtimes errors suppressed)", err)
+					loggedChtimesError = true // once is enough
+				}
+			}
+			nFiles++
+		default:
+		}
+	}
+	return nil
+}
+
+func validRelativeDir(dir string) bool {
+	if strings.Contains(dir, `\`) || path.IsAbs(dir) {
+		return false
+	}
+	dir = path.Clean(dir)
+	if strings.HasPrefix(dir, "../") || strings.HasSuffix(dir, "/..") || dir == ".." {
+		return false
+	}
+	return true
+}
+
+func validRelPath(p string) bool {
+	if p == "" || strings.Contains(p, `\`) || strings.HasPrefix(p, "/") || strings.Contains(p, "../") {
+		return false
+	}
+	return true
+}
 
 func MakeGet() *cobra.Command {
 	tools := get.MakeTools()
@@ -77,14 +191,24 @@ func MakeGet() *cobra.Command {
 
 		outFilePath := path.Join(tmp, fileName)
 
-		out, err := os.Create(outFilePath)
-		if err != nil {
-			return err
-		}
-		defer out.Close()
+		if tool.NeedDecompression == true {
+			outFilePathDir := filepath.Dir(outFilePath)
+			outFilePath = path.Join(outFilePathDir, tool.Name)
+			r := ioutil.NopCloser(res.Body)
+			untarErr := Untar(r, outFilePathDir)
+			if untarErr != nil {
+				return untarErr
+			}
+		} else {
+			out, err := os.Create(outFilePath)
+			if err != nil {
+				return err
+			}
+			defer out.Close()
 
-		if _, err = io.Copy(out, res.Body); err != nil {
-			return err
+			if _, err = io.Copy(out, res.Body); err != nil {
+				return err
+			}
 		}
 
 		finalName := tool.Name

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Tool struct {
-	Name           string
-	Repo           string
-	Owner          string
-	Version        string
-	URLTemplate    string
-	BinaryTemplate string
-	NoExtension    bool
+	Name              string
+	Repo              string
+	Owner             string
+	Version           string
+	URLTemplate       string
+	BinaryTemplate    string
+	NoExtension       bool
+	NeedDecompression bool
 }
 
 var templateFuncs = map[string]interface{}{
@@ -195,7 +196,8 @@ https://storage.googleapis.com/kubernetes-release/release/{{.Version}}/bin/{{$os
 			Version:     "v0.9.0",
 			URLTemplate: `https://github.com/ahmetb/kubectx/releases/download/{{.Version}}/kubectx`,
 			// Author recommends to keep using Bash version in this release https://github.com/ahmetb/kubectx/releases/tag/v0.9.0
-			NoExtension: true,
+			NoExtension:       true,
+			NeedDecompression: false,
 		},
 	}
 	return tools

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -151,3 +151,66 @@ func Test_DownloadWindows(t *testing.T) {
 		t.Fatalf("want: %s, got: %s", want, got)
 	}
 }
+
+func Test_DownloadHelmDarwin(t *testing.T) {
+	tools := MakeTools()
+	name := "helm"
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	got, err := tool.GetURL("darwin", arch64bit, tool.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://get.helm.sh/helm-v3.2.4-darwin-amd64.tar.gz"
+	if got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}
+
+func Test_DownloadHelmLinux(t *testing.T) {
+	tools := MakeTools()
+	name := "helm"
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	got, err := tool.GetURL("linux", arch64bit, tool.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz"
+	if got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}
+
+func Test_DownloadHelmWindows(t *testing.T) {
+	tools := MakeTools()
+	name := "helm"
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	got, err := tool.GetURL("mingw64_nt-10.0-18362", arch64bit, tool.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://get.helm.sh/helm-v3.2.4-windows-amd64.zip"
+	if got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}

--- a/pkg/helm/untar.go
+++ b/pkg/helm/untar.go
@@ -9,6 +9,7 @@ package helm
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -28,6 +29,80 @@ import (
 // Untar reads the gzip-compressed tar file from r and writes it into dir.
 func Untar(r io.Reader, dir string) error {
 	return untar(r, dir)
+}
+
+// Untar reads the compressed zip file from r and writes it into dir.
+func Unzip(r zip.Reader, dir string) error {
+	return unzip(r, dir)
+}
+
+func unzip(r zip.Reader, dir string) (err error) {
+	if err != nil {
+		return err
+	}
+	t0 := time.Now()
+	nFiles := 0
+	madeDir := map[string]bool{}
+	defer func() {
+		td := time.Since(t0)
+		if err == nil {
+			log.Printf("extracted zip into %s: %d files, %d dirs (%v)", dir, nFiles, len(madeDir), td)
+		} else {
+			log.Printf("error extracting zip into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
+		}
+	}()
+
+	// Closure to address file descriptors issue with all the deferred .Close() methods
+	extractAndWriteFile := func(f *zip.File) error {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := rc.Close(); err != nil {
+				panic(err)
+			}
+		}()
+		baseFile := filepath.Base(f.Name)
+		abs := path.Join(dir, baseFile)
+
+		fmt.Println(abs)
+
+		fi := f.FileInfo()
+		mode := fi.Mode()
+
+		switch {
+		case mode.IsDir():
+			break
+		case mode.IsRegular():
+			f, err := os.OpenFile(abs, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					panic(err)
+				}
+			}()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+		default:
+		}
+		nFiles++
+		return nil
+	}
+
+	for _, f := range r.File {
+		err := extractAndWriteFile(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func untar(r io.Reader, dir string) (err error) {


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <me@tuananh.org>

Allow `arkade get` to download tgz/zip archives

There are a few points I still need clarification.

* for kubectx, the cli name is same as the tool so I can reuse `tool.Name`. However, will there be case the cli name is different than the repo name? In that case, should I add a new field `BinaryName` to the Tool struct and use that to pull the cli from the tgz/zip archive instead? 
* Will there be case there will be multiple cli in the same tgz/zip that need to be pull out?
* I can only test manually by changing the url for now because `kubectx` author  is still recommending to use bash version.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Attempt to partially fix #123 

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

Right now, there's no tgz/zip tool so I manually change the url of `kubectx` to use `tgz` format (hardcode download url to `https://github.com/ahmetb/kubectx/releases/download/v0.9.0/kubectx_v0.9.0_darwin_x86_64.tar.gz` and `NeedDecompress` to ` true` during testing.

![image](https://user-images.githubusercontent.com/627278/85094289-a5de7400-b218-11ea-82f2-2f30153ca39e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
