### PR TITLE
Add Sponsored Apps for Venafi

### DIFF
--- a/cmd/venafi/cloud_issuer.go
+++ b/cmd/venafi/cloud_issuer.go
@@ -1,0 +1,28 @@
+package venafi
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// MakeCloudIssuer makes an app for the Venafi Cloud issuer
+func MakeCloudIssuer() *cobra.Command {
+
+	command := &cobra.Command{
+		Use:   "cloud-issuer",
+		Short: "Install the cert-manager issuer for Venafi cloud",
+		Long: `Install the cert-manager issuer for Venafi cloud to obtain 
+TLS certificates from enterprise-grade CAs.`,
+		Example: `  arkade venafi install cloud-issuer
+  arkade venafi install cloud-issuer --help`,
+		SilenceUsage: true,
+	}
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Installing the cloud-issuer for you now.")
+		return nil
+	}
+
+	return command
+}

--- a/cmd/venafi/cloud_issuer.go
+++ b/cmd/venafi/cloud_issuer.go
@@ -32,30 +32,37 @@ https://www.venafi.com/venaficloud/devopsaccelerate`,
 	command.Flags().StringP("secret-file", "f", "", "Your Venafi cloud secret from a file")
 	command.Flags().String("namespace", "default", "Namespace for the issuer")
 	command.Flags().String("name", "cloud-venafi-issuer", "Name for the issuer")
-	command.Flags().StringP("zone", "z", "", "The zone for Venafi cloud")
-
-	command.RunE = func(cmd *cobra.Command, args []string) error {
-		name, err := command.Flags().GetString("name")
-		if err != nil {
-			return err
-		}
-		clusterIssuer, err := command.Flags().GetBool("cluster-issuer")
-		if err != nil {
-			return err
-		}
-		namespace, err := command.Flags().GetString("namespace")
-		if err != nil {
-			return err
-		}
-
+	command.Flags().StringP("zone", "z", "", "The zone for the issuer")
+	command.PreRunE = func(cmd *cobra.Command, args []string) error {
 		zone, err := command.Flags().GetString("zone")
 		if err != nil {
 			return err
 		}
-
 		if len(zone) == 0 {
 			return fmt.Errorf("a zone is required")
 		}
+		_, err = command.Flags().GetString("name")
+		if err != nil {
+			return err
+		}
+		_, err = command.Flags().GetBool("cluster-issuer")
+		if err != nil {
+			return err
+		}
+		_, err = command.Flags().GetString("namespace")
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		name, _ := command.Flags().GetString("name")
+		clusterIssuer, _ := command.Flags().GetBool("cluster-issuer")
+		namespace, _ := command.Flags().GetString("namespace")
+
+		zone, _ := command.Flags().GetString("zone")
+
 		kind := "Issuer"
 		if clusterIssuer {
 			kind = "ClusterIssuer"
@@ -123,6 +130,7 @@ Zone: %s
 		if res.ExitCode != 0 {
 			return fmt.Errorf(`unable to apply %s, error: %s`, p, res.Stderr)
 		}
+
 		fmt.Println(res.Stdout)
 
 		// Check for error, mention to install cert-manager

--- a/cmd/venafi/cloud_issuer.go
+++ b/cmd/venafi/cloud_issuer.go
@@ -1,8 +1,15 @@
 package venafi
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"text/template"
 
+	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/spf13/cobra"
 )
 
@@ -13,14 +20,17 @@ func MakeCloudIssuer() *cobra.Command {
 		Use:   "cloud-issuer",
 		Short: "Install the cert-manager issuer for Venafi cloud",
 		Long: `Install the cert-manager issuer for Venafi cloud to obtain 
-TLS certificates from enterprise-grade CAs.`,
+TLS certificates from enterprise-grade CAs.
+
+Register and download your secret from your dashboard at:
+https://www.venafi.com/venaficloud/devopsaccelerate`,
 		Example: `  arkade venafi install cloud-issuer
   arkade venafi install cloud-issuer --help`,
 		SilenceUsage: true,
 	}
 
-	command.Flags().String("cloud-secret", "", "Your Venafi cloud secret")
-	command.Flags().StringP("cloud-secret-file", "f", "", "Your Venafi cloud secret from a file")
+	command.Flags().String("secret", "", "Your Venafi cloud secret")
+	command.Flags().StringP("secret-file", "f", "", "Your Venafi cloud secret from a file")
 	command.Flags().String("namespace", "default", "Namespace for the issuer")
 	command.Flags().String("name", "cloud-venafi-issuer", "Name for the issuer")
 	command.Flags().StringP("zone", "z", "", "The zone for Venafi cloud")
@@ -44,16 +54,88 @@ TLS certificates from enterprise-grade CAs.`,
 			return fmt.Errorf("a zone is required")
 		}
 
+		// 	kubectl create secret generic \
+		//    cloud-secret \
+		//    --namespace='NAMESPACE OF YOUR ISSUER RESOURCE' \
+		//    --from-literal=apikey='YOUR_CLOUD_API_KEY_HERE'
+
+		tokenFileName, _ := command.Flags().GetString("secret-file")
+		tokenString, _ := command.Flags().GetString("secret")
+
+		var accessKeyFrom, accessKeyValue string
+		if len(tokenFileName) > 0 {
+			accessKeyFrom = "--from-file"
+			accessKeyValue = tokenFileName
+		} else if len(tokenString) > 0 {
+			accessKeyFrom = "--from-literal"
+			accessKeyValue = tokenString
+		} else {
+			return fmt.Errorf(`--secret or secret-file is a required`)
+		}
+
 		fmt.Printf(`Installing the cloud-issuer for you now.
 Name: %s
 Namespace: %s
 Zone: %s
 
 `, name, namespace, zone)
-		// 	kubectl create secret generic \
-		//    cloud-secret \
-		//    --namespace='NAMESPACE OF YOUR ISSUER RESOURCE' \
-		//    --from-literal=apikey='YOUR_CLOUD_API_KEY_HERE'
+		clusterSecretName := name + "-secret"
+		res, err := k8s.KubectlTask("create", "secret", "generic",
+			clusterSecretName,
+			"--namespace="+namespace,
+			accessKeyFrom, "apikey="+accessKeyValue)
+
+		if err != nil {
+			return err
+		} else if len(res.Stderr) > 0 && strings.Contains(res.Stderr, "AlreadyExists") {
+			fmt.Printf("[Warning] secret %s already exists and will be used\n", clusterSecretName)
+		} else if len(res.Stderr) > 0 {
+			return fmt.Errorf("error from kubectl\n%q", res.Stderr)
+		}
+
+		tmpl, err := template.New("yaml").Parse(issuerTemplate)
+
+		if err != nil {
+			return err
+		}
+
+		var tpl bytes.Buffer
+
+		err = tmpl.Execute(&tpl, struct {
+			Name      string
+			Namespace string
+			Zone      string
+		}{
+			Name:      name,
+			Namespace: namespace,
+			Zone:      zone,
+		})
+
+		if err != nil {
+			return err
+		}
+
+		d := os.TempDir()
+		p := path.Join(d, "issuer.yaml")
+
+		err = ioutil.WriteFile(p, tpl.Bytes(), os.ModePerm)
+		if err != nil {
+			return err
+		}
+
+		res, err = k8s.KubectlTask("apply", "-f", p)
+
+		if err != nil {
+			return err
+		}
+
+		if res.ExitCode != 0 {
+			return fmt.Errorf(`unable to apply %s, error: %s`, p, res.Stderr)
+		}
+		fmt.Println(res.Stdout)
+
+		// Check for error, mention to install cert-manager
+		//no matches for kind "Issuer"
 
 		fmt.Println(`# Query the status of the issuer:
 kubectl get issuer ` + name + ` -n ` + namespace + ` -o wide
@@ -81,9 +163,9 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   venafi:
-    zone: "{{.Zone}}" # Set this to the Venafi policy zone you want to use
+    zone: "{{.Zone}}"
     cloud:
       apiTokenSecretRef:
-        name: cloud-secret
-		key: apikey
+        name: {{.Name}}-secret
+        key: apikey
 `

--- a/cmd/venafi/cloud_issuer.go
+++ b/cmd/venafi/cloud_issuer.go
@@ -19,10 +19,71 @@ TLS certificates from enterprise-grade CAs.`,
 		SilenceUsage: true,
 	}
 
+	command.Flags().String("cloud-secret", "", "Your Venafi cloud secret")
+	command.Flags().StringP("cloud-secret-file", "f", "", "Your Venafi cloud secret from a file")
+	command.Flags().String("namespace", "default", "Namespace for the issuer")
+	command.Flags().String("name", "cloud-venafi-issuer", "Name for the issuer")
+	command.Flags().StringP("zone", "z", "", "The zone for Venafi cloud")
+
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Installing the cloud-issuer for you now.")
+		name, err := command.Flags().GetString("name")
+		if err != nil {
+			return err
+		}
+		namespace, err := command.Flags().GetString("namespace")
+		if err != nil {
+			return err
+		}
+
+		zone, err := command.Flags().GetString("zone")
+		if err != nil {
+			return err
+		}
+
+		if len(zone) == 0 {
+			return fmt.Errorf("a zone is required")
+		}
+
+		fmt.Printf(`Installing the cloud-issuer for you now.
+Name: %s
+Namespace: %s
+Zone: %s
+
+`, name, namespace, zone)
+		// 	kubectl create secret generic \
+		//    cloud-secret \
+		//    --namespace='NAMESPACE OF YOUR ISSUER RESOURCE' \
+		//    --from-literal=apikey='YOUR_CLOUD_API_KEY_HERE'
+
+		fmt.Println(`# Query the status of the issuer:
+kubectl get issuer ` + name + ` -n ` + namespace + ` -o wide
+
+# Find out how to issue a certificate with cert-manager:
+# https://cert-manager.io/docs/usage/certificate/
+`)
+
 		return nil
 	}
 
 	return command
 }
+
+const CloudIssuerInfo = `# Check the status of the issuer:
+kubectl get issuer name -n namespace -o wide
+
+# Find out how to issue a certificate with cert-manager:
+# https://cert-manager.io/docs/usage/certificate/`
+
+const issuerTemplate = `apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{.Name}}
+  namespace: {{.Namespace}}
+spec:
+  venafi:
+    zone: "{{.Zone}}" # Set this to the Venafi policy zone you want to use
+    cloud:
+      apiTokenSecretRef:
+        name: cloud-secret
+		key: apikey
+`

--- a/cmd/venafi/cloud_issuer.go
+++ b/cmd/venafi/cloud_issuer.go
@@ -1,3 +1,6 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package venafi
 
 import (

--- a/cmd/venafi/cloud_issuer.go
+++ b/cmd/venafi/cloud_issuer.go
@@ -119,7 +119,7 @@ Zone: %s
 			return err
 		}
 
-		p, err := writeFile("issuer.yaml", manifest)
+		p, err := writeFile("cloud-issuer.yaml", manifest)
 
 		res, err = k8s.KubectlTask("apply", "-f", p)
 

--- a/cmd/venafi/common.go
+++ b/cmd/venafi/common.go
@@ -1,0 +1,36 @@
+package venafi
+
+import (
+	"bytes"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+func writeFile(name string, data []byte) (string, error) {
+	d := os.TempDir()
+	p := path.Join(d, "issuer.yaml")
+
+	err := ioutil.WriteFile(p, data, os.ModePerm)
+
+	return p, err
+}
+
+func templateManifest(templateSt string, data interface{}) ([]byte, error) {
+	tmpl, err := template.New("yaml").Parse(templateSt)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var tpl bytes.Buffer
+
+	err = tmpl.Execute(&tpl, data)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tpl.Bytes(), err
+}

--- a/cmd/venafi/common.go
+++ b/cmd/venafi/common.go
@@ -1,3 +1,6 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package venafi
 
 import (

--- a/cmd/venafi/info.go
+++ b/cmd/venafi/info.go
@@ -1,0 +1,29 @@
+package venafi
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeInfo() *cobra.Command {
+
+	command := &cobra.Command{
+		Use:          "info",
+		Short:        "Info for an app",
+		Long:         `Info for an app`,
+		Example:      `  arkade venafi info [APP]`,
+		SilenceUsage: true,
+	}
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("give an app as an argument")
+		}
+		fmt.Printf("Info for your app: %s\n", args[0])
+
+		return nil
+	}
+
+	return command
+}

--- a/cmd/venafi/info.go
+++ b/cmd/venafi/info.go
@@ -20,7 +20,13 @@ func MakeInfo() *cobra.Command {
 		if len(args) == 0 {
 			return fmt.Errorf("give an app as an argument")
 		}
-		fmt.Printf("Info for your app: %s\n", args[0])
+
+		info := "None found."
+		if args[0] == "cloud-issuer" {
+			info = CloudIssuerInfo
+		}
+
+		fmt.Printf("Info for your app: %s\n\n%s\n\n", args[0], info)
 
 		return nil
 	}

--- a/cmd/venafi/info.go
+++ b/cmd/venafi/info.go
@@ -1,3 +1,6 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package venafi
 
 import (

--- a/cmd/venafi/info.go
+++ b/cmd/venafi/info.go
@@ -27,6 +27,8 @@ func MakeInfo() *cobra.Command {
 		info := "None found."
 		if args[0] == "cloud-issuer" {
 			info = CloudIssuerInfo
+		} else if args[0] == "tpp-issuer" {
+			info = TPPIssuerInfo
 		}
 
 		fmt.Printf("Info for your app: %s\n\n%s\n\n", args[0], info)

--- a/cmd/venafi/install.go
+++ b/cmd/venafi/install.go
@@ -5,9 +5,10 @@ import "github.com/spf13/cobra"
 func MakeInstall() *cobra.Command {
 
 	command := &cobra.Command{
-		Use:   "install",
-		Short: "Install Sponsored Apps for Venafi",
-		Long:  `Install Sponsored Apps for Venafi`,
+		Use:     "install",
+		Short:   "Install Sponsored Apps for Venafi",
+		Long:    `Install Sponsored Apps for Venafi`,
+		Aliases: []string{"i"},
 		Example: `  arkade venafi install [APP]
   arkade venafi install --help`,
 		SilenceUsage: true,

--- a/cmd/venafi/install.go
+++ b/cmd/venafi/install.go
@@ -1,3 +1,6 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package venafi
 
 import "github.com/spf13/cobra"

--- a/cmd/venafi/install.go
+++ b/cmd/venafi/install.go
@@ -1,0 +1,20 @@
+package venafi
+
+import "github.com/spf13/cobra"
+
+func MakeInstall() *cobra.Command {
+
+	command := &cobra.Command{
+		Use:   "install",
+		Short: "Install Sponsored Apps for Venafi",
+		Long:  `Install Sponsored Apps for Venafi`,
+		Example: `  arkade venafi install [APP]
+  arkade venafi install --help`,
+		SilenceUsage: true,
+	}
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		return cmd.Usage()
+	}
+	return command
+}

--- a/cmd/venafi/root.go
+++ b/cmd/venafi/root.go
@@ -14,6 +14,7 @@ func MakeVenafi() *cobra.Command {
 		Short: "Sponsored Apps for Venafi",
 		Long: `Sponsored apps for Venafi.com. Venafi specialises in Machine Identity and 
 support for cert-manager.`,
+		Aliases: []string{"v"},
 		Example: `  arkade venafi install [APP]
   arkade venafi info [APP]`,
 		SilenceUsage: true,
@@ -21,9 +22,6 @@ support for cert-manager.`,
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		return cmd.Usage()
-
-		// return nil
-
 	}
 
 	install := MakeInstall()

--- a/cmd/venafi/root.go
+++ b/cmd/venafi/root.go
@@ -1,0 +1,34 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package venafi
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func MakeVenafi() *cobra.Command {
+
+	command := &cobra.Command{
+		Use:   "venafi",
+		Short: "Sponsored Apps - Venafi",
+		Long: `Sponsored apps by Venafi.com. Venafi specialises in Machine Identity and is 
+the custodian of cert-manager`,
+		Example: `  arkade venafi install [APP]
+  arkade venafi info [APP]
+  arkade venafi --help
+  arkade venafi install --help`,
+		SilenceUsage: true,
+	}
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		fmt.Println("No apps available yet")
+
+		return nil
+
+	}
+
+	return command
+}

--- a/cmd/venafi/root.go
+++ b/cmd/venafi/root.go
@@ -4,8 +4,6 @@
 package venafi
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -13,22 +11,26 @@ func MakeVenafi() *cobra.Command {
 
 	command := &cobra.Command{
 		Use:   "venafi",
-		Short: "Sponsored Apps - Venafi",
-		Long: `Sponsored apps by Venafi.com. Venafi specialises in Machine Identity and is 
-the custodian of cert-manager`,
+		Short: "Sponsored Apps for Venafi",
+		Long: `Sponsored apps for Venafi.com. Venafi specialises in Machine Identity and 
+support for cert-manager.`,
 		Example: `  arkade venafi install [APP]
-  arkade venafi info [APP]
-  arkade venafi --help
-  arkade venafi install --help`,
+  arkade venafi info [APP]`,
 		SilenceUsage: true,
 	}
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
-		fmt.Println("No apps available yet")
+		return cmd.Usage()
 
-		return nil
+		// return nil
 
 	}
+
+	install := MakeInstall()
+	install.AddCommand(MakeCloudIssuer())
+	install.AddCommand(MakeTPPIssuer())
+	command.AddCommand(install)
+	command.AddCommand(MakeInfo())
 
 	return command
 }

--- a/cmd/venafi/root.go
+++ b/cmd/venafi/root.go
@@ -1,6 +1,7 @@
 // Copyright (c) arkade author(s) 2020. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// venafi contains a suite of Sponsored Apps for arkade
 package venafi
 
 import (

--- a/cmd/venafi/templates_test.go
+++ b/cmd/venafi/templates_test.go
@@ -1,0 +1,86 @@
+package venafi
+
+import (
+	"testing"
+)
+
+func TestCloudIssuerTemplate_NamespacedIssuer(t *testing.T) {
+	manifest, err := templateManifest(cloudIssuerTemplate, struct {
+		Name      string
+		Namespace string
+		Zone      string
+		Kind      string
+	}{
+		Name:      "cloud",
+		Namespace: "default",
+		Zone:      "dev",
+		Kind:      "Issuer",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Uncomment to capture formatted results
+	// ioutil.WriteFile("/tmp/test.yaml", manifest, os.ModePerm)
+	want := `apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cloud
+  namespace: default
+spec:
+  venafi:
+    zone: "dev"
+    cloud:
+      apiTokenSecretRef:
+        name: cloud-secret
+        key: apikey
+`
+	got := string(manifest)
+	if got != want {
+		t.Errorf(`want
+%q
+but got
+%q`, want, got)
+	}
+}
+
+func TestCloudIssuerTemplate_ClusterIssuer(t *testing.T) {
+	manifest, err := templateManifest(cloudIssuerTemplate, struct {
+		Name      string
+		Namespace string
+		Zone      string
+		Kind      string
+	}{
+		Name:      "cloud",
+		Namespace: "default",
+		Zone:      "dev",
+		Kind:      "ClusterIssuer",
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Uncomment to capture formatted results
+	// ioutil.WriteFile("/tmp/test.yaml", manifest, os.ModePerm)
+	want := `apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cloud
+spec:
+  venafi:
+    zone: "dev"
+    cloud:
+      apiTokenSecretRef:
+        name: cloud-secret
+        key: apikey
+`
+	got := string(manifest)
+	if got != want {
+		t.Errorf(`want
+%q
+but got
+%q`, want, got)
+	}
+}

--- a/cmd/venafi/templates_test.go
+++ b/cmd/venafi/templates_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package venafi
 
 import (

--- a/cmd/venafi/tpp_issuer.go
+++ b/cmd/venafi/tpp_issuer.go
@@ -1,0 +1,29 @@
+package venafi
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// MakeTPPIssuer makes the app for the TPP issuer
+func MakeTPPIssuer() *cobra.Command {
+
+	command := &cobra.Command{
+		Use:   "tpp-issuer",
+		Short: "Install the cert-manager issuer for Venafi TPP",
+		Long: `Install the cert-manager issuer for Venafi TPP to obtain 
+TLS certificates from enterprise-grade CAs from self-hosted Venafi 
+instances.`,
+		Example: `  arkade venafi install cloud-issuer
+  arkade venafi install tpp-issuer --help`,
+		SilenceUsage: true,
+	}
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Installing the TPP issuer for you now.")
+		return nil
+	}
+
+	return command
+}

--- a/cmd/venafi/tpp_issuer.go
+++ b/cmd/venafi/tpp_issuer.go
@@ -23,10 +23,70 @@ instances.`,
 		SilenceUsage: true,
 	}
 
+	command.Flags().String("name", "tpp-venafi-issuer", "The name for the Issuer")
+	command.Flags().String("namespace", "default", "The Kubernetes namespace for the Issuer")
+	command.Flags().Bool("cluster-issuer", false, "Use a ClusterIssuer instead of an Issuer for the given namespace")
+	command.Flags().String("url", "", "The URL for your TPP server")
+	command.Flags().StringP("username", "u", "", "Your TPP username")
+	command.Flags().StringP("password", "p", "", "Your TPP password")
+
+	command.PreRunE = func(cmd *cobra.Command, args []string) error {
+		username, err := cmd.Flags().GetString("username")
+		if err != nil {
+			return err
+		}
+		if len(username) == 0 {
+			return fmt.Errorf("username is required")
+		}
+		password, err := cmd.Flags().GetString("password")
+		if err != nil {
+			return err
+		}
+		if len(password) == 0 {
+			return fmt.Errorf("password is required")
+		}
+		url, err := cmd.Flags().GetString("url")
+		if err != nil {
+			return err
+		}
+		if len(url) == 0 {
+			return fmt.Errorf("url is required")
+		}
+		_, err = cmd.Flags().GetBool("cluster-issuer")
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		fmt.Println("Installing the TPP issuer for you now.")
+		username, _ := cmd.Flags().GetString("username")
+		password, _ := cmd.Flags().GetString("password")
+		url, _ := cmd.Flags().GetString("url")
+		name, _ := cmd.Flags().GetString("name")
+		clusterIssuer, _ := cmd.Flags().GetBool("cluster-issuer")
+
+		fmt.Println(url, username, password, name, clusterIssuer)
 		return nil
 	}
 
 	return command
 }
+
+const tppIssuerTemplate = `apiVersion: cert-manager.io/v1
+kind: {{.Kind}}
+metadata:
+  name: {{.Name}}
+{{- if eq .Kind "Issuer" }}
+  namespace: {{.Namespace}}
+{{- end }}
+spec:
+  venafi:
+    zone: "{{.Zone}}"
+    tpp:
+      url: {{.URL}}
+      caBundle: {{.CABundle}}
+      credentialsRef:
+        name: {{.Name}}-secret
+`

--- a/cmd/venafi/tpp_issuer.go
+++ b/cmd/venafi/tpp_issuer.go
@@ -1,3 +1,6 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 package venafi
 
 import (

--- a/cmd/venafi/tpp_issuer.go
+++ b/cmd/venafi/tpp_issuer.go
@@ -156,7 +156,7 @@ instances.`,
 			return err
 		}
 
-		p, err := writeFile("issuer.yaml", manifest)
+		p, err := writeFile("tpp-issuer.yaml", manifest)
 
 		res, err = k8s.KubectlTask("apply", "-f", p)
 
@@ -170,11 +170,24 @@ instances.`,
 
 		fmt.Println(res.Stdout)
 
+		fmt.Println(`# Query the status of the issuer:
+kubectl get issuer ` + name + ` -n ` + namespace + ` -o wide
+
+# Find out how to issue a certificate with cert-manager:
+# https://cert-manager.io/docs/usage/certificate/
+		`)
+
 		return nil
 	}
 
 	return command
 }
+
+const TPPIssuerInfo = `# Check the status of the issuer:
+kubectl get issuer name -n namespace -o wide
+
+# Find out how to issue a certificate with cert-manager:
+# https://cert-manager.io/docs/usage/certificate/`
 
 const tppIssuerTemplate = `apiVersion: cert-manager.io/v1
 kind: {{.Kind}}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/morikuni/aec v1.0.0
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-password v0.1.2
 	github.com/spf13/cobra v1.1.1
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,9 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/alexellis/arkade/cmd"
+	"github.com/alexellis/arkade/cmd/venafi"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +34,8 @@ func main() {
 	rootCmd.AddCommand(cmd.MakeGet())
 	rootCmd.AddCommand(cmd.MakeUninstall())
 	rootCmd.AddCommand(cmd.MakeShellCompletion())
+
+	rootCmd.AddCommand(venafi.MakeVenafi())
 
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add Sponsored Apps for Venafi as part of the [Dev Fund](https://venafi.com/blog/venafi-adds-30th-developer-machine-identity-management-development-fund)

## Motivation and Context

This fixes #236 

A dedicated `venafi` command will be added which makes it easy to install the two cert-manager issuer types for Venafi's enterprise Machine Identity products.

Example:

```bash
arkade venafi install cloud-issuer \
  --zone dev \
  --secret-file ../devops-api.txt \
  --cluster-issuer
```

An alias also makes the command shorter if required `arkade v i cloud-issuer`

TPP example:

```bash
arkade venafi install tpp-issuer \
  --url https://tpp.venafidemo.com/vedsdk/ \
  --zone arkade
```

The `--ca-bundle` flag is optional.

Additional documentation: https://cert-manager.io/docs/configuration/venafi/

## How Has This Been Tested?

The cloud-issuer app has been tested and it created the issuer as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
