### PR TITLE
Fix for downloading the linkerd2 binaries

### DIFF
--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var linkerdVersion = "stable-2.9.0"
+var linkerdVersion = "stable-2.9.1"
 
 func MakeInstallLinkerd() *cobra.Command {
 	var linkerd = &cobra.Command{

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1076,3 +1076,44 @@ func Test_DownloadNats(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadLinkerd(t *testing.T) {
+	tools := MakeTools()
+	name := "linkerd2"
+
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+
+	tests := []test{
+		{os: "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-windows.exe"},
+		{os: "linux",
+			arch:    arch64bit,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-linux-amd64"},
+		{os: "darwin",
+			arch:    arch64bit,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-darwin"},
+		{os: "linux",
+			arch:    archARM64,
+			version: "stable-2.9.1",
+			url:     "https://github.com/linkerd/linkerd2/releases/download/stable-2.9.1/linkerd2-cli-stable-2.9.1-linux-arm64"},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -294,13 +294,15 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:   "linkerd",
 			Repo:    "linkerd2",
 			Name:    "linkerd2",
-			Version: "stable-2.9.0",
+			Version: "stable-2.9.1",
 			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
 {{.Name}}-cli-{{.Version}}-windows.exe
 {{- else if eq .OS "darwin" -}}
 {{.Name}}-cli-{{.Version}}-darwin
-{{- else if eq .OS "linux" -}}
-{{.Name}}-cli-{{.Version}}-linux
+{{- else if eq .Arch "x86_64" -}}
+{{.Name}}-cli-{{.Version}}-linux-amd64
+{{- else if eq .Arch "aarch64" -}}
+{{.Name}}-cli-{{.Version}}-linux-arm64
 {{- end -}}
 `,
 		})


### PR DESCRIPTION
Clones https://github.com/alexellis/arkade/pull/308 resolves https://github.com/alexellis/arkade/issues/327

## Description
Appends the correct arch to the download URLs for linkerd2

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
Tested in `pkg/get/get_test.go`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
