### PR TITLE
Fix for downloading the Linux linkerd2 binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# arkade - Portable DevOps Marketplace
+# arkade - The Open Source Kubernetes Marketplace
 
 arkade provides a portable marketplace for downloading your favourite devops CLIs and installing helm charts, with a single command.
 

--- a/cmd/apps/gitlab_app.go
+++ b/cmd/apps/gitlab_app.go
@@ -4,15 +4,9 @@
 package apps
 
 import (
-	"log"
-	"os"
-	"path"
-
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -45,16 +39,7 @@ func MakeInstallGitLab() *cobra.Command {
 
 	gitlabApp.RunE = func(cmd *cobra.Command, args []string) error {
 		namespace, _ := cmd.Flags().GetString("namespace")
-		userPath, err := config.InitUserDir()
 		kubeConfigPath, _ := cmd.Flags().GetString("kubeconfig")
-
-		if err != nil {
-			return err
-		}
-
-		clientArch, clientOS := env.GetClientArch()
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
 
 		overrides := map[string]string{}
 		overrides["global.domain"], _ = cmd.Flags().GetString("domain")
@@ -89,20 +74,12 @@ func MakeInstallGitLab() *cobra.Command {
 
 		options := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("gitlab/gitlab").
 			WithHelmURL("https://charts.gitlab.io").
 			WithOverrides(overrides).
 			WithKubeconfigPath(kubeConfigPath)
 
-		_ = os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
-
-		_, err = apps.MakeInstallChart(options)
+		_, err := apps.MakeInstallChart(options)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -5,18 +5,12 @@ package apps
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 
 	"github.com/alexellis/arkade/pkg"
-	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/spf13/cobra"
 )
 
@@ -41,23 +35,7 @@ func MakeInstallKafkaConnector() *cobra.Command {
 
 		updateRepo, _ := command.Flags().GetBool("update-repo")
 
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
 		namespace, _ := command.Flags().GetString("namespace")
-
-		if namespace != "openfaas" {
-			return fmt.Errorf(`to override the "openfaas", install via tiller`)
-		}
-
-		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		topicsVal, err := command.Flags().GetString("topics")
 		if err != nil {
@@ -91,17 +69,11 @@ func MakeInstallKafkaConnector() *cobra.Command {
 
 		kafkaConnectorAppOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("openfaas/kafka-connector").
 			WithHelmURL("https://openfaas.github.io/faas-netes/").
 			WithOverrides(overrides).
 			WithHelmUpdateRepo(updateRepo).
 			WithKubeconfigPath(kubeConfigPath)
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
 
 		_, err = apps.MakeInstallChart(kafkaConnectorAppOptions)
 		if err != nil {

--- a/cmd/apps/kong_ingress_app.go
+++ b/cmd/apps/kong_ingress_app.go
@@ -2,18 +2,11 @@ package apps
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 
 	"github.com/alexellis/arkade/pkg/apps"
-	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 
 	"github.com/alexellis/arkade/pkg"
-	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/spf13/cobra"
 )
 
@@ -37,21 +30,7 @@ func MakeInstallKongIngress() *cobra.Command {
 
 		updateRepo, _ := command.Flags().GetBool("update-repo")
 
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
-
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
 		namespace, _ := command.Flags().GetString("namespace")
-
-		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		overrides := map[string]string{}
 		// always need to be set to  false
@@ -66,22 +45,13 @@ func MakeInstallKongIngress() *cobra.Command {
 			return err
 		}
 
-		arch := k8s.GetNodeArchitecture()
-		fmt.Printf("Node architecture: %q\n", arch)
-
 		kongIngressAppOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("kong/kong").
 			WithHelmURL("https://charts.konghq.com/").
 			WithOverrides(overrides).
 			WithHelmUpdateRepo(updateRepo).
 			WithKubeconfigPath(kubeConfigPath)
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
 
 		_, err = apps.MakeInstallChart(kongIngressAppOptions)
 		if err != nil {

--- a/cmd/apps/kubernetes_dashboard_app.go
+++ b/cmd/apps/kubernetes_dashboard_app.go
@@ -38,7 +38,7 @@ func MakeInstallKubernetesDashboard() *cobra.Command {
 			return err
 		}
 
-		fmt.Println(KubernetesDashboardInfoMsg)
+		fmt.Println(KubernetesDashboardInstallMsg)
 
 		return nil
 	}

--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -197,8 +197,3 @@ var LinkerdInfoMsg = `# Find out more at:
 
 export PATH=$PATH:` + getExportPath() + `
 linkerd2 --help`
-
-var linkerdInstallMsg = `=======================================================================
-= Linkerd has been installed.                                         =
-=======================================================================` +
-	"\n\n" + LinkerdInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var linkerdVersion = "stable-2.9.0"
+var linkerdVersion = "stable-2.9.1"
 
 func MakeInstallLinkerd() *cobra.Command {
 	var linkerd = &cobra.Command{

--- a/cmd/apps/loki_app.go
+++ b/cmd/apps/loki_app.go
@@ -5,14 +5,10 @@ package apps
 
 import (
 	"log"
-	"os"
-	"path"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -36,20 +32,6 @@ func MakeInstallLoki() *cobra.Command {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 		log.Println(kubeConfigPath)
 		namespace, _ := lokiApp.Flags().GetString("namespace")
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
-		clientArch, clientOS := env.GetClientArch()
-
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
-		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
-			return err
-		}
 
 		persistence, _ := lokiApp.Flags().GetBool("persistence")
 		installGrafana, _ := lokiApp.Flags().GetBool("grafana")
@@ -71,20 +53,12 @@ func MakeInstallLoki() *cobra.Command {
 
 		lokiOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("loki/loki-stack").
 			WithHelmURL("https://grafana.github.io/loki/charts").
 			WithOverrides(overrides).
 			WithKubeconfigPath(kubeConfigPath)
 
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
-
-		_, err = apps.MakeInstallChart(lokiOptions)
+		_, err := apps.MakeInstallChart(lokiOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -5,9 +5,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 	"strconv"
 	"strings"
 
@@ -16,9 +13,7 @@ import (
 	"github.com/alexellis/arkade/pkg/types"
 
 	"github.com/alexellis/arkade/pkg"
-	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/sethvargo/go-password/password"
 	"github.com/spf13/cobra"
 )
@@ -104,18 +99,6 @@ func MakeInstallMinio() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
-		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-
 		overrides := map[string]string{}
 
 		gen, err := password.NewGenerator(&password.GeneratorInput{
@@ -147,18 +130,12 @@ func MakeInstallMinio() *cobra.Command {
 
 		minioAppOptions := types.DefaultInstallOptions().
 			WithNamespace(ns).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("minio/minio").
 			WithHelmURL("https://helm.min.io/").
 			WithOverrides(overrides).
 			WithHelmUpdateRepo(updateRepo).
 			WithKubeconfigPath(kubeConfigPath).
 			WithWait(wait)
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
 
 		_, err = apps.MakeInstallChart(minioAppOptions)
 		if err != nil {

--- a/cmd/apps/nats_connector.go
+++ b/cmd/apps/nats_connector.go
@@ -4,15 +4,9 @@
 package apps
 
 import (
-	"log"
-	"os"
-	"path"
-
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -34,20 +28,6 @@ func MakeInstallNATSConnector() *cobra.Command {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 
 		namespace, _ := natsConnectorApp.Flags().GetString("namespace")
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
-		clientArch, clientOS := env.GetClientArch()
-
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
-		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
-			return err
-		}
 
 		overrides := map[string]string{}
 
@@ -59,20 +39,12 @@ func MakeInstallNATSConnector() *cobra.Command {
 
 		natsConnectorOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("openfaas/nats-connector").
 			WithHelmURL("https://openfaas.github.io/faas-netes/").
 			WithOverrides(overrides).
 			WithKubeconfigPath(kubeConfigPath)
 
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
-
-		_, err = apps.MakeInstallChart(natsConnectorOptions)
+		_, err := apps.MakeInstallChart(natsConnectorOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/nfs_app.go
+++ b/cmd/apps/nfs_app.go
@@ -5,15 +5,10 @@ package apps
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
@@ -38,20 +33,6 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 
 		namespace, _ := nfsProvisionerApp.Flags().GetString("namespace")
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
-		clientArch, clientOS := env.GetClientArch()
-
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
-		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
-			return err
-		}
 
 		nfsServer, _ := command.Flags().GetString("nfs-server")
 		nfsPath, _ := command.Flags().GetString("nfs-path")
@@ -84,20 +65,12 @@ func MakeInstallNfsProvisioner() *cobra.Command {
 
 		nfsProvisionerOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("stable/nfs-client-provisioner").
 			WithHelmURL("https://charts.helm.sh/stable").
 			WithOverrides(overrides).
 			WithKubeconfigPath(kubeConfigPath)
 
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
-
-		_, err = apps.MakeInstallChart(nfsProvisionerOptions)
+		_, err := apps.MakeInstallChart(nfsProvisionerOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -5,15 +5,10 @@ package apps
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -40,21 +35,10 @@ flag and the ingress-nginx docs for more info`,
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
 
 		wait, _ := command.Flags().GetBool("wait")
 
 		namespace, _ := command.Flags().GetString("namespace")
-
-		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		overrides := map[string]string{}
 
@@ -79,18 +63,13 @@ flag and the ingress-nginx docs for more info`,
 
 		nginxOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("ingress-nginx/ingress-nginx").
 			WithHelmURL("https://kubernetes.github.io/ingress-nginx").
 			WithOverrides(overrides).
 			WithWait(wait).
 			WithKubeconfigPath(kubeConfigPath)
 
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
-		_, err = apps.MakeInstallChart(nginxOptions)
+		_, err := apps.MakeInstallChart(nginxOptions)
 
 		if err != nil {
 			return err

--- a/cmd/apps/nginx_inc_app.go
+++ b/cmd/apps/nginx_inc_app.go
@@ -2,9 +2,6 @@ package apps
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 	"strconv"
 
 	"github.com/alexellis/arkade/pkg/apps"
@@ -12,9 +9,6 @@ import (
 	"github.com/alexellis/arkade/pkg/types"
 
 	"github.com/alexellis/arkade/pkg"
-	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/spf13/cobra"
 )
 
@@ -43,19 +37,7 @@ func MakeInstallNginxIncIngress() *cobra.Command {
 
 		updateRepo, _ := command.Flags().GetBool("update-repo")
 
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
 		namespace, _ := command.Flags().GetString("namespace")
-
-		clientArch, clientOS := env.GetClientArch()
-
-		fmt.Printf("Client: %s, %s\n", clientArch, clientOS)
-		log.Printf("User dir established as: %s\n", userPath)
-
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
 
 		overrides := map[string]string{}
 
@@ -112,7 +94,6 @@ func MakeInstallNginxIncIngress() *cobra.Command {
 
 		nginxIncIngressAppOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("nginx-stable/nginx-ingress").
 			WithHelmURL("https://helm.nginx.com/stable").
 			WithOverrides(overrides).
@@ -122,11 +103,6 @@ func MakeInstallNginxIncIngress() *cobra.Command {
 		if command.Flags().Changed("kubeconfig") {
 			kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 			nginxIncIngressAppOptions.WithKubeconfigPath(kubeConfigPath)
-		}
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
 		}
 
 		_, err = apps.MakeInstallChart(nginxIncIngressAppOptions)

--- a/cmd/apps/of_loki.go
+++ b/cmd/apps/of_loki.go
@@ -5,17 +5,12 @@ package apps
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"path"
 
 	"github.com/alexellis/arkade/pkg/k8s"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/config"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -39,20 +34,6 @@ func MakeInstallOpenFaaSLoki() *cobra.Command {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
 
 		namespace, _ := OpenFaaSlokiApp.Flags().GetString("namespace")
-		userPath, err := config.InitUserDir()
-		if err != nil {
-			return err
-		}
-
-		clientArch, clientOS := env.GetClientArch()
-
-		log.Printf("Client: %s, %s\n", clientArch, clientOS)
-
-		log.Printf("User dir established as: %s\n", userPath)
-
-		if err := os.Setenv("HELM_HOME", path.Join(userPath, ".helm")); err != nil {
-			return err
-		}
 
 		openfaasNamespace, _ := OpenFaaSlokiApp.Flags().GetString("openfaas-namespace")
 		lokiURL, _ := OpenFaaSlokiApp.Flags().GetString("loki-url")
@@ -68,20 +49,12 @@ func MakeInstallOpenFaaSLoki() *cobra.Command {
 
 		lokiOptions := types.DefaultInstallOptions().
 			WithNamespace(namespace).
-			WithHelmPath(path.Join(userPath, ".helm")).
 			WithHelmRepo("lucas/openfaas-loki").
 			WithHelmURL("https://lucasroesler.com/openfaas-loki").
 			WithOverrides(overrides).
 			WithKubeconfigPath(kubeConfigPath)
 
-		os.Setenv("HELM_HOME", path.Join(userPath, ".helm"))
-
-		_, err = helm.TryDownloadHelm(userPath, clientArch, clientOS)
-		if err != nil {
-			return err
-		}
-
-		_, err = apps.MakeInstallChart(lokiOptions)
+		_, err := apps.MakeInstallChart(lokiOptions)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -106,7 +106,10 @@ func MakeInstallRegistry() *cobra.Command {
 			return err
 		}
 
-		persistence, _ := registry.Flags().GetBool("persistence")
+		persistence, err := registry.Flags().GetBool("persistence")
+		if err != nil {
+			return err
+		}
 
 		overrides := map[string]string{}
 

--- a/cmd/apps/traefik2_app.go
+++ b/cmd/apps/traefik2_app.go
@@ -121,8 +121,7 @@ arkade install traefik2 --dashboard
 
 # Find your LoadBalancer IP:
 
-kubectl get svc -n kube-system traefik
-`
+kubectl get svc -n kube-system traefik`
 
 const traefikInstallMsg = `=======================================================================
 =                  traefik2 has been installed                        =

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1026,3 +1026,43 @@ func Test_DownloadMinio(t *testing.T) {
 		}
 	}
 }
+func Test_DownloadLinkerd(t *testing.T) {
+	tools := MakeTools()
+	name := "linkerd2"
+
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	tests := []test{
+		{os: "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-windows.exe"},
+		{os: "linux",
+			arch:    arch64bit,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-linux-amd64"},
+		{os: "darwin",
+			arch:    arch64bit,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-darwin"},
+		{os: "linux",
+			arch:    archARM64,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-linux-arm64"},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Fatalf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -294,13 +294,15 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:   "linkerd",
 			Repo:    "linkerd2",
 			Name:    "linkerd2",
-			Version: "stable-2.9.0",
+			Version: "stable-2.9.1",
 			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
 {{.Name}}-cli-{{.Version}}-windows.exe
 {{- else if eq .OS "darwin" -}}
 {{.Name}}-cli-{{.Version}}-darwin
-{{- else if eq .OS "linux" -}}
-{{.Name}}-cli-{{.Version}}-linux
+{{- else if eq .Arch "x86_64" -}}
+{{.Name}}-cli-{{.Version}}-linux-amd64
+{{- else if eq .Arch "aarch64" -}}
+{{.Name}}-cli-{{.Version}}-linux-arm64
 {{- end -}}
 `,
 		})

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -755,11 +755,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/v{{.Version}}/{{.Name}
 	{{- else if eq .OS "darwin" -}}
 	{{.Name}}_darwin_amd64
 	{{- else if eq .Arch "armv6l" -}}
-	{{.Name}}_arm
+	{{.Name}}_linux_arm
 	{{- else if eq .Arch "armv7l" -}}
-	{{.Name}}_arm
+	{{.Name}}_linux_arm
 	{{- else if eq .Arch "aarch64" -}}
-	{{.Name}}_arm64
+	{{.Name}}_linux_arm64
 	{{- else -}}
 	{{.Name}}_linux_amd64
 	{{- end -}}`,

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -134,13 +134,33 @@ func AddHelmRepo(name, url string, update bool) error {
 	}
 	res, err := task.Execute()
 
-	println(res.Stderr)
-
 	if err != nil {
 		return err
 	}
+
+	println(res.Stderr)
+
 	if res.ExitCode != 0 {
 		return fmt.Errorf("exit code %d", res.ExitCode)
+	}
+
+	if update {
+		task := execute.ExecTask{
+			Command:     fmt.Sprintf("%s repo update", env.LocalBinary("helm", subdir)),
+			Env:         os.Environ(),
+			StreamStdio: true,
+		}
+		res, err := task.Execute()
+
+		if err != nil {
+			return err
+		}
+
+		println(res.Stderr)
+
+		if res.ExitCode != 0 {
+			return fmt.Errorf("exit code %d", res.ExitCode)
+		}
 	}
 
 	return nil

--- a/pkg/k8s/kubernetes_exec.go
+++ b/pkg/k8s/kubernetes_exec.go
@@ -65,6 +65,18 @@ func Kubectl(parts ...string) error {
 	return nil
 }
 
+func CreateNamespace(namespace string) error {
+	nsRes, nsErr := KubectlTask("create", "namespace", namespace)
+	if nsErr != nil {
+		return nsErr
+	}
+	if nsRes.ExitCode != 0 {
+		fmt.Printf("[Warning] unable to create namespace %s, may already exist: %s", namespace, nsRes.Stderr)
+	}
+
+	return nil
+}
+
 func CreateSecret(secret types.K8sSecret) error {
 	secretData, err := flattenSecretData(secret.SecretData)
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -53,11 +53,6 @@ func (o *InstallerOptions) WithNamespace(namespace string) *InstallerOptions {
 	return o
 }
 
-func (o *InstallerOptions) WithHelmPath(helmPath string) *InstallerOptions {
-	o.Helm.HelmPath = helmPath
-	return o
-}
-
 func (o *InstallerOptions) WithWait(wait bool) *InstallerOptions {
 	o.Helm.Wait = wait
 	return o


### PR DESCRIPTION
Downloading the linkerd2 client binary failed on the missing architecture suffix in the URL (eg. `-amd64`).
This is only the case for the Linux client, and **amd64** + **arm64** are the only available architectures.

This PR fixes downloading the linux linkerd2 clients on amd64 and arm64. 

## Description
Adds a conditional check on the Arch and updates the download URL accordingly.

## Motivation and Context
This fixes running `arkade install linkerd` on a linux client.

## How Has This Been Tested?
Tested by building arkade on a Linux x86_64 machine. 

`go build main.go install linkerd`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

