### PR TITLE
Add support for tgz/zip archives to the get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ arkade will determine the correct URL to download a CLI tool of your choice taki
 arkade get kubectl
 arkade get faas-cli
 arkade get kubectx
+arkade get helm
 ```
 
 > This is a time saver compared to searching for download pages every time you need a tool.

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -151,3 +151,66 @@ func Test_DownloadWindows(t *testing.T) {
 		t.Fatalf("want: %s, got: %s", want, got)
 	}
 }
+
+func Test_DownloadHelmDarwin(t *testing.T) {
+	tools := MakeTools()
+	name := "helm"
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	got, err := tool.GetURL("darwin", arch64bit, tool.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://get.helm.sh/helm-v3.2.4-darwin-amd64.tar.gz"
+	if got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}
+
+func Test_DownloadHelmLinux(t *testing.T) {
+	tools := MakeTools()
+	name := "helm"
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	got, err := tool.GetURL("linux", arch64bit, tool.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz"
+	if got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}
+
+func Test_DownloadHelmWindows(t *testing.T) {
+	tools := MakeTools()
+	name := "helm"
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	got, err := tool.GetURL("mingw64_nt-10.0-18362", arch64bit, tool.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://get.helm.sh/helm-v3.2.4-windows-amd64.zip"
+	if got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}

--- a/pkg/helm/untar.go
+++ b/pkg/helm/untar.go
@@ -9,6 +9,7 @@ package helm
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -28,6 +29,80 @@ import (
 // Untar reads the gzip-compressed tar file from r and writes it into dir.
 func Untar(r io.Reader, dir string) error {
 	return untar(r, dir)
+}
+
+// Untar reads the compressed zip file from r and writes it into dir.
+func Unzip(r zip.Reader, dir string) error {
+	return unzip(r, dir)
+}
+
+func unzip(r zip.Reader, dir string) (err error) {
+	if err != nil {
+		return err
+	}
+	t0 := time.Now()
+	nFiles := 0
+	madeDir := map[string]bool{}
+	defer func() {
+		td := time.Since(t0)
+		if err == nil {
+			log.Printf("extracted zip into %s: %d files, %d dirs (%v)", dir, nFiles, len(madeDir), td)
+		} else {
+			log.Printf("error extracting zip into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
+		}
+	}()
+
+	// Closure to address file descriptors issue with all the deferred .Close() methods
+	extractAndWriteFile := func(f *zip.File) error {
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := rc.Close(); err != nil {
+				panic(err)
+			}
+		}()
+		baseFile := filepath.Base(f.Name)
+		abs := path.Join(dir, baseFile)
+
+		fmt.Println(abs)
+
+		fi := f.FileInfo()
+		mode := fi.Mode()
+
+		switch {
+		case mode.IsDir():
+			break
+		case mode.IsRegular():
+			f, err := os.OpenFile(abs, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := f.Close(); err != nil {
+					panic(err)
+				}
+			}()
+
+			_, err = io.Copy(f, rc)
+			if err != nil {
+				return err
+			}
+		default:
+		}
+		nFiles++
+		return nil
+	}
+
+	for _, f := range r.File {
+		err := extractAndWriteFile(f)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func untar(r io.Reader, dir string) (err error) {


### PR DESCRIPTION
Add support for tgz/zip archives to the get command

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Introduces support for "get" command to use tgz and zip archives
and adds helm3 option to "get" command.

This commit squashes three commits from PR #130 and closes #130.

Signed-off-by: Tuan Anh Tran <me@tuananh.org>
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>


## Motivation and Context

Closes #123 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by the author

This commit squashes the three plus the merge commit.