### PR TITLE
Switch to jFrog's Chart Center mirror for stable repos

### DIFF
--- a/cmd/apps/grafana_app.go
+++ b/cmd/apps/grafana_app.go
@@ -63,7 +63,7 @@ func MakeInstallGrafana() *cobra.Command {
 		}
 
 		updateRepo, _ := grafana.Flags().GetBool("update-repo")
-		err = helm.AddHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", updateRepo)
+		err = helm.AddHelmRepo("center", StableChartRepo, updateRepo)
 		if err != nil {
 			return err
 		}
@@ -80,7 +80,7 @@ func MakeInstallGrafana() *cobra.Command {
 		}
 
 		// download the chart
-		err = helm.FetchChart("stable/grafana", chartVersion)
+		err = helm.FetchChart("center/stable/grafana", chartVersion)
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func MakeInstallGrafana() *cobra.Command {
 		}
 
 		// install the chart
-		err = helm.Helm3Upgrade("stable/grafana", namespace,
+		err = helm.Helm3Upgrade("center/stable/grafana", namespace,
 			"values.yaml",
 			chartVersion,
 			overrides,

--- a/cmd/apps/jenkins_app.go
+++ b/cmd/apps/jenkins_app.go
@@ -20,6 +20,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// StableChartRepo https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository
+const StableChartRepo = "https://repo.chartcenter.io"
+
 func MakeInstallJenkins() *cobra.Command {
 	var jenkins = &cobra.Command{
 		Use:          "jenkins",
@@ -72,12 +75,12 @@ func MakeInstallJenkins() *cobra.Command {
 			return err
 		}
 
-		err = helm.AddHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", updateRepo)
+		err = helm.AddHelmRepo("center", StableChartRepo, updateRepo)
 		if err != nil {
 			return err
 		}
 
-		err = helm.FetchChart("stable/jenkins", defaultVersion)
+		err = helm.FetchChart("center/stable/jenkins", defaultVersion)
 
 		if err != nil {
 			return err
@@ -97,7 +100,7 @@ func MakeInstallJenkins() *cobra.Command {
 			return err
 		}
 
-		err = helm.Helm3Upgrade("stable/jenkins", ns,
+		err = helm.Helm3Upgrade("center/stable/jenkins", ns,
 			"values.yaml",
 			defaultVersion,
 			overrides,

--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -67,7 +67,7 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = helm.FetchChart("stable/kube-state-metrics", defaultVersion)
+		err = helm.FetchChart("center/stable/kube-state-metrics", defaultVersion)
 
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 
 		fmt.Println("Chart path: ", chartPath)
 
-		err = helm.Helm3Upgrade("stable/kube-state-metrics", namespace,
+		err = helm.Helm3Upgrade("center/stable/kube-state-metrics", namespace,
 			"values.yaml",
 			defaultVersion,
 			setMap,

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -65,7 +65,7 @@ func MakeInstallMetricsServer() *cobra.Command {
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = helm.FetchChart("stable/metrics-server", defaultVersion)
+		err = helm.FetchChart("center/stable/metrics-server", defaultVersion)
 
 		if err != nil {
 			return err
@@ -84,7 +84,7 @@ func MakeInstallMetricsServer() *cobra.Command {
 
 		fmt.Println("Chart path: ", chartPath)
 
-		err = helm.Helm3Upgrade("stable/metrics-server", namespace,
+		err = helm.Helm3Upgrade("center/stable/metrics-server", namespace,
 			"values.yaml",
 			defaultVersion,
 			overrides,

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -79,12 +79,12 @@ func MakeInstallMinio() *cobra.Command {
 			return err
 		}
 
-		err = helm.AddHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", updateRepo)
+		err = helm.AddHelmRepo("center", StableChartRepo, updateRepo)
 		if err != nil {
 			return err
 		}
 
-		err = helm.FetchChart("stable/minio", defaultVersion)
+		err = helm.FetchChart("center/stable/minio", defaultVersion)
 
 		if err != nil {
 			return err
@@ -134,7 +134,7 @@ func MakeInstallMinio() *cobra.Command {
 			return err
 		}
 
-		err = helm.Helm3Upgrade("stable/minio", ns,
+		err = helm.Helm3Upgrade("center/stable/minio", ns,
 			"values.yaml",
 			defaultVersion,
 			overrides,

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -76,7 +76,7 @@ func MakeInstallMongoDB() *cobra.Command {
 			return fmt.Errorf("unable to add repo %s", err)
 		}
 
-		err = helm.FetchChart("stable/mongodb", defaultVersion)
+		err = helm.FetchChart("center/stable/mongodb", defaultVersion)
 
 		if err != nil {
 			return fmt.Errorf("unable fetch chart %s", err)
@@ -95,7 +95,7 @@ func MakeInstallMongoDB() *cobra.Command {
 			return err
 		}
 
-		err = helm.Helm3Upgrade("stable/mongodb",
+		err = helm.Helm3Upgrade("center/stable/mongodb",
 			namespace, "values.yaml", defaultVersion, overrides, wait)
 		if err != nil {
 			return fmt.Errorf("unable to mongodb chart with helm %s", err)

--- a/cmd/apps/nfs_app.go
+++ b/cmd/apps/nfs_app.go
@@ -85,8 +85,8 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 		nfsProvisionerOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
 			WithHelmPath(path.Join(userPath, ".helm")).
-			WithHelmRepo("stable/nfs-client-provisioner").
-			WithHelmURL("https://kubernetes-charts.storage.googleapis.com").
+			WithHelmRepo("center/stable/nfs-client-provisioner").
+			WithHelmURL(StableChartRepo).
 			WithOverrides(overrides).
 			WithKubeconfigPath(kubeConfigPath)
 

--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -91,13 +91,13 @@ func MakeInstallRegistry() *cobra.Command {
 
 		htPasswd := fmt.Sprintf("%s:%s\n", username, string(val))
 
-		err = helm.AddHelmRepo("stable", "https://kubernetes-charts.storage.googleapis.com", updateRepo)
+		err = helm.AddHelmRepo("center", StableChartRepo, updateRepo)
 		if err != nil {
 			return err
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = helm.FetchChart("stable/docker-registry", defaultVersion)
+		err = helm.FetchChart("center/stable/docker-registry", defaultVersion)
 
 		if err != nil {
 			return err
@@ -115,7 +115,7 @@ func MakeInstallRegistry() *cobra.Command {
 
 		ns := "default"
 
-		err = helm.Helm3Upgrade("stable/docker-registry", ns,
+		err = helm.Helm3Upgrade("center/stable/docker-registry", ns,
 			"values.yaml",
 			defaultVersion,
 			overrides,

--- a/cmd/apps/sealed_secret_app.go
+++ b/cmd/apps/sealed_secret_app.go
@@ -73,7 +73,7 @@ func MakeInstallSealedSecrets() *cobra.Command {
 			return fmt.Errorf("unable to add repo %s", err)
 		}
 
-		err = helm.FetchChart("stable/sealed-secrets", defaultVersion)
+		err = helm.FetchChart("center/stable/sealed-secrets", defaultVersion)
 
 		if err != nil {
 			return fmt.Errorf("unable fetch chart %s", err)
@@ -90,7 +90,7 @@ func MakeInstallSealedSecrets() *cobra.Command {
 			return err
 		}
 
-		err = helm.Helm3Upgrade("stable/sealed-secrets",
+		err = helm.Helm3Upgrade("center/stable/sealed-secrets",
 			namespace, "values.yaml", defaultVersion, overrides, wait)
 		if err != nil {
 			return fmt.Errorf("unable to sealed secret chart with helm %s", err)

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -211,7 +211,7 @@ func Test_DownloadHelmDarwin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "https://get.helm.sh/helm-v3.2.4-darwin-amd64.tar.gz"
+	want := "https://get.helm.sh/helm-v3.4.1-darwin-amd64.tar.gz"
 	if got != want {
 		t.Fatalf("want: %s, got: %s", want, got)
 	}
@@ -232,7 +232,7 @@ func Test_DownloadHelmLinux(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz"
+	want := "https://get.helm.sh/helm-v3.4.1-linux-amd64.tar.gz"
 	if got != want {
 		t.Fatalf("want: %s, got: %s", want, got)
 	}
@@ -253,7 +253,7 @@ func Test_DownloadHelmWindows(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "https://get.helm.sh/helm-v3.2.4-windows-amd64.zip"
+	want := "https://get.helm.sh/helm-v3.4.1-windows-amd64.zip"
 	if got != want {
 		t.Fatalf("want: %s, got: %s", want, got)
 	}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -28,7 +28,7 @@ func MakeTools() []Tool {
 			Owner:   "helm",
 			Repo:    "helm",
 			Name:    "helm",
-			Version: "v3.2.4",
+			Version: "v3.4.1",
 			URLTemplate: `{{$arch := "arm"}}
 
 {{- if eq .Arch "x86_64" -}}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -185,7 +185,7 @@ func FetchChart(chart, version string) error {
 func Helm3Upgrade(chart, namespace, values, version string, overrides map[string]string, wait bool) error {
 
 	chartName := chart
-	if index := strings.Index(chartName, "/"); index > -1 {
+	if index := strings.LastIndex(chartName, "/"); index > -1 {
 		chartName = chartName[index+1:]
 	}
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Switch to jFrog's Chart Center mirror for stable repos

## Motivation and Context

The stable repos have been removed from their original
GCS bucket. The mirror is giving a 404 error despite the
index.yaml file showing the download URL.


Chart center from jFrog appears to have valid mirrors of the
older charts: https://chartcenter.io

This is not a fix for the issue, but is a workaround.
Apps will have to be removed if no suitable upstream chart is
available going forward.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with the docker-registry app.

See also: #273 #274 