### PR TITLE
Upgrade issuers to cert-manager v1

### DIFF
--- a/cmd/apps/openfaas_ingress_app.go
+++ b/cmd/apps/openfaas_ingress_app.go
@@ -68,7 +68,6 @@ func MakeInstallOpenFaaSIngress() *cobra.Command {
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		staging, _ := command.Flags().GetBool("staging")
 		clusterIssuer, _ := command.Flags().GetBool("cluster-issuer")
@@ -244,7 +243,7 @@ spec:
     - {{.IngressDomain}}
     secretName: {{.IngressName}}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 {{- if .ClusterIssuer }}
 kind: ClusterIssuer
 {{- else }}
@@ -262,6 +261,7 @@ spec:
     privateKeySecretRef:
       name: example-issuer-account-key
     solvers:
-    - http01:
+    - selector: {}
+      http01:
         ingress:
           class: {{.IngressClass}}`

--- a/cmd/apps/openfaas_ingress_app_test.go
+++ b/cmd/apps/openfaas_ingress_app_test.go
@@ -35,7 +35,7 @@ spec:
     - openfaas.subdomain.example.com
     secretName: openfaas-gateway
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-prod
@@ -47,7 +47,8 @@ spec:
     privateKeySecretRef:
       name: example-issuer-account-key
     solvers:
-    - http01:
+    - selector: {}
+      http01:
         ingress:
           class: traefik`
 
@@ -82,7 +83,7 @@ spec:
     - openfaas.subdomain.example.com
     secretName: openfaas-gateway
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-staging
@@ -94,7 +95,8 @@ spec:
     privateKeySecretRef:
       name: example-issuer-account-key
     solvers:
-    - http01:
+    - selector: {}
+      http01:
         ingress:
           class: traefik`
 
@@ -129,7 +131,7 @@ spec:
     - openfaas.subdomain.example.com
     secretName: openfaas-gateway
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -140,7 +142,8 @@ spec:
     privateKeySecretRef:
       name: example-issuer-account-key
     solvers:
-    - http01:
+    - selector: {}
+      http01:
         ingress:
           class: traefik`
 

--- a/cmd/apps/registry_ingress_app.go
+++ b/cmd/apps/registry_ingress_app.go
@@ -191,7 +191,7 @@ spec:
     - {{.IngressDomain}}
     secretName: docker-registry
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{.IssuerType}}


### PR DESCRIPTION
## Description
This upgrades the issuers in ingress apps to v1 cert manager API

Tested by installing and creting ingresses with arkade

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Describe your changes in detail -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #253
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
