### PR TITLE
Cert-manager now uses pinned version

### DIFF
--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -34,6 +34,7 @@ func MakeInstallCertManager() *cobra.Command {
 	certManager.RunE = func(command *cobra.Command, args []string) error {
 		wait, _ := command.Flags().GetBool("wait")
 		const certManagerVersion = "v0.12.0"
+		const certManagerCRDVersion = "0.12"
 		kubeConfigPath := config.GetDefaultKubeconfig()
 
 		if command.Flags().Changed("kubeconfig") {
@@ -93,7 +94,7 @@ func MakeInstallCertManager() *cobra.Command {
 		}
 
 		log.Printf("Applying CRD\n")
-		crdsURL := "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml"
+		crdsURL := fmt.Sprintf("https://raw.githubusercontent.com/jetstack/cert-manager/release-%s/deploy/manifests/00-crds.yaml", certManagerCRDVersion)
 		res, err := k8s.KubectlTask("apply", "--validate=false", "-f",
 			crdsURL)
 		if err != nil {
@@ -110,7 +111,7 @@ func MakeInstallCertManager() *cobra.Command {
 		if helm3 {
 			err := helm.Helm3Upgrade("jetstack/cert-manager", namespace,
 				"values.yaml",
-				"v0.12.0",
+				certManagerVersion,
 				overrides,
 				wait)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

The cert-manager app was using a string rather than the
version variable when the chart was installed. This moves
it to using the version variable

Signed-off-by: Alistair Hey <alistair.hey@form3.tech>

<!--- Provide a general summary of your changes in the Title above -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/alexellis/arkade/commit/3b6845bced66cecfd302f153792ae10052718596#r40689484
`
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
installed on amd64 k3d cluster
cert-manager installed and ran correctly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
