### PR TITLE
Move to using issuers rather than cluster issuers

### DIFF
--- a/cmd/apps/openfaas_ingress_app.go
+++ b/cmd/apps/openfaas_ingress_app.go
@@ -28,6 +28,7 @@ type inputData struct {
 	IngressClass     string
 	IssuerType       string
 	IssuerAPI        string
+	ClusterIssuer    bool
 }
 
 //MakeInstallOpenFaaSIngess will install a clusterissuer and request a cert from certmanager for the domain you specify
@@ -44,6 +45,7 @@ func MakeInstallOpenFaaSIngress() *cobra.Command {
 	openfaasIngress.Flags().StringP("email", "e", "", "Letsencrypt Email")
 	openfaasIngress.Flags().String("ingress-class", "nginx", "Ingress class to be used such as nginx or traefik")
 	openfaasIngress.Flags().Bool("staging", false, "set --staging to true to use the staging Letsencrypt issuer")
+	openfaasIngress.Flags().Bool("cluster-issuer", false, "set to true to create a clusterissuer rather than a namespaces issuer (default: false)")
 
 	openfaasIngress.RunE = func(command *cobra.Command, args []string) error {
 
@@ -68,8 +70,9 @@ func MakeInstallOpenFaaSIngress() *cobra.Command {
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		staging, _ := command.Flags().GetBool("staging")
+		clusterIssuer, _ := command.Flags().GetBool("cluster-issuer")
 
-		yamlBytes, templateErr := buildYAML(domain, email, ingressClass, staging)
+		yamlBytes, templateErr := buildYAML(domain, email, ingressClass, staging, clusterIssuer)
 		if templateErr != nil {
 			log.Print("Unable to install the application. Could not build the templated yaml file for the resources")
 			return templateErr
@@ -131,7 +134,7 @@ func writeTempFile(input []byte, fileLocation string) (string, error) {
 	return filename, nil
 }
 
-func buildYAML(domain, email, ingressClass string, staging bool) ([]byte, error) {
+func buildYAML(domain, email, ingressClass string, staging, clusterIssuer bool) ([]byte, error) {
 	tmpl, err := template.New("yaml").Parse(ingressYamlTemplate)
 
 	if err != nil {
@@ -144,6 +147,7 @@ func buildYAML(domain, email, ingressClass string, staging bool) ([]byte, error)
 		IngressClass:     ingressClass,
 		IssuerType:       "letsencrypt-prod",
 		IssuerAPI:        "https://acme-v02.api.letsencrypt.org/directory",
+		ClusterIssuer:    clusterIssuer,
 	}
 
 	if staging {
@@ -197,7 +201,11 @@ metadata:
   name: openfaas-gateway
   namespace: openfaas
   annotations:
+{{- if .ClusterIssuer }}
     cert-manager.io/cluster-issuer: {{.IssuerType}}
+{{- else }}
+    cert-manager.io/issuer: {{.IssuerType}}
+{{- end }}
     kubernetes.io/ingress.class: {{.IngressClass}}
 spec:
   rules:
@@ -214,9 +222,16 @@ spec:
     secretName: openfaas-gateway
 ---
 apiVersion: cert-manager.io/v1alpha2
+{{- if .ClusterIssuer }}
 kind: ClusterIssuer
+{{- else }}
+kind: Issuer
+{{- end }}
 metadata:
   name: {{.IssuerType}}
+{{- if not .ClusterIssuer }}
+  namespace: openfaas
+{{- end }}
 spec:
   acme:
     email: {{.CertmanagerEmail}}

--- a/cmd/apps/openfaas_ingress_app_test.go
+++ b/cmd/apps/openfaas_ingress_app_test.go
@@ -11,7 +11,101 @@ import (
 )
 
 func Test_buildYAML_SubsitutesDomainEmailAndIngress(t *testing.T) {
-	templBytes, _ := buildYAML("openfaas.subdomain.example.com", "openfaas@subdomain.example.com", "traefik", false)
+	templBytes, _ := buildYAML("openfaas.subdomain.example.com", "openfaas@subdomain.example.com", "traefik", false, false)
+	var want = `
+apiVersion: extensions/v1beta1 
+kind: Ingress
+metadata:
+  name: openfaas-gateway
+  namespace: openfaas
+  annotations:
+    cert-manager.io/issuer: letsencrypt-prod
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+  - host: openfaas.subdomain.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: gateway
+          servicePort: 8080
+        path: /
+  tls:
+  - hosts:
+    - openfaas.subdomain.example.com
+    secretName: openfaas-gateway
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: letsencrypt-prod
+  namespace: openfaas
+spec:
+  acme:
+    email: openfaas@subdomain.example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: example-issuer-account-key
+    solvers:
+    - http01:
+        ingress:
+          class: traefik`
+
+	got := string(templBytes)
+	if want != got {
+		t.Errorf("suffix, want: %q, got: %q", want, got)
+	}
+}
+
+func Test_buildYAMLStaging(t *testing.T) {
+	templBytes, _ := buildYAML("openfaas.subdomain.example.com", "openfaas@subdomain.example.com", "traefik", true, false)
+	var want = `
+apiVersion: extensions/v1beta1 
+kind: Ingress
+metadata:
+  name: openfaas-gateway
+  namespace: openfaas
+  annotations:
+    cert-manager.io/issuer: letsencrypt-staging
+    kubernetes.io/ingress.class: traefik
+spec:
+  rules:
+  - host: openfaas.subdomain.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: gateway
+          servicePort: 8080
+        path: /
+  tls:
+  - hosts:
+    - openfaas.subdomain.example.com
+    secretName: openfaas-gateway
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: letsencrypt-staging
+  namespace: openfaas
+spec:
+  acme:
+    email: openfaas@subdomain.example.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: example-issuer-account-key
+    solvers:
+    - http01:
+        ingress:
+          class: traefik`
+
+	got := string(templBytes)
+	if want != got {
+		t.Errorf("suffix, want: %q, got: %q", want, got)
+	}
+}
+
+func Test_buildYAMLClusterIssuer(t *testing.T) {
+	templBytes, _ := buildYAML("openfaas.subdomain.example.com", "openfaas@subdomain.example.com", "traefik", false, true)
 	var want = `
 apiVersion: extensions/v1beta1 
 kind: Ingress
@@ -43,52 +137,6 @@ spec:
   acme:
     email: openfaas@subdomain.example.com
     server: https://acme-v02.api.letsencrypt.org/directory
-    privateKeySecretRef:
-      name: example-issuer-account-key
-    solvers:
-    - http01:
-        ingress:
-          class: traefik`
-
-	got := string(templBytes)
-	if want != got {
-		t.Errorf("suffix, want: %q, got: %q", want, got)
-	}
-}
-
-func Test_buildYAMLStaging(t *testing.T) {
-	templBytes, _ := buildYAML("openfaas.subdomain.example.com", "openfaas@subdomain.example.com", "traefik", true)
-	var want = `
-apiVersion: extensions/v1beta1 
-kind: Ingress
-metadata:
-  name: openfaas-gateway
-  namespace: openfaas
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-staging
-    kubernetes.io/ingress.class: traefik
-spec:
-  rules:
-  - host: openfaas.subdomain.example.com
-    http:
-      paths:
-      - backend:
-          serviceName: gateway
-          servicePort: 8080
-        path: /
-  tls:
-  - hosts:
-    - openfaas.subdomain.example.com
-    secretName: openfaas-gateway
----
-apiVersion: cert-manager.io/v1alpha2
-kind: ClusterIssuer
-metadata:
-  name: letsencrypt-staging
-spec:
-  acme:
-    email: openfaas@subdomain.example.com
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: example-issuer-account-key
     solvers:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes #160 

OpenFaaS ingress and registry ingress are now using a namespaced issuer,
they were before both installing clusterIssuers.

Openfaas ingress retains a flag to use the cluster issuer. The default
is now to use a namespaced issuer. This may cause doftware relying on this
undocumented behaviour to break. To switch back to the old functionality
you can pass the `--cluster-issuer` flag to the openfaas-ingress
installation command.

This has been tested by using both staging and production LE issuers to
create ingress backed by TLS certs using the cluster issuer (Docker
registry) and using both the ClusterIssuer and Issuer for OpenFaaS
Ingress

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#160 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
Users relying on the undocumented `ClusterIssuer` installed with `openfaas-ingress` will need to pass the `--cluster-issuer` flag to get same behaviour 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
