### PR TITLE
Fixes #301 Updated HashiCorp products to latest version

### DIFF
--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -456,13 +456,13 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 https://github.com/{{.Owner}}/{{.Repo}}/releases/download/v{{.Version}}/{{.Name}}-{{.Version}}-{{$osStr}}-{{$archStr}}.{{$extStr}}`,
 		})
 
-	// https://releases.hashicorp.com/terraform/0.13.1/terraform_0.13.1_linux_amd64.zip
+	// https://releases.hashicorp.com/terraform/0.14.3/terraform_0.14.3_linux_amd64.zip
 	tools = append(tools,
 		Tool{
 			Owner:   "hashicorp",
 			Repo:    "terraform",
 			Name:    "terraform",
-			Version: "0.13.1",
+			Version: "0.14.3",
 			URLTemplate: `{{$arch := .Arch}}
 
 {{- if eq .Arch "x86_64" -}}
@@ -504,7 +504,7 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			Owner:   "hashicorp",
 			Repo:    "packer",
 			Name:    "packer",
-			Version: "1.6.5",
+			Version: "1.6.6",
 			URLTemplate: `{{$arch := .Arch}}
 
 {{- if eq .Arch "x86_64" -}}


### PR DESCRIPTION
## Description

The default for Packer and Terraform were not at the latest versions.
This update brings both of those to the newest version by default.
Vagrant is at the current latest version. Linked to issue #302 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the make command and everything compiled and all tests passed. I just updated the version for the Terraform and Packer tools.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
