### PR TITLE
Add registry-creds app

### DIFF
--- a/cmd/apps/registry_creds_app.go
+++ b/cmd/apps/registry_creds_app.go
@@ -1,0 +1,155 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/k8s"
+
+	"github.com/alexellis/arkade/pkg"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallRegistryCredsOperator() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "registry-creds",
+		Short: "Install registry-creds",
+		Long: `Install the registry-creds operator, to take a single registry secret and 
+to propagate it to all available namespaces. Works on regular Intel, ARM 
+and ARM64 clusters.`,
+		Example:      `  arkade install registry-creds`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().String("username", "", "Username for your registry or the Docker Hub")
+	command.Flags().String("password", "", "Password for your registry or the Docker Hub")
+	command.Flags().String("email", "", "Email address for your registry or the Docker Hub (optional)")
+	command.Flags().String("server", "", "Server for your registry or the Docker Hub, default: is blank, for the Docker Hub")
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath := config.GetDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		var (
+			username string
+			password string
+			email    string
+			server   string
+		)
+
+		fmt.Printf("Applying controller's manifests.\n")
+		_, err := k8s.KubectlTask("apply", "-f",
+			"https://raw.githubusercontent.com/alexellis/registry-creds/master/mainfest.yaml")
+		if err != nil {
+			return err
+		}
+
+		if command.Flags().Changed("username") {
+			var err error
+			username, err = command.Flags().GetString("username")
+			if err != nil {
+				return err
+			}
+			password, err = command.Flags().GetString("password")
+			if err != nil {
+				return err
+			}
+			email, err = command.Flags().GetString("email")
+			if err != nil {
+				return err
+			}
+			server, err = command.Flags().GetString("server")
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Attempting to create secret for user: %s\n", username)
+			serverStr := ""
+			if len(server) > 0 {
+				serverStr = "--docker-server=" + server
+			}
+			res, err := k8s.KubectlTask("create", "secret", "docker-registry", "registry-seed-secret",
+				"--namespace=kube-system",
+				"--docker-username="+username, "--docker-password="+password,
+				"--docker-email="+email, serverStr)
+			if err != nil {
+				return err
+			}
+
+			if res.ExitCode != 0 {
+				fmt.Printf("Warning: %s\n", res.Stderr)
+			} else {
+				fmt.Printf("%s", res.Stdout)
+			}
+
+			dir := os.TempDir()
+			cr := path.Join(dir, "clusterpullsecret.yaml")
+
+			err = ioutil.WriteFile(cr, []byte(`apiVersion: ops.alexellis.io/v1
+kind: ClusterPullSecret
+metadata:
+  name: primary
+spec:
+  secretRef:
+    name: registry-seed-secret
+    namespace: kube-system
+`), 0644)
+
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Wrote temporary file: %s\n", cr)
+
+			fmt.Printf("Creating ClusterPullSecret\n")
+			crRes, err := k8s.KubectlTask("apply", "-f", cr)
+			if err != nil {
+				return err
+			}
+			if crRes.ExitCode != 0 {
+				fmt.Printf("Warning: %s\n", crRes.Stderr)
+			}
+
+			fmt.Printf(`
+# To view your ClusterPullSecret
+kubectl get ClusterPullSecret/primary
+
+# View your Seed Secret
+kubectl get secret -n kube-system registry-seed-secret
+
+# View your ServiceAccount's imagePullSecrets list
+kubectl get serviceaccount default -o yaml
+
+`)
+		}
+
+		fmt.Println(`=======================================================================
+= registry-creds has been installed.                                  =
+=======================================================================` +
+			"\n\n" + RegistryCredsOperatorInfoMsg + "\n\n" + pkg.ThanksForUsing)
+
+		return nil
+	}
+
+	return command
+}
+
+const RegistryCredsOperatorInfoMsg = `This operator is used to propagate a single ImagePullSecret to all 
+namespaces within your cluster, so that images can be pulled with 
+authentication.
+
+Why is that required? For private images, and to cope with the 
+Docker Hub's recent rate limiting for anonymous pulls of layers.
+
+# Find out more at
+https://github.com/alexellis/registry-creds`

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -97,6 +97,8 @@ arkade info --help`,
 			msg = apps.RedisInfoMsg
 		case "kube-image-prefetch":
 			msg = apps.KubeImagePrefetchInfoMsg
+		case "registry-creds":
+			msg = apps.RegistryCredsOperatorInfoMsg
 		default:
 			return fmt.Errorf("no info available for app: %s", appName)
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -79,6 +79,7 @@ And to see options for a specific app before installing, run:
 	command.AddCommand(apps.MakeInstallRedis())
 	command.AddCommand(apps.MakeInstallOSM())
 	command.AddCommand(apps.MakeInstallKubeImagePrefetch())
+	command.AddCommand(apps.MakeInstallRegistryCredsOperator())
 
 	command.AddCommand(MakeInfo())
 


### PR DESCRIPTION
The registry-creds app can generate your initial ClusterPullSecret, or when left
blank, just installs the operator.

An example, for detailed usage will be given at: https://github.com/alexellis/registry-creds

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
