### PR TITLE
Enable BinaryTemplate to take a slash for semver mismatches

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -855,7 +855,7 @@ func Test_DownloadHelmfile(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "0.132.1"
+	const toolVersion = "v0.132.1"
 
 	tests := []test{
 		{os: "mingw64_nt-10.0-18362",
@@ -883,5 +883,21 @@ func Test_DownloadHelmfile(t *testing.T) {
 		if got != tc.url {
 			t.Errorf("want: %s, got: %s", tc.url, got)
 		}
+	}
+}
+
+func Test_getBinaryURL_SlashInDownloadPath(t *testing.T) {
+	got := getBinaryURL("roboll", "helmfile", "0.134.0", "v0.134.0/helmfile_0.134.0_darwin_amd64")
+	want := "https://github.com/roboll/helmfile/releases/download/v0.134.0/helmfile_0.134.0_darwin_amd64"
+	if got != want {
+		t.Fatalf("want %s, but got: %s", want, got)
+	}
+}
+
+func Test_getBinaryURL_NoSlashInDownloadPath(t *testing.T) {
+	got := getBinaryURL("openfaas", "faas-cli", "0.19.0", "faas-cli_darwin")
+	want := "https://github.com/openfaas/faas-cli/releases/download/0.19.0/faas-cli_darwin"
+	if got != want {
+		t.Fatalf("want %s, but got: %s", want, got)
 	}
 }

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -48,11 +48,10 @@ https://get.helm.sh/helm-{{.Version}}-{{$os}}-{{$arch}}.{{$ext}}`,
 
 	tools = append(tools,
 		Tool{
-			Owner:   "roboll",
-			Repo:    "helmfile",
-			Name:    "helmfile",
-			Version: "0.135.0",
-			URLTemplate: `{{$arch := "386"}}
+			Owner: "roboll",
+			Repo:  "helmfile",
+			Name:  "helmfile",
+			BinaryTemplate: `{{$arch := "386"}}
 	{{- if eq .Arch "x86_64" -}}
 	{{$arch = "amd64"}}
 	{{- end -}}
@@ -65,7 +64,7 @@ https://get.helm.sh/helm-{{.Version}}-{{$os}}-{{$arch}}.{{$ext}}`,
 	{{$ext = ".exe"}}
 	{{- end -}}
 	
-	https://github.com/roboll/helmfile/releases/download/v{{.Version}}/helmfile_{{$os}}_{{$arch}}{{$ext}}`,
+helmfile_{{$os}}_{{$arch}}{{$ext}}`,
 		})
 
 	// https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/darwin/amd64/kubectl


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Enable BinaryTemplate to take a slash for semver mismatches

## Motivation and Context

Some projects give a "v" in their download URL and do not do
so within their binary name such as:

download/v1.0.0/tool_1.0.0_amd64

This mismatch means that we have to template the version
accordingly.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with the helmfile download, where I was able to remove the pinned version.
