### PR TITLE
Add kustomize and change default mode for get

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -22,12 +22,12 @@ func MakeGet() *cobra.Command {
 releases or downloads page. The tool is usually downloaded in binary format 
 and provides a fast and easy alternative to a package manager.`,
 		Example: `  arkade get helm
-  arkade get linkerd2 --stash
+  arkade get linkerd2 --stash=false
   arkade get --help`,
 		SilenceUsage: true,
 	}
 
-	command.Flags().Bool("stash", false, "When set to true, stash binary in HOME/.arkade/bin/, otherwise store in /tmp/")
+	command.Flags().Bool("stash", true, "When set to true, stash binary in HOME/.arkade/bin/, otherwise store in /tmp/")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -83,7 +83,10 @@ sudo install -m 755 %s /usr/local/bin/%s
 			fmt.Printf(`Run the following to add the (%s) binary to your PATH variable
 
 export PATH=$PATH:$HOME/.arkade/bin/
-`, finalName)
+
+%s
+
+`, finalName, outFilePath)
 
 		}
 		return err

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -176,6 +176,9 @@ func getByDownloadTemplate(tool Tool, os, arch, version string) (string, error) 
 		"OS":      os,
 		"Arch":    arch,
 		"Version": version,
+		"Repo":    tool.Repo,
+		"Owner":   tool.Owner,
+		"Name":    tool.Name,
 	}
 
 	err = t.Execute(&buf, inputs)

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -508,6 +508,57 @@ func Test_DownloadKubebuilder(t *testing.T) {
 			version: "2.3.1",
 			url:     "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_arm64.tar.gz"},
 	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Fatalf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
+func Test_DownloadKustomize(t *testing.T) {
+	tools := MakeTools()
+	name := "kustomize"
+
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	type test struct {
+		os      string
+		arch    string
+		version string
+		url     string
+	}
+
+	ver := "kustomize/v3.8.1"
+
+	tests := []test{
+		{os: "linux",
+			arch:    arch64bit,
+			version: ver,
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_linux_amd64.tar.gz",
+		},
+		{os: "darwin",
+			arch:    arch64bit,
+			version: ver,
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_darwin_amd64.tar.gz",
+		},
+		{os: "linux",
+			arch:    "arm64",
+			version: ver,
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_.tar.gz",
+		},
+	}
+
 	for _, tc := range tests {
 		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
 		if err != nil {

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -256,5 +256,24 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			{{- end -}}
 			https://github.com/kubernetes-sigs/kubebuilder/releases/download/v{{.Version}}/kubebuilder_{{.Version}}_{{$osStr}}_{{$arch}}.tar.gz`,
 		})
+
+	tools = append(tools,
+		Tool{
+			Owner:   "kubernetes-sigs",
+			Repo:    "kustomize",
+			Name:    "kustomize",
+			Version: "kustomize/v3.8.1",
+			URLTemplate: `
+	{{$osStr := ""}}
+	{{- if eq .OS "linux" -}}
+	{{- if eq .Arch "x86_64" -}}
+	{{$osStr = "linux_amd64"}}
+	{{- end -}}
+	{{- else if eq .OS "darwin" -}}
+	{{$osStr = "darwin_amd64"}}
+	{{- end -}}
+	https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_v3.8.1_{{$osStr}}.tar.gz`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
Add kustomize and change default mode for get

Tested downloading and using kustomize, along with setting
the default "get" mode to "stash", which adds the binary to
the $HOME/.arkade/bin folder.

Users can still run --stash=false to download to /tmp/ and
get a sudo install message.

Closes: #183

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
