### PR TITLE
Add secrets API and fix #287 for inlets-operator app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alexellis/arkade
 go 1.13
 
 require (
-	github.com/alexellis/go-execute v0.0.0-20191207085904-961405ea7544
+	github.com/alexellis/go-execute v0.0.0-20201205082949-69a2cde04f4f
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/morikuni/aec v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alexellis/go-execute v0.0.0-20191207085904-961405ea7544 h1:KjtKgzxk/0wfp7vZxWUYPMiEJKep7FJ7C7o/vtHyc/Q=
-github.com/alexellis/go-execute v0.0.0-20191207085904-961405ea7544/go.mod h1:zfRbgnPVxXCSpiKrg1CE72hNUWInqxExiaz2D9ppTts=
+github.com/alexellis/go-execute v0.0.0-20201205082949-69a2cde04f4f h1:5auqirFmPvQPu2Cq8gSKPyT6l7KYr9UniEbmvOBiWXM=
+github.com/alexellis/go-execute v0.0.0-20201205082949-69a2cde04f4f/go.mod h1:zfRbgnPVxXCSpiKrg1CE72hNUWInqxExiaz2D9ppTts=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/pkg/k8s/kubernetes_exec.go
+++ b/pkg/k8s/kubernetes_exec.go
@@ -5,6 +5,7 @@ package k8s
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/alexellis/arkade/pkg/types"
@@ -19,7 +20,18 @@ func GetNodeArchitecture() string {
 
 	return arch
 }
+func KubectlTaskStdin(reader io.Reader, parts ...string) (execute.ExecResult, error) {
+	task := execute.ExecTask{
+		Command:     "kubectl",
+		Args:        parts,
+		StreamStdio: false,
+		Stdin:       reader,
+	}
 
+	res, err := task.Execute()
+
+	return res, err
+}
 func KubectlTask(parts ...string) (execute.ExecResult, error) {
 	task := execute.ExecTask{
 		Command:     "kubectl",


### PR DESCRIPTION

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add secrets API and fix #287 for inlets-operator app

The secrets API allows for re-creation of existing secrets in
the cluster when reinstalling apps. This also refactors to a
pattern that can be reused in other apps.

## Motivation and Context

Fixes #287 

Reduces duplication across apps

## How Has This Been Tested?

Tested with the app it was added to for taking in a token to DO. First by using /etc/hosts as the key, then providing a real API token file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
