### PR TITLE
Fix bug in NFS app (#144)

### DIFF
--- a/cmd/apps/nfs_app.go
+++ b/cmd/apps/nfs_app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/env"
 	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -68,10 +69,13 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 		overrides["nfs.server"] = nfsServer
 		overrides["nfs.path"] = nfsPath
 
-		switch clientArch {
-		case "arm", "armhf", "arm64", "aarch64":
-			overrides["image.repository"] = "quay.io/external_storage/nfs-client-provisioner-arm"
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if suffix := getValuesSuffix(arch); suffix == "-armhf" || suffix == "-arm64" {
+			overrides["image.repository"] = "quay.io/external_storage/nfs-client-provisioner-arm:latest"
 		}
+
 		customFlags, _ := command.Flags().GetStringArray("set")
 
 		if err := config.MergeFlags(overrides, customFlags); err != nil {

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -2,7 +2,7 @@ package get
 
 import "testing"
 
-const faasCLIVersion = "0.12.6"
+const faasCLIVersion = "0.12.8"
 const arch64bit = "x86_64"
 
 func Test_DownloadDarwin(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix bug in NFS app (#144)

## Motivation and Context

The NFS app was using the client architecture instead of the
node's CPU architecture to decide which Docker image to use
for the provisioner.

Fixes: #144

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Mirrors code from OpenFaaS app

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
