### PR TITLE
Add Open Service Mesh (OSM) and update Linkerd2

### DIFF
--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -5,16 +5,14 @@ package apps
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
-	"net/url"
 	"os"
 	"path"
-	"strings"
 
+	"github.com/alexellis/arkade/pkg/get"
 	"github.com/alexellis/arkade/pkg/k8s"
 
 	"github.com/alexellis/arkade/pkg"
@@ -25,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var linkerdVersion = "stable-2.6.1"
+var linkerdVersion = "stable-2.8.1"
 
 func MakeInstallLinkerd() *cobra.Command {
 	var linkerd = &cobra.Command{
@@ -55,17 +53,17 @@ func MakeInstallLinkerd() *cobra.Command {
 			return err
 		}
 
-		_, clientOS := env.GetClientArch()
+		arch, clientOS := env.GetClientArch()
 
 		fmt.Printf("Client: %q\n", clientOS)
 
 		log.Printf("User dir established as: %s\n", userPath)
 
-		err = downloadLinkerd(userPath, clientOS)
+		err = downloadLinkerd(userPath, arch, clientOS)
 		if err != nil {
 			return err
 		}
-		fmt.Println("Running linkerd check, this may take a few moments.")
+		fmt.Println("Running linkerd2 check, this may take a few moments.")
 
 		_, err = linkerdCli("check", "--pre")
 		if err != nil {
@@ -104,16 +102,13 @@ func MakeInstallLinkerd() *cobra.Command {
 = Linkerd has been installed.                                        =
 =======================================================================
 
-# Get the linkerd-cli
-curl -sL https://run.linkerd.io/install | sh
-
 # Find out more at:
 # https://linkerd.io
 
-# To use the Linkerd CLI set this path:
+# To use the linkerd2 CLI set this path:
 
 export PATH=$PATH:` + path.Join(userPath, "bin/") + `
-linkerd --help
+linkerd2 --help
 
 ` + pkg.ThanksForUsing)
 		return nil
@@ -122,47 +117,43 @@ linkerd --help
 	return linkerd
 }
 
-func getLinkerdURL(os, version string) string {
-	osSuffix := strings.ToLower(os)
-	return fmt.Sprintf("https://github.com/linkerd/linkerd2/releases/download/%s/linkerd2-cli-%s-%s", version, version, osSuffix)
-}
+// func getLinkerdURL(os, version string) string {
+// 	osSuffix := strings.ToLower(os)
+// 	return fmt.Sprintf("https://github.com/linkerd/linkerd2/releases/download/%s/linkerd2-cli-%s-%s", version, version, osSuffix)
+// }
 
-func downloadLinkerd(userPath, clientOS string) error {
-	filePath := path.Join(path.Join(userPath, "bin"), "linkerd")
-	if _, statErr := os.Stat(filePath); statErr != nil {
-		linkerdURL := getLinkerdURL(clientOS, linkerdVersion)
-		fmt.Println(linkerdURL)
-		parsedURL, _ := url.Parse(linkerdURL)
+func downloadLinkerd(userPath, arch, clientOS string) error {
 
-		res, err := http.DefaultClient.Get(parsedURL.String())
-		if err != nil {
-			return err
-		}
-
-		defer res.Body.Close()
-		out, err := os.Create(filePath)
-		if err != nil {
-			return err
-		}
-		defer out.Close()
-
-		// Write the body to file
-		_, err = io.Copy(out, res.Body)
-		if err != nil {
-			return err
-		}
-
-		err = os.Chmod(filePath, 0755)
-		if err != nil {
-			return err
+	tools := get.MakeTools()
+	var tool *get.Tool
+	for _, t := range tools {
+		if t.Name == "linkerd2" {
+			tool = &t
+			break
 		}
 	}
+	if tool == nil {
+		return fmt.Errorf("unable to find tool definition")
+	}
+
+	if _, err := os.Stat(fmt.Sprintf("%s", env.LocalBinary(tool.Name, ""))); errors.Is(err, os.ErrNotExist) {
+
+		outPath, finalName, err := get.Download(tool, arch, clientOS, tool.Version, get.DownloadArkadeDir)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Downloaded to: ", outPath, finalName)
+	} else {
+		fmt.Printf("%s already exists, skipping download.\n", tool.Name)
+	}
+
 	return nil
 }
 
 func linkerdCli(parts ...string) (execute.ExecResult, error) {
 	task := execute.ExecTask{
-		Command:     fmt.Sprintf("%s", env.LocalBinary("linkerd", "")),
+		Command:     fmt.Sprintf("%s", env.LocalBinary("linkerd2", "")),
 		Args:        parts,
 		Env:         os.Environ(),
 		StreamStdio: true,
@@ -191,16 +182,13 @@ func getExportPath() string {
 	return path.Join(userPath, "bin/")
 }
 
-var LinkerdInfoMsg = `# Get the linkerd-cli
-curl -sL https://run.linkerd.io/install | sh
-
-# Find out more at:
+var LinkerdInfoMsg = `# Find out more at:
 # https://linkerd.io
 
-# To use the Linkerd CLI set this path:
+# To use the linkerd2 CLI set this path:
 
 export PATH=$PATH:` + getExportPath() + `
-linkerd --help`
+linkerd2 --help`
 
 var linkerdInstallMsg = `=======================================================================
 = Linkerd has been installed.                                         =

--- a/cmd/apps/osm_app.go
+++ b/cmd/apps/osm_app.go
@@ -1,0 +1,166 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/alexellis/arkade/pkg/get"
+	"github.com/alexellis/arkade/pkg/k8s"
+
+	"github.com/alexellis/arkade/pkg"
+
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	execute "github.com/alexellis/go-execute/pkg/v1"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallOSM() *cobra.Command {
+	var osm = &cobra.Command{
+		Use:          "osm",
+		Short:        "Install osm",
+		Long:         `Install Open Service Mesh (OSM) - a lightweight, extensible, cloud native service mesh`,
+		Example:      `  arkade install osm`,
+		SilenceUsage: true,
+	}
+
+	osm.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath := config.GetDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+		if arch != IntelArch {
+			return fmt.Errorf(OnlyIntelArch)
+		}
+
+		userPath, err := getUserPath()
+		if err != nil {
+			return err
+		}
+
+		arch, clientOS := env.GetClientArch()
+
+		fmt.Printf("Client: %q\n", clientOS)
+
+		log.Printf("User dir established as: %s\n", userPath)
+
+		err = downloadOSM(userPath, arch, clientOS)
+		if err != nil {
+			return err
+		}
+		fmt.Println("Running osm check, this may take a few moments.")
+
+		_, err = osmCli("check", "--pre-flight")
+		if err != nil {
+			return err
+		}
+
+		res, err := osmCli("install")
+		if err != nil {
+			return err
+		}
+		if res.ExitCode != 0 {
+			return fmt.Errorf("exit code %d, error: %s", res.ExitCode, res.Stderr)
+		}
+
+		_, err = osmCli("check")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(`=======================================================================
+= OSM has been installed.                                        =
+=======================================================================
+
+# Get the osm-cli
+curl -sL https://run.osm.io/install | sh
+
+# Find out more at:
+# https://osm.io
+
+# To use the OSM CLI set this path:
+
+export PATH=$PATH:` + path.Join(userPath, "bin/") + `
+osm --help
+
+` + pkg.ThanksForUsing)
+		return nil
+	}
+
+	return osm
+}
+
+func downloadOSM(userPath, arch, clientOS string) error {
+	t := &get.Tool{
+		Name:    "osm",
+		Repo:    "osm",
+		Owner:   "openservicemesh",
+		Version: "v0.1.0",
+		URLTemplate: `
+{{$osStr := ""}}
+{{ if HasPrefix .OS "ming" -}}
+{{$osStr = "windows"}}
+{{- else if eq .OS "Linux" -}}
+{{$osStr = "linux"}}
+{{- else if eq .OS "Darwin" -}}
+{{$osStr = "darwin"}}
+{{- end -}}
+https://github.com/openservicemesh/osm/releases/download/{{.Version}}/osm-{{.Version}}-{{$osStr}}-amd64.tar.gz`,
+	}
+
+	u, err := get.GetDownloadURL(t, clientOS, arch, t.Version)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Download URL: %s\n", u)
+
+	return nil
+}
+
+func osmCli(parts ...string) (execute.ExecResult, error) {
+	task := execute.ExecTask{
+		Command:     fmt.Sprintf("%s", env.LocalBinary("osm", "")),
+		Args:        parts,
+		Env:         os.Environ(),
+		StreamStdio: true,
+	}
+
+	res, err := task.Execute()
+
+	if err != nil {
+		return res, err
+	}
+
+	if res.ExitCode != 0 {
+		return res, fmt.Errorf("exit code %d, stderr: %s", res.ExitCode, res.Stderr)
+	}
+
+	return res, nil
+}
+
+var OSMInfoMsg = `# The osm CLI is installed at:
+# $HOME/.bin/arkade
+
+# Find out more at:
+# https://github.com/openservicemesh/osm
+
+# To use the OSM CLI set this path:
+
+export PATH=$PATH:` + getExportPath() + `
+osm --help`
+
+var osmInstallMsg = `=======================================================================
+= Open Service Mesh (OSM) has been installed.                                         =
+=======================================================================` +
+	"\n\n" + OSMInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -4,17 +4,8 @@
 package cmd
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 
-	"github.com/alexellis/arkade/pkg/archive"
 	"github.com/alexellis/arkade/pkg/env"
 	"github.com/alexellis/arkade/pkg/get"
 	"github.com/spf13/cobra"
@@ -61,81 +52,10 @@ and provides a fast and easy alternative to a package manager.`,
 		arch, operatingSystem := env.GetClientArch()
 		version := ""
 
-		downloadURL, err := get.GetDownloadURL(tool, strings.ToLower(operatingSystem), strings.ToLower(arch), version)
+		outFilePath, finalName, err := get.Download(tool, arch, operatingSystem, version, get.DownloadTempDir)
+
 		if err != nil {
 			return err
-		}
-
-		fmt.Println(downloadURL)
-
-		res, err := http.DefaultClient.Get(downloadURL)
-		if err != nil {
-			return err
-		}
-
-		if res.Body != nil {
-			defer res.Body.Close()
-		}
-
-		if res.StatusCode != http.StatusOK {
-			return fmt.Errorf("incorrect status for downloading tool: %d", res.StatusCode)
-		}
-
-		_, fileName := path.Split(downloadURL)
-		tmp := os.TempDir()
-
-		outFilePath := path.Join(tmp, fileName)
-
-		if tool.IsArchive() {
-			outFilePathDir := filepath.Dir(outFilePath)
-			if len(tool.BinaryTemplate) > 0 {
-				fileName, err = get.GetBinaryName(tool, strings.ToLower(operatingSystem), strings.ToLower(arch))
-				if err != nil {
-					return err
-				}
-				outFilePath = path.Join(outFilePathDir, fileName)
-			} else {
-				outFilePath = path.Join(outFilePathDir, tool.Name)
-			}
-			if strings.Contains(strings.ToLower(operatingSystem), "mingw") && tool.NoExtension == false {
-				outFilePath += ".exe"
-			}
-			r := ioutil.NopCloser(res.Body)
-			if strings.HasSuffix(downloadURL, "tar.gz") || strings.HasSuffix(downloadURL, "tgz") {
-				untarErr := archive.Untar(r, outFilePathDir)
-				if untarErr != nil {
-					return untarErr
-				}
-			} else if strings.HasSuffix(downloadURL, "zip") {
-				buff := bytes.NewBuffer([]byte{})
-				size, err := io.Copy(buff, res.Body)
-				if err != nil {
-					return err
-				}
-
-				reader := bytes.NewReader(buff.Bytes())
-
-				unzipErr := archive.Unzip(reader, size, outFilePathDir)
-				if unzipErr != nil {
-					return unzipErr
-				}
-			}
-
-		} else {
-			out, err := os.Create(outFilePath)
-			if err != nil {
-				return err
-			}
-			defer out.Close()
-
-			if _, err = io.Copy(out, res.Body); err != nil {
-				return err
-			}
-		}
-
-		finalName := tool.Name
-		if strings.Contains(strings.ToLower(operatingSystem), "mingw") && tool.NoExtension == false {
-			finalName = finalName + ".exe"
 		}
 
 		fmt.Printf(`Tool written to: %s

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -77,6 +77,7 @@ And to see options for a specific app before installing, run:
 	command.AddCommand(apps.MakeInstallOpenFaaSLoki())
 	command.AddCommand(apps.MakeInstallNfsProvisioner())
 	command.AddCommand(apps.MakeInstallRedis())
+	command.AddCommand(apps.MakeInstallOSM())
 
 	command.AddCommand(MakeInfo())
 

--- a/pkg/get/download.go
+++ b/pkg/get/download.go
@@ -1,0 +1,139 @@
+package get
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/archive"
+	"github.com/alexellis/arkade/pkg/env"
+)
+
+const (
+	DownloadTempDir   = iota
+	DownloadArkadeDir = iota
+)
+
+func Download(tool *Tool, arch, operatingSystem, version string, downloadMode int) (string, string, error) {
+
+	downloadURL, err := GetDownloadURL(tool, strings.ToLower(operatingSystem), strings.ToLower(arch), version)
+	if err != nil {
+		return "", "", err
+	}
+
+	fmt.Println(downloadURL)
+
+	res, err := http.DefaultClient.Get(downloadURL)
+	if err != nil {
+		return "", "", err
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("incorrect status for downloading tool: %d", res.StatusCode)
+	}
+
+	_, fileName := path.Split(downloadURL)
+	tmp := os.TempDir()
+
+	outFilePath := path.Join(tmp, fileName)
+
+	if tool.IsArchive() {
+		outFilePathDir := filepath.Dir(outFilePath)
+		if len(tool.BinaryTemplate) > 0 {
+			fileName, err = GetBinaryName(tool, strings.ToLower(operatingSystem), strings.ToLower(arch), version)
+			if err != nil {
+				return "", "", err
+			}
+			outFilePath = path.Join(outFilePathDir, fileName)
+		} else {
+			outFilePath = path.Join(outFilePathDir, tool.Name)
+		}
+		if strings.Contains(strings.ToLower(operatingSystem), "mingw") && tool.NoExtension == false {
+			outFilePath += ".exe"
+		}
+		r := ioutil.NopCloser(res.Body)
+		if strings.HasSuffix(downloadURL, "tar.gz") || strings.HasSuffix(downloadURL, "tgz") {
+			untarErr := archive.Untar(r, outFilePathDir)
+			if untarErr != nil {
+				return "", "", untarErr
+			}
+		} else if strings.HasSuffix(downloadURL, "zip") {
+			buff := bytes.NewBuffer([]byte{})
+			size, err := io.Copy(buff, res.Body)
+			if err != nil {
+				return "", "", err
+			}
+
+			reader := bytes.NewReader(buff.Bytes())
+
+			unzipErr := archive.Unzip(reader, size, outFilePathDir)
+			if unzipErr != nil {
+				return "", "", unzipErr
+			}
+		}
+
+	} else {
+		out, err := os.Create(outFilePath)
+		if err != nil {
+			return "", "", err
+		}
+		defer out.Close()
+
+		if _, err = io.Copy(out, res.Body); err != nil {
+			return "", "", err
+		}
+	}
+
+	finalName := tool.Name
+	if strings.Contains(strings.ToLower(operatingSystem), "mingw") && tool.NoExtension == false {
+		finalName = finalName + ".exe"
+	}
+
+	if downloadMode == DownloadArkadeDir {
+		localPath := env.LocalBinary(finalName, "")
+
+		_, err := copyFile(path.Join(outFilePath), localPath)
+		if err != nil {
+			return "", "", err
+		}
+		outFilePath = localPath
+	}
+
+	return outFilePath, finalName, nil
+}
+
+func copyFile(src, dst string) (int64, error) {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+
+	userReadWriteExecute := 0700
+	destination, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(userReadWriteExecute))
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+	nBytes, err := io.Copy(destination, source)
+	return nBytes, err
+}

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -36,7 +37,7 @@ func (tool Tool) IsArchive() bool {
 	return strings.HasSuffix(downloadURL, "tar.gz") || strings.HasSuffix(downloadURL, "zip") || strings.HasSuffix(downloadURL, "tgz")
 }
 
-func GetBinaryName(tool *Tool, os, arch string) (string, error) {
+func GetBinaryName(tool *Tool, os, arch, version string) (string, error) {
 	if len(tool.BinaryTemplate) > 0 {
 		var err error
 		t := template.New(tool.Name + "_binaryname")
@@ -48,9 +49,10 @@ func GetBinaryName(tool *Tool, os, arch string) (string, error) {
 
 		var buf bytes.Buffer
 		err = t.Execute(&buf, map[string]string{
-			"OS":   os,
-			"Arch": arch,
-			"Name": tool.Name,
+			"OS":      os,
+			"Arch":    arch,
+			"Name":    tool.Name,
+			"Version": version,
 		})
 		if err != nil {
 			return "", err
@@ -110,9 +112,10 @@ func getURLByGithubTemplate(tool Tool, os, arch, version string) (string, error)
 
 	var buf bytes.Buffer
 	pref := map[string]string{
-		"OS":   os,
-		"Arch": arch,
-		"Name": tool.Name,
+		"OS":      os,
+		"Arch":    arch,
+		"Name":    tool.Name,
+		"Version": version,
 	}
 
 	err = t.Execute(&buf, pref)
@@ -175,8 +178,9 @@ func getByDownloadTemplate(tool Tool, os, arch, version string) (string, error) 
 		"Arch":    arch,
 		"Version": version,
 	}
+	log.Println(inputs)
 	err = t.Execute(&buf, inputs)
-	fmt.Println(inputs)
+
 	if err != nil {
 		return "", err
 	}

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -170,11 +170,13 @@ func getByDownloadTemplate(tool Tool, os, arch, version string) (string, error) 
 	}
 
 	var buf bytes.Buffer
-	err = t.Execute(&buf, map[string]string{
+	inputs := map[string]string{
 		"OS":      os,
 		"Arch":    arch,
 		"Version": version,
-	})
+	}
+	err = t.Execute(&buf, inputs)
+	fmt.Println(inputs)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -201,6 +201,38 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 {{- else if eq .Arch "aarch64" -}}
 {{.Name}}-arm64
 {{- end -}}`,
+		},
+		Tool{
+			Name:    "osm",
+			Repo:    "osm",
+			Owner:   "openservicemesh",
+			Version: "v0.1.0",
+			URLTemplate: `
+	{{$osStr := ""}}
+	{{ if HasPrefix .OS "ming" -}}
+	{{$osStr = "windows"}}
+	{{- else if eq .OS "linux" -}}
+	{{$osStr = "linux"}}
+	{{- else if eq .OS "darwin" -}}
+	{{$osStr = "darwin"}}
+	{{- end -}}
+	https://github.com/openservicemesh/osm/releases/download/{{.Version}}/osm-{{.Version}}-{{$osStr}}-amd64.tar.gz`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:   "linkerd",
+			Repo:    "linkerd",
+			Name:    "linkerd2",
+			Version: "stable-2.8.1",
+			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
+{{.Name}}-cli-{{.Version}}-windows.exe
+{{- else if eq .OS "darwin" -}}
+{{.Name}}-cli-{{.Version}}-darwin
+{{- else if eq .OS "linux" -}}
+{{.Name}}-cli-{{.Version}}-linux
+{{- end -}}
+`,
 		})
 
 	return tools


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Add Open Service Mesh (OSM)
* Update the Linkerd2 version
* Share the code between the "get" command and apps which get CLIs are part of their installation process i.e. the Linkerd app

## Motivation and Context

We have an app for Istio and Linkerd, so this adds OSM - https://openservicemesh.io released by Microsoft / Azure this week.

Further changes are required to pull the code in cmd/get.go up into the pkg folder so that it can be used from the OSM install command. That code includes work to handle archives and custom binary names.

## How Has This Been Tested?

The first time running the app downloads the binary from helm.

```bash
space-mini:arkade alex$ go build && ./arkade install osm
Using kubeconfig: /Users/alex/.kube/config
Node architecture: "amd64"
Client: "Darwin"
2020/08/06 17:10:00 User dir established as: /Users/alex/.arkade/
osm already exists, skipping download.
Running osm check, this may take a few moments.
ok: initialize Kubernetes client
ok: query Kubernetes API
ok: Kubernetes version
ok: can create namespaces
ok: can create customresourcedefinitions
ok: can create clusterroles
ok: can create clusterrolebindings
ok: can create mutatingwebhookconfigurations
ok: can create serviceaccounts
ok: can create services
ok: can create deployments
ok: can create configmaps
ok: can read secrets
ok: can modify iptables
All checks successful!
OSM installed successfully in namespace [osm-system] with mesh name [osm]
=======================================================================
= OSM has been installed.                                        =
=======================================================================
# The osm CLI is installed at:
# $HOME/.bin/arkade/osm

# Find out more at:
# https://github.com/openservicemesh/osm

# Docs are live at:
# https://openservicemesh.io

# Walk-through a demo at:
# https://github.com/openservicemesh/osm/blob/main/docs/example/README.md

# To use the OSM CLI set this path:

export PATH=$PATH:/Users/alex/.arkade/bin
osm --help
Thanks for using arkade!
space-mini:arkade alex$ export PATH=$PATH:/Users/alex/.arkade/bin
space-mini:arkade alex$ osm --help
The osm cli enables you to install and manage the
Open Service Mesh (OSM) in your Kubernetes cluster

To install and configure OSM, run:

   $ osm install

Usage:
  osm [command]

Available Commands:
  check       check osm control plane
  dashboard   open grafana dashboard through ssh redirection
  env         osm client environment information
  help        Help about any command
  install     install osm control plane
  mesh        manage osm installations
  namespace   manage osm namespaces
  version     osm cli version

Flags:
  -h, --help               help for osm
  -n, --namespace string   namespace scope for this request (default "osm-system")

Use "osm [command] --help" for more information about a command.
space-mini:arkade alex$ 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
