### PR TITLE
Add a WithSecrets to App installer

### DIFF
--- a/ci/hashgen.sh
+++ b/ci/hashgen.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-for f in bin/arkade*; do shasum -a 256 $f > $f.sha256; done

--- a/pkg/apps/chart_app.go
+++ b/pkg/apps/chart_app.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 )
 
@@ -11,6 +12,12 @@ func MakeInstallChart(options *types.InstallerOptions) (*types.InstallerOutput, 
 
 	if err := config.SetKubeconfig(options.KubeconfigPath); err != nil {
 		return nil, err
+	}
+
+	for _, secret := range options.Secrets {
+		if err := k8s.CreateSecret(secret); err != nil {
+			return nil, err
+		}
 	}
 
 	err := helm.AddHelmRepo(options.Helm.Repo.Name, options.Helm.Repo.URL, options.Helm.UpdateRepo)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,10 +12,16 @@ type InstallerOptions struct {
 }
 
 type K8sSecret struct {
-	Type      string
-	Name      string
-	KeyValues map[string]string
-	Namespace string
+	Type       string
+	Name       string
+	SecretData []SecretsData
+	Namespace  string
+}
+
+type SecretsData struct {
+	Type  string // file or literal
+	Key   string
+	Value string
 }
 
 type HelmConfig struct {
@@ -104,13 +110,15 @@ func DefaultInstallOptions() *InstallerOptions {
 	}
 }
 
-func NewGenericSecret(name, namespace string, secretData map[string]string) K8sSecret {
+func NewGenericSecret(name, namespace string, secretData []SecretsData) K8sSecret {
 	return K8sSecret{
-		Type:      KubernetesGenericSecret,
-		Name:      name,
-		Namespace: namespace,
-		KeyValues: secretData,
+		Type:       KubernetesGenericSecret,
+		Name:       name,
+		Namespace:  namespace,
+		SecretData: secretData,
 	}
 }
 
 const KubernetesGenericSecret = "generic"
+const StringLiteralSecret = "string-literal"
+const FromFileSecret = "from-file"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -8,6 +8,14 @@ type InstallerOptions struct {
 	NodeArch       string
 	Helm           *HelmConfig
 	Verbose        bool
+	Secrets        []K8sSecret
+}
+
+type K8sSecret struct {
+	Type      string
+	Name      string
+	KeyValues map[string]string
+	Namespace string
 }
 
 type HelmConfig struct {
@@ -69,6 +77,16 @@ func (o *InstallerOptions) WithOverrides(overrides map[string]string) *Installer
 	return o
 }
 
+func (o *InstallerOptions) WithValuesFile(filename string) *InstallerOptions {
+	o.Helm.ValuesFile = filename
+	return o
+}
+
+func (o *InstallerOptions) WithSecret(secret K8sSecret) *InstallerOptions {
+	o.Secrets = append(o.Secrets, secret)
+	return o
+}
+
 func DefaultInstallOptions() *InstallerOptions {
 	return &InstallerOptions{
 		Namespace:      "default",
@@ -85,3 +103,14 @@ func DefaultInstallOptions() *InstallerOptions {
 		Verbose: false,
 	}
 }
+
+func NewGenericSecret(name, namespace string, secretData map[string]string) K8sSecret {
+	return K8sSecret{
+		Type:      KubernetesGenericSecret,
+		Name:      name,
+		Namespace: namespace,
+		KeyValues: secretData,
+	}
+}
+
+const KubernetesGenericSecret = "generic"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This converts OpenFaaS to the new app style and adds a .WithSecret() to
app options. This can be used to create a basic secret for now (the
default k8s type of generic) - It could be extended in the future to
create other k8s secret types.


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #267 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by installing OpenFaaS On a k3d cluster and logging in to the UI
(thich uses the basic auth secret)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
