### PR TITLE
Fix: create /Users/$HOME/.arkade/bin always

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -5,6 +5,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/user"
 
 	"github.com/alexellis/arkade/pkg/env"
 	"github.com/alexellis/arkade/pkg/get"
@@ -27,7 +29,7 @@ and provides a fast and easy alternative to a package manager.`,
 		SilenceUsage: true,
 	}
 
-	command.Flags().Bool("stash", true, "When set to true, stash binary in HOME/.arkade/bin/, otherwise store in /tmp/")
+	command.Flags().Bool("stash", true, "When set to true, stash binary in $HOME/.arkade/bin/, otherwise store in /tmp/")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -64,6 +66,14 @@ and provides a fast and easy alternative to a package manager.`,
 		if stash {
 			dlMode = get.DownloadArkadeDir
 		}
+
+		currentUser, err := user.Current()
+		if err != nil {
+			return err
+		}
+
+		defaultArkPath := fmt.Sprintf("%s/.arkade/bin", currentUser.HomeDir)
+		_ = os.MkdirAll(defaultArkPath, 0744)
 
 		outFilePath, finalName, err := get.Download(tool, arch, operatingSystem, version, dlMode)
 


### PR DESCRIPTION
Signed-off-by: guacamole <gunjanwalecha@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`arkade get <tool>` fails if `$HOME/.arkade/bin` doesn't exist. This PR tries to fix this issue by always creating the folder and ignores the error if any.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for #195 
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on MacOS
![arkade-dir-fix](https://user-images.githubusercontent.com/68041753/91323327-6450e300-e7de-11ea-99c0-e056fb425790.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
