### PR TITLE
Add CLI for Civo cloud

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -624,3 +624,45 @@ func Test_DownloadK9s(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadCivo(t *testing.T) {
+	tools := MakeTools()
+	name := "civo"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "0.6.27"
+
+	tests := []test{
+		{os: "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/civo/cli/releases/download/v0.6.27/civo-0.6.27-windows-amd64.zip`,
+		},
+		{os: "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/civo/cli/releases/download/v0.6.27/civo-0.6.27-linux-amd64.tar.gz`,
+		},
+		{os: "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/civo/cli/releases/download/v0.6.27/civo-0.6.27-darwin-amd64.tar.gz`,
+		},
+		{os: "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     `https://github.com/civo/cli/releases/download/v0.6.27/civo-0.6.27-linux-arm.tar.gz`,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -329,5 +329,37 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_{{$osStr}}_{{$archStr}}.tar.gz`,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:          "civo",
+			Repo:           "cli",
+			Name:           "civo",
+			Version:        "0.6.27",
+			BinaryTemplate: `civo`,
+			URLTemplate: `
+
+		{{$extStr := "tar.gz"}}
+		{{ if HasPrefix .OS "ming" -}}
+		{{$extStr = "zip"}}
+		{{- end -}}
+
+		{{$osStr := ""}}
+		{{ if HasPrefix .OS "ming" -}}
+		{{$osStr = "windows"}}
+		{{- else if eq .OS "linux" -}}
+		{{$osStr = "linux"}}
+		{{- else if eq .OS "darwin" -}}
+		{{$osStr = "darwin"}}
+		{{- end -}}
+
+		{{$archStr := .Arch}}
+		{{- if eq .Arch "armv7l" -}}
+		{{$archStr = "arm"}}
+		{{- else if eq .Arch "x86_64" -}}
+		{{$archStr = "amd64"}}
+		{{- end -}}		
+https://github.com/{{.Owner}}/{{.Repo}}/releases/download/v{{.Version}}/{{.Name}}-{{.Version}}-{{$osStr}}-{{$archStr}}.{{$extStr}}`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add CLI for Civo cloud

## Motivation and Context
Civo cloud is a UK IaaS provider and has a managed k3s service.

They now produce a multi-arch Go binary, so it can be included
in arkade.

## How Has This Been Tested?

New unit tests and e2e testing on MacOS

<img width="1485" alt="Screenshot 2020-08-24 at 15 41 05" src="https://user-images.githubusercontent.com/6358735/91058674-a92f1b00-e620-11ea-9351-c3e82c363691.png">
