### PR TITLE
Add setting to not install namespace on chart_app

### DIFF
--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -198,6 +198,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 			WithHelmURL("https://openfaas.github.io/faas-netes/").
 			WithHelmRepo("openfaas/openfaas").
 			WithNamespace(namespace).
+			WithInstallNamespace(false).
 			WithWait(wait)
 
 		if _, err := apps.MakeInstallChart(appOpts); err != nil {

--- a/pkg/apps/chart_app.go
+++ b/pkg/apps/chart_app.go
@@ -20,8 +20,10 @@ func MakeInstallChart(options *types.InstallerOptions) (*types.InstallerOutput, 
 		return nil, err
 	}
 
-	if err := k8s.CreateNamespace(options.Namespace); err != nil {
-		return nil, err
+	if options.CreateNamespace {
+		if err := k8s.CreateNamespace(options.Namespace); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, secret := range options.Secrets {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -3,12 +3,13 @@ package types
 import "github.com/alexellis/arkade/pkg/config"
 
 type InstallerOptions struct {
-	Namespace      string
-	KubeconfigPath string
-	NodeArch       string
-	Helm           *HelmConfig
-	Verbose        bool
-	Secrets        []K8sSecret
+	Namespace       string
+	CreateNamespace bool
+	KubeconfigPath  string
+	NodeArch        string
+	Helm            *HelmConfig
+	Verbose         bool
+	Secrets         []K8sSecret
 }
 
 type K8sSecret struct {
@@ -93,11 +94,17 @@ func (o *InstallerOptions) WithSecret(secret K8sSecret) *InstallerOptions {
 	return o
 }
 
+func (o *InstallerOptions) WithInstallNamespace(b bool) *InstallerOptions {
+	o.CreateNamespace = b
+	return o
+}
+
 func DefaultInstallOptions() *InstallerOptions {
 	return &InstallerOptions{
-		Namespace:      "default",
-		KubeconfigPath: config.GetDefaultKubeconfig(),
-		NodeArch:       "x86_64",
+		Namespace:       "default",
+		KubeconfigPath:  config.GetDefaultKubeconfig(),
+		NodeArch:        "x86_64",
+		CreateNamespace: false,
 		Helm: &HelmConfig{
 			Repo: &HelmRepo{
 				Version: "",


### PR DESCRIPTION


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes: #317 
This commit allows an app author to not get the chart_app install option
to try to create the namespace. This is useful when namespaces are
created from a yaml file with specific annotations.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#317 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```sh
heyal@heyal-xps:~/go/src/github.com/alexellis/arkade$ go build && ./arkade install openfaas
Using Kubeconfig: /home/heyal/.kube/config
Using Kubeconfig: /home/heyal/.kube/config
Client: x86_64, Linux
2021/01/30 15:25:14 User dir established as: /home/heyal/.arkade/
"openfaas" has been added to your repositories

Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "ingress-nginx" chart repository
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "minio" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "loki" chart repository
...Successfully got an update from the "istio" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "crossplane-alpha" chart repository
...Successfully got an update from the "bitnami-redis" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 

VALUES values.yaml
Command: /home/heyal/.arkade/bin/helm [upgrade --install openfaas openfaas/openfaas --namespace openfaas --values /tmp/charts/openfaas/values.yaml --set faasnetes.imagePullPolicy=Always --set gateway.replicas=1 --set queueWorker.replicas=1 --set serviceType=NodePort --set openfaasImagePullPolicy=IfNotPresent --set gateway.directFunctions=true --set operator.create=false --set basicAuthPlugin.replicas=1 --set ingressOperator.create=false --set queueWorker.maxInflight=1 --set basic_auth=true --set clusterRole=false]
Release "openfaas" does not exist. Installing it now.
NAME: openfaas
LAST DEPLOYED: Sat Jan 30 15:25:29 2021
NAMESPACE: openfaas
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
To verify that openfaas has started, run:

  kubectl -n openfaas get deployments -l "release=openfaas, app=openfaas"
=======================================================================
= OpenFaaS has been installed.                                        =
=======================================================================

# Get the faas-cli
curl -SLsf https://cli.openfaas.com | sudo sh

# Forward the gateway to your machine
kubectl rollout status -n openfaas deploy/gateway
kubectl port-forward -n openfaas svc/gateway 8080:8080 &

# If basic auth is enabled, you can now log into your gateway:
PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
echo -n $PASSWORD | faas-cli login --username admin --password-stdin

faas-cli store deploy figlet
faas-cli list

# For Raspberry Pi
faas-cli store list \
 --platform armhf

faas-cli store deploy figlet \
 --platform armhf

# Find out more at:
# https://github.com/openfaas/faas

Thanks for using arkade!


```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
