### PR TITLE
Fix `arkade get kustomize`

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -580,23 +580,23 @@ func Test_DownloadKustomize(t *testing.T) {
 		}
 	}
 
-	ver := "kustomize/v3.8.1"
+	ver := "v3.8.8"
 
 	tests := []test{
 		{os: "linux",
 			arch:    arch64bit,
 			version: ver,
-			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_linux_amd64.tar.gz",
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_linux_amd64.tar.gz",
 		},
 		{os: "darwin",
 			arch:    arch64bit,
 			version: ver,
-			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_darwin_amd64.tar.gz",
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_darwin_amd64.tar.gz",
 		},
 		{os: "linux",
 			arch:    "arm64",
 			version: ver,
-			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_.tar.gz",
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_linux_arm64.tar.gz",
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -330,17 +330,19 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:   "kubernetes-sigs",
 			Repo:    "kustomize",
 			Name:    "kustomize",
-			Version: "kustomize/v3.8.1",
+			Version: "v3.8.8",
 			URLTemplate: `
 	{{$osStr := ""}}
 	{{- if eq .OS "linux" -}}
 	{{- if eq .Arch "x86_64" -}}
 	{{$osStr = "linux_amd64"}}
+	{{- else if eq .Arch "arm64" -}}
+  {{$osStr = "linux_arm64"}}
 	{{- end -}}
 	{{- else if eq .OS "darwin" -}}
 	{{$osStr = "darwin_amd64"}}
 	{{- end -}}
-	https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_v3.8.1_{{$osStr}}.tar.gz`,
+	https://github.com/{{.Owner}}/{{.Repo}}/releases/download/kustomize%2F{{.Version}}/{{.Name}}_{{.Version}}_{{$osStr}}.tar.gz`,
 		})
 
 	tools = append(tools,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Various fixes for `get kustomize`. 

 * Fixes the version string and URLs to download
 * Adds linux arm64 os string (untested)

## Motivation and Context

I ran `arkade get kustomize --version=v3.8.8` and it failed, because the version 3.8.1 was hard-coded in the URL string. This is a fix for this.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

I opened #299 

## How Has This Been Tested?
I changed the `get_test` suite to expect the corrected version URLs.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

I removed `kustomize/v3.8.1` as the version and replaced with `v3.8.1` without the `kustomize` part. But this seemed unavoidable due to the strange way they name their versions and files. I don't consider this a breaking change though, because it wasn't working before.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x ] I have signed-off my commits with `git commit -s`
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
