### PR TITLE
Allow acme boolean flag to enable lego behavior with default issuer

### DIFF
--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -4,14 +4,26 @@
 package apps
 
 import (
+	"bytes"
 	"fmt"
+	"log"
+
+	"text/template"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 	"golang.org/x/mod/semver"
 )
+
+type IssuerInput struct {
+	CertmanagerEmail string
+	IngressClass     string
+	IssuerName       string
+	IssuerAPI        string
+}
 
 func MakeInstallCertManager() *cobra.Command {
 	var certManager = &cobra.Command{
@@ -25,6 +37,12 @@ func MakeInstallCertManager() *cobra.Command {
 	certManager.Flags().StringP("namespace", "n", "cert-manager", "The namespace to install cert-manager")
 	certManager.Flags().StringP("version", "v", "v1.5.4", "The version of cert-manager to install, has to be >= v1.0.0")
 	certManager.Flags().Bool("update-repo", true, "Update the helm repo")
+	// Acme options
+	certManager.Flags().Bool("acme", false, "Enable automated usage of kubernetes.io/tls-acme: \"true\" annotation (implies wait)")
+	certManager.Flags().Bool("staging", false, "set --staging to true to generate a staging Letsencrypt cluster issuer")
+	certManager.Flags().StringP("email", "e", "", "Letsencrypt Email")
+	certManager.Flags().String("ingress-class", "nginx", "Ingress class to be used such as nginx or traefik")
+	// Override flags
 	certManager.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set key=value)")
 
 	certManager.RunE = func(command *cobra.Command, args []string) error {
@@ -44,6 +62,20 @@ func MakeInstallCertManager() *cobra.Command {
 		overrides := map[string]string{}
 		overrides["installCRDs"] = "true"
 
+		// Allow usage of lego behavior, see https://cert-manager.io/docs/usage/ingress/#optional-configuration
+		useAcme, _ := certManager.Flags().GetBool("acme")
+		if useAcme {
+			// Configure default issuer name in helm according to --staging flag
+			staging, _ := certManager.Flags().GetBool("staging")
+			issuerName := "letsencrypt-production-issuer"
+			if staging {
+				issuerName = "letsencrypt-staging-issuer"
+			}
+
+			overrides["ingressShim.defaultIssuerName"] = issuerName
+			overrides["ingressShim.defaultIssuerKind"] = "ClusterIssuer"
+		}
+
 		customFlags, err := command.Flags().GetStringArray("set")
 		if err != nil {
 			return err
@@ -57,13 +89,27 @@ func MakeInstallCertManager() *cobra.Command {
 			WithHelmRepo("jetstack/cert-manager").
 			WithHelmURL("https://charts.jetstack.io").
 			WithOverrides(overrides).
-			WithWait(wait).
+			WithWait(wait || useAcme).
 			WithHelmUpdateRepo(updateRepo).
 			WithKubeconfigPath(kubeConfigPath)
 
 		_, err = apps.MakeInstallChart(certmanagerOptions)
 		if err != nil {
 			return err
+		}
+
+		// Install default issuer if --acme is given
+		if useAcme {
+			email, _ := command.Flags().GetString("email")
+			ingressClass, _ := command.Flags().GetString("ingress-class")
+			staging, _ := certManager.Flags().GetBool("staging")
+
+			err = WriteDefaultIssuer(email, ingressClass, staging)
+			if err != nil {
+				return err
+			}
+			// Print ACME installation message
+			fmt.Println(AcmeInfoMsg)
 		}
 
 		fmt.Println(certManagerInstallMsg)
@@ -77,7 +123,94 @@ func MakeInstallCertManager() *cobra.Command {
 const CertManagerInfoMsg = `# Get started with cert-manager here:
 # https://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html`
 
+const AcmeInfoMsg = `# A default ClusterIssuer was installed and configured for acme usage (with kubernetes.io/tls-acme: "true"):
+# https://cert-manager.io/docs/usage/ingress/#optional-configuration`
+
 const certManagerInstallMsg = `=======================================================================
 = cert-manager  has been installed.                                   =
 =======================================================================` +
 	"\n\n" + CertManagerInfoMsg + "\n\n" + pkg.ThanksForUsing
+
+func WriteDefaultIssuer(email string, ingressClass string, staging bool) (err error) {
+	log.Printf("Installing default letsencrypt issuer\n")
+
+	yamlBytes, templateErr := buildDefaultIssuerYAML(email, ingressClass, staging)
+	if templateErr != nil {
+		fmt.Errorf("unable to install the application. Could not build the templated yaml file for the resources")
+		return templateErr
+	}
+
+	tempFile, tempFileErr := writeTempFile(yamlBytes, "temp_registry_ingress.yaml")
+	if tempFileErr != nil {
+		fmt.Errorf("unable to save generated yaml file into the temporary directory")
+		return tempFileErr
+	}
+
+	res, err := k8s.KubectlTask("apply", "-f", tempFile)
+
+	if err != nil {
+		return err
+	}
+
+	if res.ExitCode > 0 {
+		return fmt.Errorf("error installing cluster default issuer: error: %s", res.Stderr)
+	}
+
+	return nil
+}
+
+func buildDefaultIssuerYAML(email string, ingressClass string, staging bool) ([]byte, error) {
+	tmpl, err := template.New("yaml").Parse(clusterIssuerTemplate)
+
+	if err != nil {
+		return nil, err
+	}
+
+	inputData := IssuerInput{
+		CertmanagerEmail: email,
+		IngressClass:     ingressClass,
+		IssuerName:       "letsencrypt-production-issuer",
+		IssuerAPI:        "https://acme-v02.api.letsencrypt.org/directory",
+	}
+
+	if staging {
+		inputData.IssuerName = "letsencrypt-staging-issuer"
+		inputData.IssuerAPI = "https://acme-staging-v02.api.letsencrypt.org/directory"
+	}
+
+	if len(email) > 0 {
+		inputData.CertmanagerEmail = fmt.Sprintf("    email: %s", email)
+	}
+
+	var tpl bytes.Buffer
+
+	err = tmpl.Execute(&tpl, inputData)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tpl.Bytes(), nil
+}
+
+var clusterIssuerTemplate = `
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: {{.IssuerName}}
+  namespace: cert-manager
+spec:
+  acme:
+{{.CertmanagerEmail}}
+    # The ACME server URL for production
+    server: {{.IssuerAPI}}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: {{.IssuerName}}-key
+    # Enable the HTTP-01 challenge provider
+    solvers:
+      # An empty 'selector' means that this solver matches all domains
+      - selector: {}
+        http01:
+          ingress:
+            class: {{.IngressClass}}`


### PR DESCRIPTION
Signed-off-by: Fabio Napoleoni <f.napoleoni@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implement a `--acme` flag for cert-manager install subcommand that automates helm values 

```
--set=ingressShim.defaultIssuerName=letsencrypt-prod \
--set=ingressShim.defaultIssuerKind=ClusterIssuer
```

and create a global `ClusterIssuer` that is used to generate letsencrypt certificates when an ingress is annotated with `kubernetes.io/tls-acme: "true"`

Let me know if you're interested and if I should change something to make this merged.

## Motivation and Context

As explained in #271 it would be useful to have an app specific flag that implements [`kubernetes.io/tls-acme: "true"`](https://cert-manager.io/docs/usage/ingress/#optional-configuration) configuration.

I think is in the motivation of this project to have some shorthand to automate per cluster tasks that are tedious and error prone like the one above.

Also the implementation is completely optin.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built the binary locally and tested on my own cluster, I'm not so skilled with go (actually my first lines in go) thus I'm still not able to implement an automated test. If you give me some hint on how to do that I'll be glad to try.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
