### PR TITLE
Update to Portainer to v2.0, non-beta, multi-arch image

### DIFF
--- a/cmd/apps/portainer_app.go
+++ b/cmd/apps/portainer_app.go
@@ -40,10 +40,6 @@ func MakeInstallPortainer() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch && arch != "arm" {
-			return fmt.Errorf(`only Intel and "arm" is supported for this app`)
-		}
-
 		_, err := k8s.KubectlTask("create", "ns",
 			"portainer")
 		if err != nil {
@@ -53,7 +49,7 @@ func MakeInstallPortainer() *cobra.Command {
 		}
 
 		req, err := http.NewRequest(http.MethodGet,
-			"https://raw.githubusercontent.com/portainer/portainer-k8s/master/portainer-nodeport.yaml",
+			"https://raw.githubusercontent.com/portainer/k8s/master/deploy/manifests/portainer/portainer.yaml",
 			nil)
 
 		if err != nil {
@@ -69,9 +65,6 @@ func MakeInstallPortainer() *cobra.Command {
 		defer res.Body.Close()
 		body, _ := ioutil.ReadAll(res.Body)
 		manifest := string(body)
-		if arch == "arm" {
-			manifest = strings.Replace(manifest, "linux-amd64", "linux-arm", -1)
-		}
 
 		tmp := os.TempDir()
 		joined := path.Join(tmp, "portainer.yaml")


### PR DESCRIPTION
Portainer has updated to v2.0-CE (stable). The deployment manifest has a new URL, and the images is multi-arch, which I _think_ means that it's no longer necessary to do architecture checks.

## Description

1. Update the portainer YAML manifest URL
2. Remove the architecture checks, since we're on a multi-arch image now

## Motivation and Context

The current code references Portainer's k8s-beta image/manifests. These are deprecated now that v2.0 is out.

## How Has This Been Tested?

I've not tested this (_gasp!_). I'm open to suggestions about how to test, or pointers to the relevant docs :) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
