### PR TITLE
add k3d

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ arkade get kind
 kind create cluster
 ```
 
+or similar with k3d ([k3s](https://github.com/rancher/k3s) in docker):
+
+```bash
+arkade get kubectl
+arkade get k3d
+
+k3d cluster create
+```
+
 ### Install an app
 
 No need to worry about whether you're installing to Intel or ARM architecture, the correct values will be set for you automatically.

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -152,5 +152,6 @@ const arkadeGet = `Use "arkade get TOOL" to download a tool or application:
   - kubectx
   - kubeseal
   - faas-cli
-  - helm
+	- helm
+	- k3d
   `

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -318,3 +318,55 @@ func Test_DownloadKind(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadK3d(t *testing.T) {
+	tools := MakeTools()
+	name := "k3d"
+
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	type test struct {
+		os      string
+		arch    string
+		version string
+		url     string
+	}
+
+	tests := []test{
+		{os: "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: "v3.0.0",
+			url:     "https://github.com/rancher/k3d/releases/download/v3.0.0/k3d-windows-amd64"},
+		{os: "linux",
+			arch:    arch64bit,
+			version: "v3.0.0",
+			url:     "https://github.com/rancher/k3d/releases/download/v3.0.0/k3d-linux-amd64"},
+		{os: "darwin",
+			arch:    arch64bit,
+			version: "v3.0.0",
+			url:     "https://github.com/rancher/k3d/releases/download/v3.0.0/k3d-darwin-amd64"},
+		{os: "linux",
+			arch:    "armv7l",
+			version: "v3.0.0",
+			url:     "https://github.com/rancher/k3d/releases/download/v3.0.0/k3d-linux-arm"},
+		{os: "linux",
+			arch:    "aarch64",
+			version: "v3.0.0",
+			url:     "https://github.com/rancher/k3d/releases/download/v3.0.0/k3d-linux-arm64"},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Fatalf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -114,6 +114,24 @@ https://github.com/bitnami-labs/sealed-secrets/releases/download/{{.Version}}/ku
 {{.Name}}-linux-amd64
 {{- end -}}`,
 		},
+		{
+			Owner: "rancher",
+			Repo:  "k3d",
+			Name:  "k3d",
+			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
+{{.Name}}-windows-amd64
+{{- else if eq .OS "darwin" -}}
+{{.Name}}-darwin-amd64
+{{- else if eq .Arch "armv6l" -}}
+{{.Name}}-linux-arm
+{{- else if eq .Arch "armv7l" -}}
+{{.Name}}-linux-arm
+{{- else if eq .Arch "aarch64" -}}
+{{.Name}}-linux-arm64
+{{- else -}}
+{{.Name}}-linux-amd64
+{{- end -}}`,
+		},
 	}
 	return tools
 }


### PR DESCRIPTION
This PR adds https://github.com/rancher/k3d as a new tool to fetch via `arkade get k3d`.

## Description

...

## Motivation and Context

Having another tool for managing local k8s/k3s clusters easily installable via arkade :)

## How Has This Been Tested?

Added the same tests that `kind` already has.

## Types of changes

- new feature

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have tested this on arm, or have added code to prevent deployment
