### PR TITLE
Added persistence flag to loki app.

### DIFF
--- a/cmd/apps/loki_app.go
+++ b/cmd/apps/loki_app.go
@@ -28,6 +28,7 @@ func MakeInstallLoki() *cobra.Command {
 
 	lokiApp.Flags().StringP("namespace", "n", "default", "The namespace to install loki (default: default")
 	lokiApp.Flags().Bool("update-repo", true, "Update the helm repo")
+	lokiApp.Flags().Bool("persistence", false, "Use a 10Gi Persistent Volume to store data")
 	lokiApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set grafana.enabled=true)")
 	lokiApp.Flags().Bool("grafana", false, "Install Grafana alongside Loki (default: false)")
 
@@ -50,12 +51,16 @@ func MakeInstallLoki() *cobra.Command {
 			return err
 		}
 
+		persistence, _ := lokiApp.Flags().GetBool("persistence")
 		installGrafana, _ := lokiApp.Flags().GetBool("grafana")
 
 		overrides := map[string]string{}
 
 		if installGrafana {
 			overrides["grafana.enabled"] = "true"
+		}
+		if persistence {
+			overrides["loki.persistence.enabled"] = "true"
 		}
 
 		customFlags, _ := command.Flags().GetStringArray("set")


### PR DESCRIPTION
This flag makes loki use persistent volume to store data.

Signed-off-by: Pablo Caderno <kaderno@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

Added flag to the application to ease the use of persistent volumes.


## Description
<!--- Describe your changes in detail -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Via a dicussion on Slack it seemed this flag would be useful.

<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Run code against my local cluster and verified the installation and the PVC and PV were created.

```
/arkade install loki --persistence=true
2020/06/22 18:10:38 Client: x86_64, Linux
2020/06/22 18:10:38 User dir established as: /home/pcaderno/.arkade/
"loki" has been added to your repositories

VALUES values.yaml
Command: /home/pcaderno/.arkade/bin/helm3/helm [upgrade --install loki-stack loki/loki-stack --namespace default --values /tmp/charts/loki-stack/values.yaml --set loki.persistence.enabled=true]
Release "loki-stack" does not exist. Installing it now.
NAME: loki-stack
LAST DEPLOYED: Mon Jun 22 18:10:39 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
The Loki stack has been deployed to your cluster. Loki can now be added as a datasource in Grafana.

See http://docs.grafana.org/features/datasources/loki/ for more detail.
=======================================================================
= loki has been installed.                                   =
=======================================================================

# Get started with loki here:
# https://github.com/grafana/loki/blob/master/docs/README.md

# See how to integrate loki with Grafana here
# https://github.com/grafana/loki/blob/master/docs/getting-started/grafana.md

# Check loki's logs with:

kubectl logs svc/loki-stack

kubectl logs svc/loki-stack-headless


# If you installed with Grafana you can access the dashboard with the username "admin" and password shown below
 # To get password
 kubectl get secret loki-stack-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 
 # Forward traffic to your localhost
 kubectl port-forward service/loki-stack-grafana 3000:80



Thanks for using arkade!

```

```
kubectl get pvc
NAME                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
storage-loki-stack-0   Bound    pvc-a5f665a3-79a8-41fc-af4a-e70aef706a53   10Gi       RWO            standard       20s

 kubectl get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                          STORAGECLASS   REASON   AGE
pvc-a5f665a3-79a8-41fc-af4a-e70aef706a53   10Gi       RWO            Delete           Bound    default/storage-loki-stack-0   standard                23s

```


<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
