### PR TITLE
Use Latest Dashboard in Tekton App

### DIFF
--- a/cmd/apps/tekton_app.go
+++ b/cmd/apps/tekton_app.go
@@ -48,7 +48,7 @@ func MakeInstallTekton() *cobra.Command {
 
 		fmt.Println("Installing Tekton dashboard...")
 		_, err = k8s.KubectlTask("apply", "-f",
-			"https://github.com/tektoncd/dashboard/releases/download/v0.5.1/tekton-dashboard-release.yaml")
+			"https://storage.googleapis.com/tekton-releases/dashboard/latest/tekton-dashboard-release.yaml")
 		if err != nil {
 			return err
 		}
@@ -61,11 +61,12 @@ func MakeInstallTekton() *cobra.Command {
 	return tekton
 }
 
-const TektonInfoMsg = `For more information on accessing the
-Tekton dashboard: https://github.com/tektoncd/dashboard
+const TektonInfoMsg = `Want to launch a Tekton pipeline and see it in action?
+Get one here: https://github.com/tektoncd/pipeline/tree/master/examples
 
-Want to launch a Tekton pipeline and see it in action?
-Get one here: https://github.com/tektoncd/pipeline/tree/master/examples`
+For more information...
+  https://github.com/tektoncd/pipeline
+  https://github.com/tektoncd/dashboard`
 
 const TektonInstallMsg = `=======================================================================
 = Tekton pipelines and dashboard have been installed. =


### PR DESCRIPTION
## Description

Tekton Dashboard releases are independently versioned from Tekton
Pipeline releases. Since Dashboard is an optional accessory to Tekton
Pipelines, this commit removes it altogether. This change was prompted
by the Dashboard version becoming incompatible with recent Tekton
Pipelines versions. The goal of this commit to ensure that Arkade users
have a consistently working version of Tekton at all times.

I've provided further context in the linked issues. Since the Tekton Dashboard service is an optional accessory, it may be best to only provide the core Tekton Pipelines service by default for a consistent user experience.

## Motivation and Context

Fixes #198 

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

The code was formatted, vetted, and then ```go test -v ./...``` was ran against it.

After a successful ```make build```, it was manually tested via a Kind cluster, on Docker Desktop, on macOS 10.15.6 (amd64).

Here is some STDOUT that shows it in action.

```
% kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          coredns-66bff467f8-8jgng                     1/1     Running   0          11m
kube-system          coredns-66bff467f8-s6qf5                     1/1     Running   0          11m
kube-system          etcd-kind-control-plane                      1/1     Running   0          11m
kube-system          kindnet-b4t9j                                1/1     Running   0          11m
kube-system          kube-apiserver-kind-control-plane            1/1     Running   0          11m
kube-system          kube-controller-manager-kind-control-plane   1/1     Running   0          11m
kube-system          kube-proxy-585cm                             1/1     Running   0          11m
kube-system          kube-scheduler-kind-control-plane            1/1     Running   0          11m
local-path-storage   local-path-provisioner-bd4bb6b75-ljfrw       1/1     Running   0          11m

% ./arkade install tekton
Using kubeconfig: /Users/nick/.kube/config
Node architecture: "amd64"
Installing Tekton pipelines...
=======================================================================
= Tekton pipelines has been installed. =
=======================================================================

Want to launch a Tekton pipeline and see it in action?
Get one here: https://github.com/tektoncd/pipeline/tree/master/examples

For more information: https://github.com/tektoncd/pipeline

Thanks for using arkade!

% kubectl get pods -A
NAMESPACE            NAME                                           READY   STATUS    RESTARTS   AGE
kube-system          coredns-66bff467f8-8jgng                       1/1     Running   0          13m
kube-system          coredns-66bff467f8-s6qf5                       1/1     Running   0          13m
kube-system          etcd-kind-control-plane                        1/1     Running   0          14m
kube-system          kindnet-b4t9j                                  1/1     Running   0          13m
kube-system          kube-apiserver-kind-control-plane              1/1     Running   0          14m
kube-system          kube-controller-manager-kind-control-plane     1/1     Running   0          14m
kube-system          kube-proxy-585cm                               1/1     Running   0          13m
kube-system          kube-scheduler-kind-control-plane              1/1     Running   0          14m
local-path-storage   local-path-provisioner-bd4bb6b75-ljfrw         1/1     Running   0          13m
tekton-pipelines     tekton-pipelines-controller-7d5d5cc54f-nvlq9   1/1     Running   0          8s
tekton-pipelines     tekton-pipelines-webhook-5d9dc45569-cs78t      1/1     Running   0          8s

% ./arkade info tekton   
Info for app: tekton
Want to launch a Tekton pipeline and see it in action?
Get one here: https://github.com/tektoncd/pipeline/tree/master/examples

For more information: https://github.com/tektoncd/pipeline
```

Here is an example of a TaskRun in action. This leverages the Tekton Pipelines service. I copied the example from [my last PR](https://github.com/alexellis/arkade/pull/61) here.

```
% cat example.yaml 
apiVersion: tekton.dev/v1alpha1
kind: TaskRun
metadata:
  name: example-taskrun
spec:
  taskSpec:
    steps:
      - name: ubuntu
        image: ubuntu:focal
        command:
          - echo
        args:
          - "Hello world!"

% kubectl create -f example.yaml 
taskrun.tekton.dev/example-taskrun created

% kubectl logs example-taskrun-pod-g2w5h step-ubuntu 
Hello world!

% kubectl get pods -n default 
NAME                        READY   STATUS      RESTARTS   AGE
example-taskrun-pod-g2w5h   0/1     Completed   0          32s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment

Thank you for looking this over!