### PR TITLE
Add Azure provisioner for inlets-operator app

### DIFF
--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -32,11 +32,12 @@ func MakeInstallInletsOperator() *cobra.Command {
 	inletsOperator.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
 	inletsOperator.Flags().StringP("license", "l", "", "The license key if using inlets-pro")
 	inletsOperator.Flags().StringP("license-file", "f", "", "Text file containing license key, used for inlets-pro")
-	inletsOperator.Flags().StringP("provider", "p", "digitalocean", "Your infrastructure provider - 'packet', 'digitalocean', 'scaleway', 'linode', 'civo', 'gce' or 'ec2'")
-	inletsOperator.Flags().StringP("zone", "z", "us-central1-a", "The zone to provision the exit node (Used by GCE")
+	inletsOperator.Flags().StringP("provider", "p", "digitalocean", "Your infrastructure provider - 'packet', 'digitalocean', 'scaleway', 'linode', 'civo', 'gce', 'ec2', 'azure'")
+	inletsOperator.Flags().StringP("zone", "z", "us-central1-a", "The zone to provision the exit node (GCE)")
 	inletsOperator.Flags().String("project-id", "", "Project ID to be used (for GCE and Packet)")
-	inletsOperator.Flags().StringP("region", "r", "lon1", "The default region to provision the exit node (DigitalOcean, Packet and Scaleway")
-	inletsOperator.Flags().String("organization-id", "", "The organization id (Scaleway")
+	inletsOperator.Flags().StringP("region", "r", "lon1", "The default region to provision the exit node (DigitalOcean, Packet and Scaleway)")
+	inletsOperator.Flags().String("organization-id", "", "The organization id (Scaleway)")
+	inletsOperator.Flags().String("subscription-id", "", "The subscription id (Azure)")
 	inletsOperator.Flags().StringP("token-file", "t", "", "Text file containing token or a service account JSON file")
 	inletsOperator.Flags().StringP("token", "k", "", "The API access token")
 	inletsOperator.Flags().StringP("secret-key-file", "s", "", "Text file containing secret key, used for providers like ec2")
@@ -194,7 +195,7 @@ func getInletsOperatorOverrides(command *cobra.Command) (map[string]string, erro
 	}
 
 	providers := []string{
-		"digitalocean", "packet", "ec2", "scaleway", "civo", "gce", "linode",
+		"digitalocean", "packet", "ec2", "scaleway", "civo", "gce", "linode", "azure",
 	}
 
 	found := false
@@ -252,6 +253,15 @@ func getInletsOperatorOverrides(command *cobra.Command) (map[string]string, erro
 		if len(orgID) == 0 {
 			return overrides, fmt.Errorf("organization-id is required for provider %s", provider)
 		}
+	} else if provider == "azure" {
+		subscriptionID, err := command.Flags().GetString("subscription-id")
+		if err != nil {
+			return overrides, err
+		}
+		if len(subscriptionID) == 0 {
+			return overrides, fmt.Errorf("subscription-id is required for provider %s", provider)
+		}
+		overrides["subscriptionID"] = subscriptionID
 	} else if provider == "ec2" {
 		if len(secretKeyFile) == 0 {
 			return overrides, fmt.Errorf("secret-key-file is required for provider %s", provider)


### PR DESCRIPTION
Enables the Azure provisioner for inlets-operator app.

Signed-off-by: Ze Chen <zechenbit@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
This is to enable the Azure provisioner for inlets-operator in arkade.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The following up changes in arkade for #47

<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
### Install inlets-operator with provider as Azure
```
arkade install inlets-operator --provider azure --region eastus --token-file ~/client_credentials.json --subscription-id 4d6ffffe-64ee-4a11-e329-c973629efcdb
Using kubeconfig: <User>/.config/k3d/k3s-default/kubeconfig.yaml
Node architecture: "amd64"
Client: "x86_64", "Darwin"
2020/10/17 16:57:18 User dir established as: <User>/.arkade/
"inlets" has been added to your repositories

VALUES values.yaml
Command: <User>/.arkade/bin/helm [upgrade --install inlets-operator inlets/inlets-operator --namespace default --values /var/folders/pf/yb76r0855d7297p2dhq066980000gn/T/charts/inlets-operator/values.yaml --set provider=azure --set subscriptionID=4d6ffffe-64ee-4a11-e329-c973629efcdb --set region=eastus]
Release "inlets-operator" does not exist. Installing it now.
NAME: inlets-operator
LAST DEPLOYED: Sat Oct 17 16:57:23 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
1. Find the inlets-operator logs:

kubectl logs -n default deploy/inlets-operator
=======================================================================
= inlets-operator has been installed.                                  =
=======================================================================

# The default configuration is for DigitalOcean and your secret is
# stored as "inlets-access-key" in the "default" namespace or the namespace 
# you gave if installing with helm3

# To get your first Public IP run the following:

# K8s 1.17
kubectl run nginx-1 --image=nginx --port=80 --restart=Always

# K8s 1.18 and higher:

kubectl apply -f \
 https://raw.githubusercontent.com/inlets/inlets-operator/master/contrib/nginx-sample-deployment.yaml

# Then expose the Deployment as a LoadBalancer:

kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer

# Find your IP in the "EXTERNAL-IP" field, watch for "<pending>" to 
# change to an IP

kubectl get svc -w

# When you're done, remove the tunnel by deleting the service
kubectl delete svc/nginx-1

# Check the logs
kubectl logs deploy/inlets-operator -f

# Find out more at:
# https://github.com/inlets/inlets-operator

Thanks for using arkade!
```

### Install Nginx and expose to public using inlets with provider as Azure
```
➜  ~ kubectl apply -f \                  
 https://raw.githubusercontent.com/inlets/inlets-operator/master/contrib/nginx-sample-deployment.yaml
deployment.apps/nginx-1 created

➜  ~ kubectl expose deployment nginx-1 --port=80 --type=LoadBalancer
service/nginx-1 exposed

➜  ~ kubectl get svc -w                  

NAME         TYPE           CLUSTER-IP      EXTERNAL-IP                 PORT(S)        AGE
kubernetes   ClusterIP      10.43.0.1       <none>                      443/TCP        7m33s
nginx-1      LoadBalancer   10.43.254.168   172.19.0.2,52.188.158.210   80:31085/TCP   2m19s

➜  ~ curl 52.188.158.210|grep title
<title>Welcome to nginx!</title>
```

### Logs inlets-operator
```
➜  ~ kubectl logs deploy/inlets-operator 
2020/10/17 08:57:35 Inlets client: inlets/inlets:2.7.4
W1017 08:57:35.155339       1 client_config.go:552] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I1017 08:57:35.156548       1 controller.go:123] Setting up event handlers
I1017 08:57:35.156636       1 controller.go:245] Starting Tunnel controller
I1017 08:57:35.156662       1 controller.go:248] Waiting for informer caches to sync
I1017 08:57:35.258107       1 controller.go:253] Starting workers
I1017 08:57:35.258187       1 controller.go:259] Started workers
2020/10/17 08:58:14 Creating tunnel for nginx-1-tunnel.default
I1017 08:58:14.149961       1 controller.go:317] Successfully synced 'default/nginx-1'
2020/10/17 08:58:14 Provisioning started with provider:azure host:nginx-1-tunnel
2020/10/17 08:58:14 Provisioning host with Azure
2020/10/17 08:58:14 Creating resource group inlets-nginx-1-tunnel
2020/10/17 08:58:20 Resource group created inlets-nginx-1-tunnel
2020/10/17 08:58:20 Creating deployment deployment-03beffb7-64d6-41ae-953e-4e11b20e896d
2020/10/17 08:58:27 Provisioning call took: 13.127465s
2020/10/17 08:58:27 Status (nginx-1): provisioning, ID: inlets-nginx-1-tunnel|deployment-03beffb7-64d6-41ae-953e-4e11b20e896d, IP: 
I1017 08:58:27.287917       1 controller.go:317] Successfully synced 'default/nginx-1-tunnel'
I1017 08:58:28.880479       1 controller.go:317] Successfully synced 'default/nginx-1-tunnel'
I1017 08:58:36.651687       1 controller.go:317] Successfully synced 'default/nginx-1-tunnel'
I1017 08:59:13.411495       1 controller.go:317] Successfully synced 'default/nginx-1-tunnel'
I1017 08:59:38.606001       1 controller.go:317] Successfully synced 'default/nginx-1-tunnel'
2020/10/17 09:00:07 Status (nginx-1): active, ID: inlets-nginx-1-tunnel|deployment-03beffb7-64d6-41ae-953e-4e11b20e896d, IP: 52.188.158.210
```

### Delete exposed service
```
➜  ~ kubectl delete svc/nginx-1          

service "nginx-1" deleted

➜  ~ kubectl logs deploy/inlets-operator 
2020/10/17 09:16:58 Delete event: nginx-1-tunnel default [{v1 Service nginx-1 38f6a815-1b2a-4ee1-bb2a-efdc6a7a4db9 0xc000885f3b 0xc000885f3a}]
2020/10/17 09:16:58 Deleting exit-node for nginx-1: inlets-nginx-1-tunnel|deployment-03beffb7-64d6-41ae-953e-4e11b20e896d, ip: 52.188.158.210

➜  ~ kubectl get svc -w                  

NAME         TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
kubernetes   ClusterIP   10.43.0.1    <none>        443/TCP   24m
```

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
