### PR TITLE
Added kubens as tool and bumped version version of kubectx

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -106,7 +106,28 @@ func Test_DownloadKubectx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "https://github.com/ahmetb/kubectx/releases/download/v0.9.0/kubectx"
+	want := "https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubectx"
+	if got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}
+
+func Test_DownloadKubens(t *testing.T) {
+	tools := MakeTools()
+	name := "kubens"
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	got, err := tool.GetURL("linux", arch64bit, tool.Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens"
 	if got != want {
 		t.Fatalf("want: %s, got: %s", want, got)
 	}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -74,9 +74,18 @@ https://storage.googleapis.com/kubernetes-release/release/{{.Version}}/bin/{{$os
 			Owner:       "ahmetb",
 			Repo:        "kubectx",
 			Name:        "kubectx",
-			Version:     "v0.9.0",
+			Version:     "v0.9.1",
 			URLTemplate: `https://github.com/ahmetb/kubectx/releases/download/{{.Version}}/kubectx`,
-			// Author recommends to keep using Bash version in this release https://github.com/ahmetb/kubectx/releases/tag/v0.9.0
+			NoExtension: true,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "ahmetb",
+			Repo:        "kubectx",
+			Name:        "kubens",
+			Version:     "v0.9.1",
+			URLTemplate: `https://github.com/ahmetb/kubectx/releases/download/{{.Version}}/kubens`,
 			NoExtension: true,
 		})
 


### PR DESCRIPTION
Added Kubens as tool and bumped the version of kubectx to v0.9.1

## Description
updated the version of kubectx to v0.9.1 and als added kubens as tool for fast namespace switching inside a kubernetes context

## Motivation and Context
New tool
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/alexellis/arkade/issues/249


## How Has This Been Tested?
```
make test
make build
./arkade get kubectx
./arkade get kubens
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
