### PR TITLE
add kubebuilder to get command

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -474,3 +474,47 @@ func Test_DownloadInletsctl(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadKubebuilder(t *testing.T) {
+	tools := MakeTools()
+	name := "kubebuilder"
+
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	type test struct {
+		os      string
+		arch    string
+		version string
+		url     string
+	}
+
+	tests := []test{
+		{os: "darwin",
+			arch:    arch64bit,
+			version: "2.3.1",
+			url:     "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_darwin_amd64.tar.gz"},
+		{os: "linux",
+			arch:    arch64bit,
+			version: "2.3.1",
+			url:     "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz"},
+		{os: "linux",
+			arch:    "arm64",
+			version: "2.3.1",
+			url:     "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_arm64.tar.gz"},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Fatalf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -237,5 +237,24 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 `,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:   "kubernetes-sigs",
+			Repo:    "kubebuilder",
+			Name:    "kubebuilder",
+			Version: "2.3.1",
+			URLTemplate: `{{$arch := "arm64"}}
+			{{- if eq .Arch "x86_64" -}}
+			{{$arch = "amd64"}}
+			{{- end -}}
+
+			{{$osStr := ""}}
+			{{- if eq .OS "linux" -}}
+			{{$osStr = "linux"}}
+			{{- else if eq .OS "darwin" -}}
+			{{$osStr = "darwin"}}
+			{{- end -}}
+			https://github.com/kubernetes-sigs/kubebuilder/releases/download/v{{.Version}}/kubebuilder_{{.Version}}_{{$osStr}}_{{$arch}}.tar.gz`,
+		})
 	return tools
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit will solve issue #180 which will add kubebuilder to get command
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
```
$ go run main.go get kubebuilder
Downloading kubebuilder
https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_darwin_amd64.tar.gz
/var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/etcd kubebuilder_2.3.1_darwin_amd64/bin/etcd
/var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kube-apiserver kubebuilder_2.3.1_darwin_amd64/bin/kube-apiserver
/var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kubectl kubebuilder_2.3.1_darwin_amd64/bin/kubectl
/var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kubebuilder kubebuilder_2.3.1_darwin_amd64/bin/kubebuilder
2020/08/17 16:50:37 extracted tarball into /var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T: 4 files, 0 dirs (7.075645194s)
Tool written to: /var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kubebuilder

Run the following to copy to install the tool:

chmod +x /var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kubebuilder
sudo install -m 755 /var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kubebuilder /usr/local/bin/kubebuilder

$ chmod +x /var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kubebuilder


$ sudo install -m 755 /var/folders/30/rs8_07d90xvb5k16p6swq24r0000gp/T/kubebuilder /usr/local/bin/kubebuilder
Password:

$kubebuilder

Development kit for building Kubernetes extensions and tools.

Provides libraries and tools to create new projects, APIs and controllers.
Includes tools for packaging artifacts into an installer container.

Typical project lifecycle:

- initialize a project:

  kubebuilder init --domain example.com --license apache2 --owner "The Kubernetes authors"

- create one or more a new resource APIs and add your code to them:

  kubebuilder create api --group <group> --version <version> --kind <Kind>

Create resource will prompt the user for if it should scaffold the Resource and / or Controller. To only
scaffold a Controller for an existing Resource, select "n" for Resource. To only define
the schema for a Resource without writing a Controller, select "n" for Controller.

After the scaffold is written, api will run make on the project.

Usage:
  kubebuilder [command]

Available Commands:
  create      Scaffold a Kubernetes API or webhook.
  edit        This command will edit the project configuration
  help        Help about any command
  init        Initialize a new project
  version     Print the kubebuilder version

Flags:
  -h, --help   help for kubebuilder

Use "kubebuilder [command] --help" for more information about a command.
```
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
