### PR TITLE
Added namespace creation for redis app

### DIFF
--- a/cmd/apps/redis_app.go
+++ b/cmd/apps/redis_app.go
@@ -65,6 +65,17 @@ func MakeInstallRedis() *cobra.Command {
 			"rbac.create":           "true",
 		}
 
+		// create the namespace
+		nsRes, nsErr := k8s.KubectlTask("create", "namespace", namespace)
+		if nsErr != nil {
+			return nsErr
+		}
+
+		// ignore errors
+		if nsRes.ExitCode != 0 {
+			log.Printf("[Warning] unable to create namespace %s, may already exist: %s", namespace, nsRes.Stderr)
+		}
+
 		customFlags, _ := command.Flags().GetStringArray("set")
 
 		if err := config.MergeFlags(overrides, customFlags); err != nil {


### PR DESCRIPTION
Helm3 doesnt create namespaces by default
so it has to be created if not present

Fixes #143

Signed-off-by: Pablo Caderno <kaderno@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Added namespace creation code like in other apps.

## Description
<!--- Describe your changes in detail -->
Added namespace creation code like in other apps.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/alexellis/arkade/issues/143



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Tested the new code without redis namespace:

```
 kubectl get namespaces
NAME              STATUS   AGE
default           Active   23d
kube-node-lease   Active   23d
kube-public       Active   23d
kube-system       Active   23d
loki-stack        Active   23d
```
```
$ ./arkade install redis
2020/07/15 19:15:29 Client: x86_64, Linux
2020/07/15 19:15:29 User dir established as: /home/pcaderno/.arkade/
Node architecture: "amd64"
"bitnami-redis" has been added to your repositories

Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "crossplane-alpha" chart repository
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "loki" chart repository
...Successfully got an update from the "es-operator" chart repository
...Successfully got an update from the "istio" chart repository
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "bitnami-redis" chart repository
...Successfully got an update from the "stable/nfs-client-provisioner" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
VALUES values.yaml
Command: /home/pcaderno/.arkade/bin/helm3/helm [upgrade --install redis bitnami-redis/redis --namespace redis --values /tmp/charts/redis/values.yaml --set rbac.create=true --set serviceAccount.create=true]
Release "redis" does not exist. Installing it now.
NAME: redis
LAST DEPLOYED: Wed Jul 15 19:15:51 2020
NAMESPACE: redis
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
** Please be patient while the chart is being deployed **
Redis can be accessed via port 6379 on the following DNS names from within your cluster:

redis-master.redis.svc.cluster.local for read/write operations
redis-slave.redis.svc.cluster.local for read-only operations


To get your password run:

    export REDIS_PASSWORD=$(kubectl get secret --namespace redis redis -o jsonpath="{.data.redis-password}" | base64 --decode)

To connect to your Redis server:

1. Run a Redis pod that you can use as a client:
   kubectl run --namespace redis redis-client --rm --tty -i --restart='Never' \
    --env REDIS_PASSWORD=$REDIS_PASSWORD \
   --image docker.io/bitnami/redis:6.0.5-debian-10-r32 -- bash

2. Connect using the Redis CLI:
   redis-cli -h redis-master -a $REDIS_PASSWORD
   redis-cli -h redis-slave -a $REDIS_PASSWORD

To connect to your database from outside the cluster execute the following commands:

    kubectl port-forward --namespace redis svc/redis-master 6379:6379 &
    redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
=======================================================================
=                       redis has been installed                      =
=======================================================================

# Redis can be accessed via port 6379 on the following DNS names from within your cluster:

# redis-master.redis.svc.cluster.local for read/write operations
# redis-slave.redis.svc.cluster.local for read-only operations


# To get your password run:

  export REDIS_PASSWORD=$(kubectl get secret --namespace redis redis -o jsonpath="{.data.redis-password}" | base64 --decode)

# To connect to your Redis server:

# 1. Run a Redis pod that you can use as a client:

  kubectl run --namespace redis redis-client --rm --tty -i --restart='Never' \
   --env REDIS_PASSWORD=$REDIS_PASSWORD \
   --image docker.io/bitnami/redis:5.0.7-debian-10-r48 -- bash

# 2. Connect using the Redis CLI:
  redis-cli -h redis-master -a $REDIS_PASSWORD
  redis-cli -h redis-slave -a $REDIS_PASSWORD

# To connect to your database from outside the cluster execute the following commands:

  kubectl port-forward --namespace redis svc/redis-master 6379:6379 &
  redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD

Thanks for using arkade!
```
```
$ kubectl get namespaces
NAME              STATUS   AGE
default           Active   23d
kube-node-lease   Active   23d
kube-public       Active   23d
kube-system       Active   23d
loki-stack        Active   23d
redis             Active   30s
```
```
 kubectl get all -n redis
NAME                 READY   STATUS              RESTARTS   AGE
pod/redis-master-0   0/1     ContainerCreating   0          20s
pod/redis-slave-0    0/1     ContainerCreating   0          20s

NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
service/redis-headless   ClusterIP   None             <none>        6379/TCP   20s
service/redis-master     ClusterIP   10.101.21.33     <none>        6379/TCP   20s
service/redis-slave      ClusterIP   10.109.179.129   <none>        6379/TCP   20s

NAME                            READY   AGE
statefulset.apps/redis-master   0/1     20s
statefulset.apps/redis-slave    0/2     20s
```

After that, I removed everything but the namespace itself and tried to install redis again:

```
 ./arkade install redis
2020/07/15 19:17:20 Client: x86_64, Linux
2020/07/15 19:17:20 User dir established as: /home/pcaderno/.arkade/
Node architecture: "amd64"
2020/07/15 19:17:20 [Warning] unable to create namespace redis, may already exist: Error from server (AlreadyExists): namespaces "redis" already exists
"bitnami-redis" has been added to your repositories

Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "crossplane-alpha" chart repository
...Successfully got an update from the "es-operator" chart repository
...Successfully got an update from the "loki" chart repository
...Successfully got an update from the "istio" chart repository
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository
...Successfully got an update from the "stable/nfs-client-provisioner" chart repository
...Successfully got an update from the "bitnami-redis" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
VALUES values.yaml
Command: /home/pcaderno/.arkade/bin/helm3/helm [upgrade --install redis bitnami-redis/redis --namespace redis --values /tmp/charts/redis/values.yaml --set serviceAccount.create=true --set rbac.create=true]
Release "redis" has been upgraded. Happy Helming!
NAME: redis
LAST DEPLOYED: Wed Jul 15 19:17:44 2020
NAMESPACE: redis
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
** Please be patient while the chart is being deployed **
Redis can be accessed via port 6379 on the following DNS names from within your cluster:

redis-master.redis.svc.cluster.local for read/write operations
redis-slave.redis.svc.cluster.local for read-only operations


To get your password run:

    export REDIS_PASSWORD=$(kubectl get secret --namespace redis redis -o jsonpath="{.data.redis-password}" | base64 --decode)

To connect to your Redis server:

1. Run a Redis pod that you can use as a client:
   kubectl run --namespace redis redis-client --rm --tty -i --restart='Never' \
    --env REDIS_PASSWORD=$REDIS_PASSWORD \
   --image docker.io/bitnami/redis:6.0.5-debian-10-r32 -- bash

2. Connect using the Redis CLI:
   redis-cli -h redis-master -a $REDIS_PASSWORD
   redis-cli -h redis-slave -a $REDIS_PASSWORD

To connect to your database from outside the cluster execute the following commands:

    kubectl port-forward --namespace redis svc/redis-master 6379:6379 &
    redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
=======================================================================
=                       redis has been installed                      =
=======================================================================

# Redis can be accessed via port 6379 on the following DNS names from within your cluster:

# redis-master.redis.svc.cluster.local for read/write operations
# redis-slave.redis.svc.cluster.local for read-only operations


# To get your password run:

  export REDIS_PASSWORD=$(kubectl get secret --namespace redis redis -o jsonpath="{.data.redis-password}" | base64 --decode)

# To connect to your Redis server:

# 1. Run a Redis pod that you can use as a client:

  kubectl run --namespace redis redis-client --rm --tty -i --restart='Never' \
   --env REDIS_PASSWORD=$REDIS_PASSWORD \
   --image docker.io/bitnami/redis:5.0.7-debian-10-r48 -- bash

# 2. Connect using the Redis CLI:
  redis-cli -h redis-master -a $REDIS_PASSWORD
  redis-cli -h redis-slave -a $REDIS_PASSWORD

# To connect to your database from outside the cluster execute the following commands:

  kubectl port-forward --namespace redis svc/redis-master 6379:6379 &
  redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD

Thanks for using arkade!

```

It shows the warning message but it works fine:

```
$ kubectl get all -n redis
NAME                 READY   STATUS    RESTARTS   AGE
pod/redis-master-0   1/1     Running   0          7m38s
pod/redis-slave-0    1/1     Running   0          7m38s
pod/redis-slave-1    1/1     Running   0          7m1s

NAME                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
service/redis-headless   ClusterIP   None             <none>        6379/TCP   7m38s
service/redis-master     ClusterIP   10.110.223.225   <none>        6379/TCP   7m38s
service/redis-slave      ClusterIP   10.102.139.132   <none>        6379/TCP   7m38s

NAME                            READY   AGE
statefulset.apps/redis-master   1/1     7m38s
statefulset.apps/redis-slave    2/2     7m38s

```



<!--- Include details of your testing environment, and the tests you ran to -->

Tested locally on minikube.

<!--- see how your change affects other areas of the code, etc. -->
NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
