### PR TITLE
remove trydownloadhelm since we did it twice here

### DIFF
--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -101,8 +101,12 @@ func MakeInstallCertManager() *cobra.Command {
 			WithHelmURL("https://charts.jetstack.io").
 			WithOverrides(overrides).
 			WithWait(wait).
-			WithHelmUpdateRepo(updateRepo).
-			WithKubeconfigPath(kubeConfigPath)
+			WithHelmUpdateRepo(updateRepo)
+
+		if command.Flags().Changed("kubeconfig") {
+			kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
+			certmanagerOptions.WithKubeconfigPath(kubeConfigPath)
+		}
 
 		_, err = apps.MakeInstallChart(certmanagerOptions)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <me@tuananh.org>

we call `TryDownloadHelm` twice here so I remove it.

## Description

we call `TryDownloadHelm` twice here so I remove it.

## Motivation and Context

Unnecessary call to `TryDownloadHelm`

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

- create cluster with kind
- test `./arkade install cert-manager` still works

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
