### PR TITLE
Add terraform CLI

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -28,6 +28,7 @@ and provides a fast and easy alternative to a package manager.`,
 	}
 
 	command.Flags().Bool("stash", true, "When set to true, stash binary in HOME/.arkade/bin/, otherwise store in /tmp/")
+	command.Flags().StringP("version", "v", "", "Download a specific version")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -40,6 +41,7 @@ and provides a fast and easy alternative to a package manager.`,
 			fmt.Println(arkadeGet + "\n" + buf)
 			return nil
 		}
+
 		var tool *get.Tool
 
 		if len(args) == 1 {
@@ -58,6 +60,10 @@ and provides a fast and easy alternative to a package manager.`,
 
 		arch, operatingSystem := env.GetClientArch()
 		version := ""
+
+		if command.Flags().Changed("version") {
+			version, _ = command.Flags().GetString("version")
+		}
 
 		stash, _ := command.Flags().GetBool("stash")
 		dlMode := get.DownloadTempDir

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -666,3 +666,45 @@ func Test_DownloadCivo(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadTerraform(t *testing.T) {
+	tools := MakeTools()
+	name := "terraform"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "0.13.1"
+
+	tests := []test{
+		{os: "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_windows_amd64.zip`,
+		},
+		{os: "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_linux_amd64.zip`,
+		},
+		{os: "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_darwin_amd64.zip`,
+		},
+		{os: "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     `https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_linux_arm.zip`,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -361,5 +361,27 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 https://github.com/{{.Owner}}/{{.Repo}}/releases/download/v{{.Version}}/{{.Name}}-{{.Version}}-{{$osStr}}-{{$archStr}}.{{$extStr}}`,
 		})
 
+	// https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_linux_amd64.zip
+	tools = append(tools,
+		Tool{
+			Owner:   "hashicorp",
+			Repo:    "terraform",
+			Name:    "terraform",
+			Version: "0.13.1",
+			URLTemplate: `{{$arch := .Arch}}
+
+{{- if eq .Arch "x86_64" -}}
+{{$arch = "amd64"}}
+{{- else if eq .Arch "armv7l" -}}
+{{$arch = "arm"}}
+{{- end -}}
+
+{{$os := .OS}}
+{{ if HasPrefix .OS "ming" -}}
+{{$os = "windows"}}
+{{- end -}}
+
+https://releases.hashicorp.com/terraform/{{.Version}}/terraform_{{.Version}}_{{$os}}_{{$arch}}.zip`})
+
 	return tools
 }


### PR DESCRIPTION
Add terraform CLI

Fixes: #200

Tested with unit tests and by downloading terraform to my Mac.

Also adds --version to "arkade get" so you can bring down
terraform 0.12.0 etc.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>
