### PR TITLE
Add OSM - Open Service Mesh

### DIFF
--- a/cmd/apps/osm_app.go
+++ b/cmd/apps/osm_app.go
@@ -1,0 +1,166 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/alexellis/arkade/pkg/get"
+	"github.com/alexellis/arkade/pkg/k8s"
+
+	"github.com/alexellis/arkade/pkg"
+
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	execute "github.com/alexellis/go-execute/pkg/v1"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallOSM() *cobra.Command {
+	var osm = &cobra.Command{
+		Use:          "osm",
+		Short:        "Install osm",
+		Long:         `Install Open Service Mesh (OSM) - a lightweight, extensible, cloud native service mesh`,
+		Example:      `  arkade install osm`,
+		SilenceUsage: true,
+	}
+
+	osm.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath := config.GetDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+		if arch != IntelArch {
+			return fmt.Errorf(OnlyIntelArch)
+		}
+
+		userPath, err := getUserPath()
+		if err != nil {
+			return err
+		}
+
+		arch, clientOS := env.GetClientArch()
+
+		fmt.Printf("Client: %q\n", clientOS)
+
+		log.Printf("User dir established as: %s\n", userPath)
+
+		err = downloadOSM(userPath, arch, clientOS)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Running osm check, this may take a few moments.")
+
+		_, err = osmCli("check", "--pre-flight")
+		if err != nil {
+			return err
+		}
+
+		res, err := osmCli("install")
+		if err != nil {
+			return err
+		}
+		if res.ExitCode != 0 {
+			return fmt.Errorf("exit code %d, error: %s", res.ExitCode, res.Stderr)
+		}
+
+		_, err = osmCli("check")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(`=======================================================================
+= OSM has been installed.                                        =
+=======================================================================
+
+# Get the osm-cli
+curl -sL https://run.osm.io/install | sh
+
+# Find out more at:
+# https://osm.io
+
+# To use the OSM CLI set this path:
+
+export PATH=$PATH:` + path.Join(userPath, "bin/") + `
+osm --help
+
+` + pkg.ThanksForUsing)
+		return nil
+	}
+
+	return osm
+}
+
+func downloadOSM(userPath, arch, clientOS string) error {
+	t := &get.Tool{
+		Name:    "osm",
+		Repo:    "osm",
+		Owner:   "openservicemesh",
+		Version: "v0.1.0",
+		URLTemplate: `
+{{$osStr := ""}}
+{{ if HasPrefix .OS "ming" -}}
+{{$osStr = "windows"}}
+{{- else if eq .OS "Linux" -}}
+{{$osStr = "linux"}}
+{{- else if eq .OS "Darwin" -}}
+{{$osStr = "darwin"}}
+{{- end -}}
+https://github.com/openservicemesh/osm/releases/download/{{.Version}}/osm-{{.Version}}-{{$osStr}}-amd64.tar.gz`,
+	}
+
+	u, err := get.GetDownloadURL(t, clientOS, arch, t.Version)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Download URL: %s\n", u)
+
+	return nil
+}
+
+func osmCli(parts ...string) (execute.ExecResult, error) {
+	task := execute.ExecTask{
+		Command:     fmt.Sprintf("%s", env.LocalBinary("osm", "")),
+		Args:        parts,
+		Env:         os.Environ(),
+		StreamStdio: true,
+	}
+
+	res, err := task.Execute()
+
+	if err != nil {
+		return res, err
+	}
+
+	if res.ExitCode != 0 {
+		return res, fmt.Errorf("exit code %d, stderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	return res, nil
+}
+
+var OSMInfoMsg = `# The osm CLI is installed at:
+# $HOME/.bin/arkade
+
+# Find out more at:
+# https://github.com/openservicemesh/osm
+
+# To use the OSM CLI set this path:
+
+export PATH=$PATH:` + getExportPath() + `
+osm --help`
+
+var osmInstallMsg = `=======================================================================
+= Open Service Mesh (OSM) has been installed.                                         =
+=======================================================================` +
+	"\n\n" + OSMInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -77,6 +77,7 @@ And to see options for a specific app before installing, run:
 	command.AddCommand(apps.MakeInstallOpenFaaSLoki())
 	command.AddCommand(apps.MakeInstallNfsProvisioner())
 	command.AddCommand(apps.MakeInstallRedis())
+	command.AddCommand(apps.MakeInstallOSM())
 
 	command.AddCommand(MakeInfo())
 

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -170,11 +170,13 @@ func getByDownloadTemplate(tool Tool, os, arch, version string) (string, error) 
 	}
 
 	var buf bytes.Buffer
-	err = t.Execute(&buf, map[string]string{
+	inputs := map[string]string{
 		"OS":      os,
 		"Arch":    arch,
 		"Version": version,
-	})
+	}
+	err = t.Execute(&buf, inputs)
+	fmt.Println(inputs)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add Open Service Mesh

## Motivation and Context

We have an app for Istio and Linkerd, so this adds OSM - https://openservicemesh.io released by Microsoft / Azure this week.

Further changes are required to pull the code in cmd/get.go up into the pkg folder so that it can be used from the OSM install command. That code includes work to handle archives and custom binary names.

## How Has This Been Tested?

The first time running the app downloads the binary from helm.

```bash
space-mini:arkade alex$ go build && ./arkade install osm
Using kubeconfig: /Users/alex/.kube/config
Node architecture: "amd64"
Client: "Darwin"
2020/08/06 17:10:00 User dir established as: /Users/alex/.arkade/
osm already exists, skipping download.
Running osm check, this may take a few moments.
ok: initialize Kubernetes client
ok: query Kubernetes API
ok: Kubernetes version
ok: can create namespaces
ok: can create customresourcedefinitions
ok: can create clusterroles
ok: can create clusterrolebindings
ok: can create mutatingwebhookconfigurations
ok: can create serviceaccounts
ok: can create services
ok: can create deployments
ok: can create configmaps
ok: can read secrets
ok: can modify iptables
All checks successful!
OSM installed successfully in namespace [osm-system] with mesh name [osm]
=======================================================================
= OSM has been installed.                                        =
=======================================================================
# The osm CLI is installed at:
# $HOME/.bin/arkade/osm

# Find out more at:
# https://github.com/openservicemesh/osm

# Docs are live at:
# https://openservicemesh.io

# Walk-through a demo at:
# https://github.com/openservicemesh/osm/blob/main/docs/example/README.md

# To use the OSM CLI set this path:

export PATH=$PATH:/Users/alex/.arkade/bin
osm --help
Thanks for using arkade!
space-mini:arkade alex$ export PATH=$PATH:/Users/alex/.arkade/bin
space-mini:arkade alex$ osm --help
The osm cli enables you to install and manage the
Open Service Mesh (OSM) in your Kubernetes cluster

To install and configure OSM, run:

   $ osm install

Usage:
  osm [command]

Available Commands:
  check       check osm control plane
  dashboard   open grafana dashboard through ssh redirection
  env         osm client environment information
  help        Help about any command
  install     install osm control plane
  mesh        manage osm installations
  namespace   manage osm namespaces
  version     osm cli version

Flags:
  -h, --help               help for osm
  -n, --namespace string   namespace scope for this request (default "osm-system")

Use "osm [command] --help" for more information about a command.
space-mini:arkade alex$ 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
