### PR TITLE
Add pre- post- commands for Chart App

### DIFF
--- a/cmd/apps/argocd_app.go
+++ b/cmd/apps/argocd_app.go
@@ -5,8 +5,8 @@ package apps
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/alexellis/arkade/pkg/commands"
 	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/k8s"
 
@@ -30,22 +30,24 @@ func MakeInstallArgoCD() *cobra.Command {
 			return err
 		}
 
+		namespace, err := commands.GetNamespace(command.Flags(), "argocd")
+		if err != nil {
+			return err
+		}
+
 		arch := k8s.GetNodeArchitecture()
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
 		}
 
-		_, err := k8s.KubectlTask("create", "ns",
-			"argocd")
+		err = commands.CreateNamespace(namespace)
 		if err != nil {
-			if !strings.Contains(err.Error(), "exists") {
-				return err
-			}
+			return nil
 		}
 
 		_, err = k8s.KubectlTask("apply", "-f",
-			"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml", "-n", "argocd")
+			"https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml", "-n", namespace)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/argocd_app.go
+++ b/cmd/apps/argocd_app.go
@@ -31,7 +31,6 @@ func MakeInstallArgoCD() *cobra.Command {
 		}
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)

--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -53,27 +53,9 @@ func MakeInstallCertManager() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
-
 		updateRepo, _ := certManager.Flags().GetBool("update-repo")
-
-		nsRes, nsErr := k8s.KubectlTask("create", "namespace", namespace)
-		if nsErr != nil {
-			return nsErr
-		}
-
-		if nsRes.ExitCode != 0 {
-			fmt.Printf("[Warning] unable to create namespace %s, may already exist: %s", namespace, nsRes.Stderr)
-		}
 
 		overrides := map[string]string{}
 
@@ -104,7 +86,7 @@ func MakeInstallCertManager() *cobra.Command {
 			WithHelmUpdateRepo(updateRepo).
 			WithKubeconfigPath(kubeConfigPath)
 
-		_, err = apps.MakeInstallChart(certmanagerOptions)
+		err = apps.MakeInstallChart(certmanagerOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/chart_app.go
+++ b/cmd/apps/chart_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -68,10 +67,6 @@ before using the generic helm chart installer command.`,
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 

--- a/cmd/apps/consul_app.go
+++ b/cmd/apps/consul_app.go
@@ -34,8 +34,6 @@ func MakeInstallConsul() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	consul.Flags().StringP("namespace", "n", "consul-system", "The namespace used for installation")
-	consul.Flags().Bool("update-repo", true, "Update the helm repo")
 	consul.Flags().StringP("datacenter", "d", "dc1", "The name of the datacenter that the agents should register as")
 	consul.Flags().Bool("enable-connect-injector", true, "If true, all the resources necessary for the Connect injector process to run will be installed")
 	consul.Flags().Bool("enable-tls-encryption", true, "If true, TLS encryption across the cluster to verify authenticity of the Consul servers and clients is enabled")
@@ -137,7 +135,7 @@ func MakeInstallConsul() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(consulOptions)
+		err = apps.MakeInstallChart(consulOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/types"
 
@@ -24,9 +26,6 @@ func MakeInstallCronConnector() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	command.Flags().StringP("namespace", "n", "openfaas", "The namespace used for installation")
-	command.Flags().Bool("update-repo", true, "Update the helm repo")
-
 	command.Flags().StringArray("set", []string{},
 		"Use custom flags or override existing flags \n(example --set key=value)")
 
@@ -35,18 +34,12 @@ func MakeInstallCronConnector() *cobra.Command {
 
 		updateRepo, _ := command.Flags().GetBool("update-repo")
 
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
-
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err
 		}
 
-		namespace, _ := command.Flags().GetString("namespace")
-
-		if namespace != "openfaas" {
-			return fmt.Errorf(`to override the "openfaas" namespace, install via helm`)
-		}
+		namespace, err := commands.GetNamespace(command.Flags(), "openfaas")
 
 		clientArch, clientOS := env.GetClientArch()
 

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -2,12 +2,10 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 
 	"github.com/alexellis/arkade/pkg/apps"
-	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 
 	"github.com/alexellis/arkade/pkg"
@@ -47,13 +45,10 @@ func MakeInstallCronConnector() *cobra.Command {
 		namespace, _ := command.Flags().GetString("namespace")
 
 		if namespace != "openfaas" {
-			return fmt.Errorf(`to override the "openfaas", install via tiller`)
+			return fmt.Errorf(`to override the "openfaas" namespace, install via helm`)
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
@@ -67,9 +62,6 @@ func MakeInstallCronConnector() *cobra.Command {
 		if err := mergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
-
-		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		cronConnectorAppOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
@@ -85,7 +77,7 @@ func MakeInstallCronConnector() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(cronConnectorAppOptions)
+		err = apps.MakeInstallChart(cronConnectorAppOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -49,7 +48,6 @@ schedule workloads to any Kubernetes cluster`,
 		if !strings.Contains(arch, "64") {
 			return fmt.Errorf(`crossplane is currently only supported on 64-bit architectures`)
 		}
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		userPath, err := config.InitUserDir()
 		if err != nil {
@@ -57,10 +55,6 @@ schedule workloads to any Kubernetes cluster`,
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 

--- a/cmd/apps/gitea_app.go
+++ b/cmd/apps/gitea_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -46,7 +45,6 @@ func MakeInstallGitea() *cobra.Command {
 		updateRepo, _ := gitea.Flags().GetBool("update-repo")
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		userPath, err := config.InitUserDir()
 		if err != nil {
@@ -54,9 +52,6 @@ func MakeInstallGitea() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
@@ -117,7 +112,7 @@ func MakeInstallGitea() *cobra.Command {
 			return fmt.Errorf("if installing on ARM platform you'll need to use an external database")
 		}
 
-		_, err = apps.MakeInstallChart(giteaAppOptions)
+		err = apps.MakeInstallChart(giteaAppOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/gitea_app.go
+++ b/cmd/apps/gitea_app.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
@@ -31,8 +33,6 @@ func MakeInstallGitea() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	gitea.Flags().Bool("update-repo", true, "Update the helm repo")
-	gitea.Flags().String("namespace", "default", "Kubernetes namespace for the application")
 	gitea.Flags().Bool("persistence", false, "Enable persistence")
 	gitea.Flags().StringP("user", "u", "gitea_admin", "Username of admin user")
 	gitea.Flags().StringP("password", "p", "", "Overide the default random admin-password if this is set")
@@ -55,7 +55,10 @@ func MakeInstallGitea() *cobra.Command {
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
-		ns, _ := gitea.Flags().GetString("namespace")
+		namespace, err := commands.GetNamespace(command.Flags(), "default")
+		if err != nil {
+			return err
+		}
 
 		persistence, _ := gitea.Flags().GetBool("persistence")
 		overrides := map[string]string{}
@@ -95,7 +98,7 @@ func MakeInstallGitea() *cobra.Command {
 		}
 
 		giteaAppOptions := types.DefaultInstallOptions().
-			WithNamespace(ns).
+			WithNamespace(namespace).
 			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("gitea-charts/gitea").
 			WithHelmURL("https://dl.gitea.io/charts").

--- a/cmd/apps/gitlab_app.go
+++ b/cmd/apps/gitlab_app.go
@@ -26,9 +26,7 @@ func MakeInstallGitLab() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	gitlabApp.Flags().StringP("namespace", "n", "default", "The namespace to install GitLab")
 	gitlabApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set global.hosts.domain)")
-	gitlabApp.Flags().Bool("update-repo", true, "Update the helm repo")
 	// Maybe these should be arguments as they are required?
 	gitlabApp.Flags().StringP("domain", "d", "", "Domain name that will be used for all publicly exposed services (required)")
 	gitlabApp.Flags().StringP("external-ip", "i", "", "Static IP to assign to NGINX Ingress Controller (required)")
@@ -102,7 +100,7 @@ func MakeInstallGitLab() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(options)
+		err = apps.MakeInstallChart(options)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/grafana_app.go
+++ b/cmd/apps/grafana_app.go
@@ -52,9 +52,6 @@ func MakeInstallGrafana() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -6,7 +6,6 @@ package apps
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -56,19 +55,12 @@ func MakeInstallInletsOperator() *cobra.Command {
 
 		namespace, _ := command.Flags().GetString("namespace")
 
-		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
-
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -6,7 +6,6 @@ package apps
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"time"
@@ -49,7 +48,6 @@ func MakeInstallIstio() *cobra.Command {
 		}
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
@@ -61,10 +59,6 @@ func MakeInstallIstio() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 

--- a/cmd/apps/jenkins_app.go
+++ b/cmd/apps/jenkins_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -47,7 +46,6 @@ func MakeInstallJenkins() *cobra.Command {
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
@@ -59,9 +57,6 @@ func MakeInstallJenkins() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 
@@ -48,14 +47,7 @@ func MakeInstallKafkaConnector() *cobra.Command {
 
 		namespace, _ := command.Flags().GetString("namespace")
 
-		if namespace != "openfaas" {
-			return fmt.Errorf(`to override the "openfaas", install via tiller`)
-		}
-
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
@@ -84,7 +76,6 @@ func MakeInstallKafkaConnector() *cobra.Command {
 		}
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
 		}
@@ -103,7 +94,7 @@ func MakeInstallKafkaConnector() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(kafkaConnectorAppOptions)
+		err = apps.MakeInstallChart(kafkaConnectorAppOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
@@ -28,8 +30,6 @@ func MakeInstallKafkaConnector() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	command.Flags().StringP("namespace", "n", "openfaas", "The namespace used for installation")
-	command.Flags().Bool("update-repo", true, "Update the helm repo")
 	command.Flags().StringP("topics", "t", "faas-request", "The topics for the connector to bind to")
 	command.Flags().String("broker-host", "kafka", "The host for the Kafka broker")
 	command.Flags().StringArray("set", []string{},
@@ -45,7 +45,10 @@ func MakeInstallKafkaConnector() *cobra.Command {
 			return err
 		}
 
-		namespace, _ := command.Flags().GetString("namespace")
+		namespace, err := commands.GetNamespace(command.Flags(), "openfaas")
+		if err != nil {
+			return err
+		}
 
 		clientArch, clientOS := env.GetClientArch()
 

--- a/cmd/apps/kong_ingress_app.go
+++ b/cmd/apps/kong_ingress_app.go
@@ -26,7 +26,6 @@ func MakeInstallKongIngress() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	command.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
 	command.Flags().Bool("update-repo", true, "Update the helm repo")
 
 	command.Flags().StringArray("set", []string{},
@@ -36,8 +35,6 @@ func MakeInstallKongIngress() *cobra.Command {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 
 		updateRepo, _ := command.Flags().GetBool("update-repo")
-
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		userPath, err := config.InitUserDir()
 		if err != nil {
@@ -83,7 +80,7 @@ func MakeInstallKongIngress() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(kongIngressAppOptions)
+		err = apps.MakeInstallChart(kongIngressAppOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -45,15 +44,12 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 		namespace, _ := command.Flags().GetString("namespace")
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)

--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg/k8s"
 
 	"github.com/alexellis/arkade/pkg"
@@ -27,7 +29,6 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	kubeStateMetrics.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
 	kubeStateMetrics.Flags().StringArray("set", []string{}, "Set individual values in the helm chart")
 
 	kubeStateMetrics.RunE = func(command *cobra.Command, args []string) error {
@@ -41,7 +42,14 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		namespace, _ := command.Flags().GetString("namespace")
+
+		namespace, err := commands.GetNamespace(command.Flags(), "kube-system")
+		if err != nil {
+			return err
+		}
+		if err := commands.CreateNamespace(namespace); err != nil {
+			return err
+		}
 
 		arch := k8s.GetNodeArchitecture()
 

--- a/cmd/apps/kubernetes_dashboard_app.go
+++ b/cmd/apps/kubernetes_dashboard_app.go
@@ -29,9 +29,6 @@ func MakeInstallKubernetesDashboard() *cobra.Command {
 			return err
 		}
 
-		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
-
 		_, err := k8s.KubectlTask("apply", "-f",
 			"https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-rc5/aio/deploy/recommended.yaml")
 		if err != nil {

--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 
@@ -41,7 +40,6 @@ func MakeInstallLinkerd() *cobra.Command {
 		}
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
 		}
@@ -53,11 +51,7 @@ func MakeInstallLinkerd() *cobra.Command {
 
 		arch, clientOS := env.GetClientArch()
 
-		fmt.Printf("Client: %q\n", clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
-		err = downloadLinkerd(userPath, arch, clientOS)
+		err = downloadLinkerd(arch, clientOS)
 		if err != nil {
 			return err
 		}
@@ -115,12 +109,7 @@ linkerd2 --help
 	return linkerd
 }
 
-// func getLinkerdURL(os, version string) string {
-// 	osSuffix := strings.ToLower(os)
-// 	return fmt.Sprintf("https://github.com/linkerd/linkerd2/releases/download/%s/linkerd2-cli-%s-%s", version, version, osSuffix)
-// }
-
-func downloadLinkerd(userPath, arch, clientOS string) error {
+func downloadLinkerd(arch, clientOS string) error {
 
 	tools := get.MakeTools()
 	var tool *get.Tool

--- a/cmd/apps/loki_app.go
+++ b/cmd/apps/loki_app.go
@@ -4,8 +4,11 @@
 package apps
 
 import (
+	"fmt"
 	"os"
 	"path"
+
+	"github.com/alexellis/arkade/pkg/commands"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
@@ -25,16 +28,17 @@ func MakeInstallLoki() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	lokiApp.Flags().StringP("namespace", "n", "default", "The namespace to install loki (default: default")
-	lokiApp.Flags().Bool("update-repo", true, "Update the helm repo")
 	lokiApp.Flags().Bool("persistence", false, "Use a 10Gi Persistent Volume to store data")
 	lokiApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set grafana.enabled=true)")
 	lokiApp.Flags().Bool("grafana", false, "Install Grafana alongside Loki (default: false)")
 
 	lokiApp.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
-		log.Println(kubeConfigPath)
-		namespace, _ := lokiApp.Flags().GetString("namespace")
+		fmt.Println(kubeConfigPath)
+		namespace, err := commands.GetNamespace(command.Flags(), "default")
+		if err != nil {
+			return err
+		}
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err

--- a/cmd/apps/loki_app.go
+++ b/cmd/apps/loki_app.go
@@ -4,7 +4,6 @@
 package apps
 
 import (
-	"log"
 	"os"
 	"path"
 
@@ -43,10 +42,6 @@ func MakeInstallLoki() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
 		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
 			return err
 		}
@@ -84,7 +79,7 @@ func MakeInstallLoki() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(lokiOptions)
+		err = apps.MakeInstallChart(lokiOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg/k8s"
 
 	"github.com/alexellis/arkade/pkg"
@@ -26,8 +28,6 @@ func MakeInstallMetricsServer() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	metricsServer.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
-
 	metricsServer.RunE = func(command *cobra.Command, args []string) error {
 		wait, _ := command.Flags().GetBool("wait")
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
@@ -39,10 +39,12 @@ func MakeInstallMetricsServer() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		namespace, _ := command.Flags().GetString("namespace")
-
-		if namespace != "kube-system" {
-			return fmt.Errorf(`to override the "kube-system", install via tiller`)
+		namespace, err := commands.GetNamespace(command.Flags(), "kube-system")
+		if err != nil {
+			return err
+		}
+		if err := commands.CreateNamespace(namespace); err != nil {
+			return err
 		}
 
 		arch := k8s.GetNodeArchitecture()

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 
@@ -47,11 +46,8 @@ func MakeInstallMetricsServer() *cobra.Command {
 		}
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		clientArch, clientOS := env.GetClientArch()
-		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -50,7 +49,6 @@ func MakeInstallMinio() *cobra.Command {
 		updateRepo, _ := minio.Flags().GetBool("update-repo")
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
@@ -62,9 +60,6 @@ func MakeInstallMinio() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -44,7 +43,6 @@ func MakeInstallMongoDB() *cobra.Command {
 		namespace, _ := command.Flags().GetString("namespace")
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
@@ -56,10 +54,6 @@ func MakeInstallMongoDB() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 

--- a/cmd/apps/nats_connector.go
+++ b/cmd/apps/nats_connector.go
@@ -4,7 +4,6 @@
 package apps
 
 import (
-	"log"
 	"os"
 	"path"
 
@@ -41,10 +40,6 @@ func MakeInstallNATSConnector() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
 		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
 			return err
 		}
@@ -72,7 +67,7 @@ func MakeInstallNATSConnector() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(natsConnectorOptions)
+		err = apps.MakeInstallChart(natsConnectorOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/nats_connector.go
+++ b/cmd/apps/nats_connector.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
@@ -25,14 +27,16 @@ func MakeInstallNATSConnector() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	natsConnectorApp.Flags().StringP("namespace", "n", "openfaas", "The namespace to install NATS connector (default: openfaas")
-	natsConnectorApp.Flags().Bool("update-repo", true, "Update the helm repo")
 	natsConnectorApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set topics=nats-test,)")
 
 	natsConnectorApp.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 
-		namespace, _ := natsConnectorApp.Flags().GetString("namespace")
+		namespace, err := commands.GetNamespace(natsConnectorApp.Flags(), "openfaas")
+		if err != nil {
+			return err
+		}
+
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err

--- a/cmd/apps/nfs_app.go
+++ b/cmd/apps/nfs_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 
@@ -45,10 +44,6 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
 		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
 			return err
 		}
@@ -70,7 +65,6 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 		overrides["nfs.path"] = nfsPath
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if suffix := getValuesSuffix(arch); suffix == "-armhf" || suffix == "-arm64" {
 			overrides["image.repository"] = "quay.io/external_storage/nfs-client-provisioner-arm:latest"
@@ -97,7 +91,7 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(nfsProvisionerOptions)
+		err = apps.MakeInstallChart(nfsProvisionerOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/nfs_app.go
+++ b/cmd/apps/nfs_app.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
@@ -27,16 +29,18 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	nfsProvisionerApp.Flags().StringP("namespace", "n", "default", "The namespace to install nfs-client (default: default")
 	nfsProvisionerApp.Flags().String("nfs-server", "", "IP or hostname of the NFS server ")
 	nfsProvisionerApp.Flags().String("nfs-path", "", "Basepath of the mount point to be used")
-	nfsProvisionerApp.Flags().Bool("update-repo", true, "Update the helm repo")
 	nfsProvisionerApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set =true)")
 
 	nfsProvisionerApp.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 
-		namespace, _ := nfsProvisionerApp.Flags().GetString("namespace")
+		namespace, err := commands.GetNamespace(command.Flags(), "default")
+		if err != nil {
+			return err
+		}
+
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
@@ -29,8 +31,6 @@ flag and the ingress-nginx docs for more info`,
 		SilenceUsage: true,
 	}
 
-	nginx.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
-	nginx.Flags().Bool("update-repo", true, "Update the helm repo")
 	nginx.Flags().Bool("host-mode", false, "If we should install ingress-nginx in host mode.")
 	nginx.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set=image=org/repo:tag)")
 
@@ -46,7 +46,10 @@ flag and the ingress-nginx docs for more info`,
 
 		wait, _ := command.Flags().GetBool("wait")
 
-		namespace, _ := command.Flags().GetString("namespace")
+		namespace, err := commands.GetNamespace(command.Flags(), "default")
+		if err != nil {
+			return err
+		}
 
 		clientArch, clientOS := env.GetClientArch()
 

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 
@@ -51,9 +50,6 @@ flag and the ingress-nginx docs for more info`,
 
 		clientArch, clientOS := env.GetClientArch()
 
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		overrides := map[string]string{}
@@ -90,7 +86,7 @@ flag and the ingress-nginx docs for more info`,
 		if err != nil {
 			return err
 		}
-		_, err = apps.MakeInstallChart(nginxOptions)
+		err = apps.MakeInstallChart(nginxOptions)
 
 		if err != nil {
 			return err

--- a/cmd/apps/of_loki.go
+++ b/cmd/apps/of_loki.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/alexellis/arkade/pkg/commands"
+
 	"github.com/alexellis/arkade/pkg/k8s"
 
 	"github.com/alexellis/arkade/pkg"
@@ -28,8 +30,6 @@ func MakeInstallOpenFaaSLoki() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	OpenFaaSlokiApp.Flags().StringP("namespace", "n", "default", "The namespace to install loki (default: default")
-	OpenFaaSlokiApp.Flags().Bool("update-repo", true, "Update the helm repo")
 	OpenFaaSlokiApp.Flags().String("openfaas-namespace", "openfaas", "set the namespace that OpenFaaS is installed into")
 	OpenFaaSlokiApp.Flags().String("loki-url", "http://loki-stack.default:3100", "set the loki url (default http://loki-stack.default:3100)")
 	OpenFaaSlokiApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set grafana.enabled=true)")
@@ -37,7 +37,11 @@ func MakeInstallOpenFaaSLoki() *cobra.Command {
 	OpenFaaSlokiApp.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 
-		namespace, _ := OpenFaaSlokiApp.Flags().GetString("namespace")
+		namespace, err := commands.GetNamespace(command.Flags(), "default")
+		if err != nil {
+			return err
+		}
+
 		userPath, err := config.InitUserDir()
 		if err != nil {
 			return err

--- a/cmd/apps/of_loki.go
+++ b/cmd/apps/of_loki.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 
@@ -46,10 +45,6 @@ func MakeInstallOpenFaaSLoki() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
 		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
 			return err
 		}
@@ -81,7 +76,7 @@ func MakeInstallOpenFaaSLoki() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(lokiOptions)
+		err = apps.MakeInstallChart(lokiOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -77,7 +76,6 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		}
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		valuesSuffix := getValuesSuffix(arch)
 
@@ -87,8 +85,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
+
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)

--- a/cmd/apps/openfaas_ingress_app.go
+++ b/cmd/apps/openfaas_ingress_app.go
@@ -68,7 +68,6 @@ func MakeInstallOpenFaaSIngress() *cobra.Command {
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		staging, _ := command.Flags().GetBool("staging")
 		clusterIssuer, _ := command.Flags().GetBool("cluster-issuer")

--- a/cmd/apps/osm_app.go
+++ b/cmd/apps/osm_app.go
@@ -6,7 +6,6 @@ package apps
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/alexellis/arkade/pkg/get"
@@ -41,7 +40,6 @@ service mesh created by Microsoft Azure.`,
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
 		}
@@ -52,10 +50,6 @@ service mesh created by Microsoft Azure.`,
 		}
 
 		arch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %q\n", clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
 
 		err = downloadOSM(userPath, arch, clientOS)
 		if err != nil {

--- a/cmd/apps/portainer_app.go
+++ b/cmd/apps/portainer_app.go
@@ -37,7 +37,6 @@ func MakeInstallPortainer() *cobra.Command {
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		_, err := k8s.KubectlTask("create", "ns",
 			"portainer")

--- a/cmd/apps/portainer_app.go
+++ b/cmd/apps/portainer_app.go
@@ -9,7 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"strings"
+
+	"github.com/alexellis/arkade/pkg/commands"
 
 	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/k8s"
@@ -34,16 +35,8 @@ func MakeInstallPortainer() *cobra.Command {
 			return err
 		}
 
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
-
-		arch := k8s.GetNodeArchitecture()
-
-		_, err := k8s.KubectlTask("create", "ns",
-			"portainer")
-		if err != nil {
-			if !strings.Contains(err.Error(), "exists") {
-				return err
-			}
+		if err := commands.CreateNamespace("portainer"); err != nil {
+			return err
 		}
 
 		req, err := http.NewRequest(http.MethodGet,

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -5,7 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strconv"
@@ -46,7 +45,6 @@ func MakeInstallPostgresql() *cobra.Command {
 		updateRepo, _ := postgresql.Flags().GetBool("update-repo")
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
@@ -58,9 +56,6 @@ func MakeInstallPostgresql() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
@@ -103,7 +98,7 @@ func MakeInstallPostgresql() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(postgresqlAppOptions)
+		err = apps.MakeInstallChart(postgresqlAppOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/redis_app.go
+++ b/cmd/apps/redis_app.go
@@ -45,12 +45,8 @@ func MakeInstallRedis() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
 		// exit on arm
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(OnlyIntelArch)
@@ -97,7 +93,7 @@ func MakeInstallRedis() *cobra.Command {
 			return err
 		}
 
-		_, err = apps.MakeInstallChart(redisAppOptions)
+		err = apps.MakeInstallChart(redisAppOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -6,11 +6,8 @@ package apps
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
-
-	"github.com/alexellis/arkade/pkg/k8s"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -61,9 +58,6 @@ func MakeInstallRegistry() *cobra.Command {
 
 		clientArch, clientOS := env.GetClientArch()
 
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
 		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
@@ -107,9 +101,6 @@ func MakeInstallRegistry() *cobra.Command {
 
 		overrides["persistence.enabled"] = "false"
 		overrides["secrets.htpasswd"] = string(htPasswd)
-
-		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		fmt.Println("Chart path: ", chartPath)
 

--- a/cmd/apps/registry_creds_app.go
+++ b/cmd/apps/registry_creds_app.go
@@ -39,7 +39,6 @@ and ARM64 clusters.`,
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		var (
 			username string

--- a/cmd/apps/sealed_secret_app.go
+++ b/cmd/apps/sealed_secret_app.go
@@ -36,7 +36,6 @@ func MakeInstallSealedSecrets() *cobra.Command {
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		wait, _ := command.Flags().GetBool("wait")
 

--- a/cmd/apps/tekton_app.go
+++ b/cmd/apps/tekton_app.go
@@ -31,7 +31,6 @@ func MakeInstallTekton() *cobra.Command {
 		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
 
 		if arch != IntelArch {
 			return fmt.Errorf(`only Intel and AMD (i.e. PC) architecture is supported for this app`)

--- a/cmd/apps/tekton_app.go
+++ b/cmd/apps/tekton_app.go
@@ -28,7 +28,6 @@ func MakeInstallTekton() *cobra.Command {
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		arch := k8s.GetNodeArchitecture()
 

--- a/cmd/apps/traefik2_app.go
+++ b/cmd/apps/traefik2_app.go
@@ -47,7 +47,6 @@ func MakeInstallTraefik2() *cobra.Command {
 		}
 
 		clientArch, clientOS := env.GetClientArch()
-		fmt.Printf("Client: %q\n", clientOS)
 
 		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
 		if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -33,7 +33,8 @@ command.`,
 
 	command.PersistentFlags().String("kubeconfig", "", "Local path for your kubeconfig file")
 	command.PersistentFlags().Bool("wait", false, "If we should wait for the resource to be ready before returning (helm3 only, default false)")
-
+	command.PersistentFlags().Bool("update-repo", true, "Update the helm repo (default true)")
+	command.PersistentFlags().StringP("namespace", "n", "", "set to a value to override the default app namespace")
 	command.RunE = func(command *cobra.Command, args []string) error {
 
 		if len(args) == 0 {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -19,10 +19,7 @@ func MakeUninstall() *cobra.Command {
 		SilenceUsage: false,
 	}
 
-	command.PersistentFlags().String("kubeconfig", "kubeconfig", "Local path for your kubeconfig file")
-	command.PersistentFlags().Bool("wait", false, "If we should wait for the resource to be ready before returning (helm3 only, default false)")
-
-	command.RunE = func(command *cobra.Command, args []string) error {
+	command.Run = func(command *cobra.Command, args []string) {
 
 		if len(args) == 0 {
 			fmt.Printf(
@@ -64,10 +61,8 @@ You can seek out technical support from the OpenFaaS community
 at https://slack.openfaas.io/
 
 `)
-			return nil
 		}
 
-		return nil
 	}
 
 	return command

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/morikuni/aec v1.0.0
 	github.com/sethvargo/go-password v0.1.2
 	github.com/spf13/cobra v0.0.5
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/mod v0.3.0
 )

--- a/pkg/apps/chart_app.go
+++ b/pkg/apps/chart_app.go
@@ -2,12 +2,17 @@ package apps
 
 import (
 	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/commands"
 	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/types"
 )
 
-func MakeInstallChart(options *types.InstallerOptions) (*types.InstallerOutput, error) {
-	result := &types.InstallerOutput{}
+func MakeInstallChart(options *types.InstallerOptions) error {
+	if options.Namespace != "default" {
+		if err := commands.CreateNamespace(options.Namespace); err != nil {
+			return err
+		}
+	}
 
 	if err := config.SetKubeconfig(options.KubeconfigPath); err != nil {
 		return nil, err
@@ -15,11 +20,20 @@ func MakeInstallChart(options *types.InstallerOptions) (*types.InstallerOutput, 
 
 	err := helm.AddHelmRepo(options.Helm.Repo.Name, options.Helm.Repo.URL, options.Helm.UpdateRepo)
 	if err != nil {
-		return result, err
+		return err
 	}
 
 	if err := helm.FetchChart(options.Helm.Repo.Name, options.Helm.Repo.Version); err != nil {
-		return result, err
+		return err
+	}
+
+	// Preinstall commands
+	if len(options.PreChartCommands) > 0 {
+		for _, preCmd := range options.PreChartCommands {
+			if err := preCmd(); err != nil {
+				return err
+			}
+		}
 	}
 
 	if err := helm.Helm3Upgrade(options.Helm.Repo.Name, options.Namespace,
@@ -27,8 +41,20 @@ func MakeInstallChart(options *types.InstallerOptions) (*types.InstallerOutput, 
 		options.Helm.Repo.Version,
 		options.Helm.Overrides,
 		options.Helm.Wait); err != nil {
-		return result, err
+		return err
 	}
 
-	return result, nil
+	// Postinstall commands
+	if len(options.PostChartCommands) == 0 {
+		return nil
+	}
+
+	for _, postCmd := range options.PostChartCommands {
+		err := postCmd()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/apps/chart_app.go
+++ b/pkg/apps/chart_app.go
@@ -1,21 +1,22 @@
 package apps
 
 import (
-	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/commands"
+	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/types"
 )
 
 func MakeInstallChart(options *types.InstallerOptions) error {
-	if options.Namespace != "default" {
+
+	if options.CreateNamespace {
 		if err := commands.CreateNamespace(options.Namespace); err != nil {
 			return err
 		}
 	}
 
 	if err := config.SetKubeconfig(options.KubeconfigPath); err != nil {
-		return nil, err
+		return err
 	}
 
 	err := helm.AddHelmRepo(options.Helm.Repo.Name, options.Helm.Repo.URL, options.Helm.UpdateRepo)

--- a/pkg/commands/create_namespace.go
+++ b/pkg/commands/create_namespace.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/alexellis/arkade/pkg/k8s"
+)
+
+func CreateNamespace(namespace string) error {
+	getNs, err := k8s.KubectlTask("get", "namespace", namespace)
+	if err != nil {
+		return err
+	}
+
+	if getNs.ExitCode == 0 {
+		fmt.Println(fmt.Sprintf("[Info] namespace exists: %s", namespace))
+		return nil
+	}
+
+	nsRes, err := k8s.KubectlTask("create", "namespace", namespace)
+	if err != nil {
+		return err
+	}
+
+	if nsRes.ExitCode != 0 {
+		fmt.Println(fmt.Sprintf("[Error] unable to create namespace %s: %s", namespace, nsRes.Stderr))
+	}
+	fmt.Println(fmt.Sprintf("[Info] namespace created: %s", namespace))
+	return nil
+}

--- a/pkg/commands/namespace.go
+++ b/pkg/commands/namespace.go
@@ -3,10 +3,13 @@ package commands
 import (
 	"fmt"
 
+	"github.com/spf13/pflag"
+
 	"github.com/alexellis/arkade/pkg/k8s"
 )
 
 func CreateNamespace(namespace string) error {
+
 	getNs, err := k8s.KubectlTask("get", "namespace", namespace)
 	if err != nil {
 		return err
@@ -27,4 +30,17 @@ func CreateNamespace(namespace string) error {
 	}
 	fmt.Println(fmt.Sprintf("[Info] namespace created: %s", namespace))
 	return nil
+}
+
+func GetNamespace(flags *pflag.FlagSet, defaultNs string) (string, error) {
+	namespace, err := flags.GetString("namespace")
+	if err != nil {
+		return namespace, err
+	}
+
+	if len(namespace) == 0 {
+		namespace = defaultNs
+	}
+
+	return namespace, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"strings"
@@ -36,6 +37,7 @@ func InitUserDir() (string, error) {
 		return helmPath, helmErr
 	}
 
+	log.Printf("User dir established as: %s\n", root)
 	return root, nil
 }
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -4,6 +4,7 @@
 package env
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path"
@@ -30,6 +31,7 @@ func GetClientArch() (arch string, os string) {
 
 	osResult := strings.TrimSpace(resOS.Stdout)
 
+	fmt.Printf("Client: %s, %s\n", archResult, osResult)
 	return archResult, osResult
 }
 

--- a/pkg/k8s/kubernetes_exec.go
+++ b/pkg/k8s/kubernetes_exec.go
@@ -13,8 +13,9 @@ import (
 func GetNodeArchitecture() string {
 	res, _ := KubectlTask("get", "nodes", `--output`, `jsonpath={range $.items[0]}{.status.nodeInfo.architecture}`)
 
-	arch := strings.TrimSpace(string(res.Stdout))
+	arch := strings.TrimSpace(res.Stdout)
 
+	fmt.Printf("Node architecture: %q\n", arch)
 	return arch
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,6 +12,7 @@ type InstallerOptions struct {
 	Verbose           bool
 	PreChartCommands  []Command
 	PostChartCommands []Command
+	CreateNamespace   bool
 }
 
 type HelmConfig struct {
@@ -87,6 +88,7 @@ func DefaultInstallOptions() *InstallerOptions {
 			Helm3:      true,
 			Wait:       false,
 		},
-		Verbose: false,
+		Verbose:         false,
+		CreateNamespace: true,
 	}
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,12 +2,16 @@ package types
 
 import "github.com/alexellis/arkade/pkg/config"
 
+type Command func() error
+
 type InstallerOptions struct {
-	Namespace      string
-	KubeconfigPath string
-	NodeArch       string
-	Helm           *HelmConfig
-	Verbose        bool
+	Namespace         string
+	KubeconfigPath    string
+	NodeArch          string
+	Helm              *HelmConfig
+	Verbose           bool
+	PreChartCommands  []Command
+	PostChartCommands []Command
 }
 
 type HelmConfig struct {
@@ -27,6 +31,7 @@ type HelmRepo struct {
 }
 
 type InstallerOutput struct {
+	Errors []error
 }
 
 func (o *InstallerOptions) WithKubeconfigPath(path string) *InstallerOptions {


### PR DESCRIPTION
Also remove a lot of duplication and not needed code (lots of duplicated
prints) This was done in 1 PR as it needed to touch a lot of app files anyway so small code removal from each file.

This also sets a global flag of namespace onto the install command, it
then creates GetNamespace and CreateNamespace functions to allow a
single place to get and create namespaces.

The new style chart_app runs create namespace for you now, on an
existing namespace the function prints a namespace exists message.
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds a pre and post install commands (a list of any functions that return error) to the chart app, they are  run in list order if they are not empty.

Also this runs a new namespace create (if not exists) command for the chart apps.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#21 
closes #13 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
build, make test and installation of some apps (checking namespaces created, checked etc)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
