### PR TITLE
Add --set flag to apps that missed it

### DIFF
--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -52,9 +52,6 @@ func MakeInstallLinkerd() *cobra.Command {
 
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
-		// if arch != IntelArch {
-		// 	return fmt.Errorf(OnlyIntelArch)
-		// }
 
 		userPath, err := getUserPath()
 		if err != nil {

--- a/cmd/apps/metricsserver_app.go
+++ b/cmd/apps/metricsserver_app.go
@@ -28,6 +28,8 @@ func MakeInstallMetricsServer() *cobra.Command {
 	}
 
 	metricsServer.Flags().StringP("namespace", "n", "kube-system", "The namespace used for installation")
+	metricsServer.Flags().StringArray("set", []string{},
+		"Use custom flags or override existing flags \n(example --set persistence.enabled=true)")
 
 	metricsServer.RunE = func(command *cobra.Command, args []string) error {
 		wait, _ := command.Flags().GetBool("wait")
@@ -80,6 +82,15 @@ func MakeInstallMetricsServer() *cobra.Command {
 		case "arm64", "aarch64":
 			overrides["image.repository"] = `gcr.io/google_containers/metrics-server-arm64`
 			break
+		}
+
+		customFlags, err := command.Flags().GetStringArray("set")
+		if err != nil {
+			return err
+		}
+
+		if err = config.MergeFlags(overrides, customFlags); err != nil {
+			return err
 		}
 
 		fmt.Println("Chart path: ", chartPath)

--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -5,14 +5,12 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/k8s"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
 	"strconv"
-	"strings"
-
-	"github.com/alexellis/arkade/pkg/k8s"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -39,10 +37,11 @@ func MakeInstallRegistry() *cobra.Command {
 	registry.Flags().StringP("password", "p", "", "Password for the registry, leave blank to generate")
 	registry.Flags().StringP("write-file", "w", "", "Write generated password to this file")
 	registry.Flags().Bool("persistence", false, "Enable persistence")
+	registry.Flags().StringArray("set", []string{},
+		"Use custom flags or override existing flags \n(example --set persistence.enabled=true)")
 
 	registry.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
@@ -113,8 +112,17 @@ func MakeInstallRegistry() *cobra.Command {
 
 		overrides := map[string]string{}
 
-		overrides["persistence.enabled"] = strings.ToLower(strconv.FormatBool(persistence))
-		overrides["secrets.htpasswd"] = string(htPasswd)
+		overrides["persistence.enabled"] = strconv.FormatBool(persistence)
+		overrides["secrets.htpasswd"] = htPasswd
+
+		customFlags, err := command.Flags().GetStringArray("set")
+		if err != nil {
+			return err
+		}
+
+		if err = config.MergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
 
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)


### PR DESCRIPTION
There are some helm based apps that didnt have the --set flag, thanks
@rhorridge for the issue #311.

I have checked the apps mentioned and added the flag is required and
tested each one by installing with a --set flag to override an existing
value (if set) and to set a new one.

Everything installed as expected

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: 311
cc @rhorridge


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installing each changed app with flag overrides

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
