### PR TITLE
Add Gitea as an installable app

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Available Commands:
   crossplane              Install Crossplane
   docker-registry         Install a Docker registry
   docker-registry-ingress Install registry ingress with TLS
+  gitea                   Install gitea
   grafana                 Install grafana
   info                    Find info about a Kubernetes app
   ingress-nginx           Install ingress-nginx

--- a/cmd/apps/gitea_app.go
+++ b/cmd/apps/gitea_app.go
@@ -1,0 +1,148 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/k8s"
+	"github.com/alexellis/arkade/pkg/types"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/sethvargo/go-password/password"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallGitea() *cobra.Command {
+	var gitea = &cobra.Command{
+		Use:          "gitea",
+		Short:        "Install gitea",
+		Long:         `Install gitea`,
+		Example:      `  arkade install gitea`,
+		SilenceUsage: true,
+	}
+
+	gitea.Flags().Bool("update-repo", true, "Update the helm repo")
+	gitea.Flags().String("namespace", "default", "Kubernetes namespace for the application")
+	gitea.Flags().Bool("persistence", false, "Enable persistence")
+	gitea.Flags().StringP("user", "u", "gitea_admin", "Username of admin user")
+	gitea.Flags().StringP("password", "p", "", "Overide the default random admin-password if this is set")
+	gitea.Flags().StringArray("set", []string{},
+		"Use custom flags or override existing flags \n(example --set persistence.enabled=true)")
+
+	gitea.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath := config.GetDefaultKubeconfig()
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ = command.Flags().GetString("kubeconfig")
+		}
+		updateRepo, _ := gitea.Flags().GetBool("update-repo")
+
+		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
+
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		userPath, err := config.InitUserDir()
+		if err != nil {
+			return err
+		}
+
+		clientArch, clientOS := env.GetClientArch()
+
+		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
+		log.Printf("User dir established as: %s\n", userPath)
+
+		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
+
+		ns, _ := gitea.Flags().GetString("namespace")
+
+		persistence, _ := gitea.Flags().GetBool("persistence")
+		overrides := map[string]string{}
+
+		overrides["persistence.enabled"] = strings.ToLower(strconv.FormatBool(persistence))
+
+		pass, _ := command.Flags().GetString("password")
+
+		if len(pass) == 0 {
+			var err error
+			pass, err = password.Generate(25, 10, 0, false, true)
+			if err != nil {
+				return err
+			}
+		}
+
+		overrides["gitea.admin.password"] = pass
+
+		adminUsername, err := command.Flags().GetString("user")
+		if err != nil {
+			return err
+		}
+		overrides["gitea.admin.username"] = adminUsername
+
+		// disabling password complexity check by default per NIST guidelines
+		// as it has been disabled upstream just waiting on a stable release
+		// user is free to enable password checks using --set flag
+		overrides["gitea.config.security.PASSWORD_COMPLEXITY"] = "off"
+
+		customFlags, err := gitea.Flags().GetStringArray("set")
+		if err != nil {
+			return fmt.Errorf("error with --set usage: %s", err)
+		}
+
+		if err := mergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		giteaAppOptions := types.DefaultInstallOptions().
+			WithNamespace(ns).
+			WithHelmPath(path.Join(userPath, ".helm")).
+			WithHelmRepo("gitea-charts/gitea").
+			WithHelmURL("https://dl.gitea.io/charts").
+			WithOverrides(overrides).
+			WithHelmUpdateRepo(updateRepo)
+
+		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
+		if err != nil {
+			return err
+		}
+
+		if _, found := overrides["gitea.config.database.HOST"]; !found && arch != IntelArch {
+			return fmt.Errorf("If installing on ARM platform you'll need to use an external database")
+		}
+
+		_, err = apps.MakeInstallChart(giteaAppOptions)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(giteaInstallMsg)
+		return nil
+	}
+
+	return gitea
+}
+
+const GiteaInfoMsg = `# Forward the gateway to your machine
+kubectl rollout status --namespace {{ namespace }} sts/gitea
+kubectl --namespace {{ namespace }} port-forward svc/gitea-http 3000:3000
+
+# Open up http://127.0.0.1:3000 to use your application
+
+# Find out more at:
+# https://gitea.com/gitea/helm-chart`
+
+var giteaInstallMsg = `=======================================================================
+=                    Gitea has been installed.                      =
+=======================================================================` +
+	"\n\n" + GiteaInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -79,6 +79,7 @@ And to see options for a specific app before installing, run:
 	command.AddCommand(apps.MakeInstallOSM())
 	command.AddCommand(apps.MakeInstallKubeImagePrefetch())
 	command.AddCommand(apps.MakeInstallRegistryCredsOperator())
+	command.AddCommand(apps.MakeInstallGitea())
 
 	command.AddCommand(MakeInfo())
 


### PR DESCRIPTION
## Description
Gitea now has an official helm chart, and this PR adds it as an app to arkade

## Motivation and Context

## How Has This Been Tested?
```
# start civo cluster
make build
./arkade install gitea -h
./arkade install gitea
kubectl --namespace default port-forward svc/gitea-http 3000:3000
# Open http://127.0.0.1:3000 in the browser
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

- [x] I have tested this on arm, or have added code to prevent deployment
