### PR TITLE
Fix the path on loki helm install

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -124,6 +124,11 @@ func AddHelmRepo(name, url string, update, helm3 bool) error {
 	if helm3 {
 		subdir = "helm3"
 	}
+
+	if index := strings.Index(name, "/"); index > -1 {
+		name = name[:index]
+	}
+
 	task := execute.ExecTask{
 		Command:     fmt.Sprintf("%s repo add %s %s", env.LocalBinary("helm", subdir), name, url),
 		Env:         os.Environ(),
@@ -192,7 +197,6 @@ func FetchChart(chart, version string, helm3 bool) error {
 	if mkErr != nil {
 		return mkErr
 	}
-
 	task := execute.ExecTask{
 		Command:     fmt.Sprintf("%s fetch %s --untar=true --untardir %s%s", env.LocalBinary("helm", subdir), chart, chartsPath, versionStr),
 		Env:         os.Environ(),


### PR DESCRIPTION
Missing a split on the  "/" in chart name so we installed the chart as "loki/loki-stack" rather than loki.

Tested by removing all references to loki from my helm3 repo ls

then used `go build && ./arkade install loki" which worked.

Fixes #132 


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see above
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
