### PR TITLE
OnlyIntelArch, should be used at every place

### DIFF
--- a/cmd/apps/redis_app.go
+++ b/cmd/apps/redis_app.go
@@ -53,7 +53,7 @@ func MakeInstallRedis() *cobra.Command {
 		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
-			return fmt.Errorf(`only Intel, i.e. PC architecture is supported for this app`)
+			return fmt.Errorf(OnlyIntelArch)
 		}
 
 		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {

--- a/cmd/apps/tekton_app.go
+++ b/cmd/apps/tekton_app.go
@@ -36,7 +36,7 @@ func MakeInstallTekton() *cobra.Command {
 		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
-			return fmt.Errorf(`only Intel and AMD (i.e. PC) architecture is supported for this app`)
+			return fmt.Errorf(OnlyIntelArch)
 		}
 
 		fmt.Println("Installing Tekton pipelines...")


### PR DESCRIPTION
This will update current apps that has same/identical message to use ```OnlyIntelArch``` and closes #228.