### PR TITLE
Add Metallb app for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Available Commands:
   kubernetes-dashboard    Install kubernetes-dashboard
   linkerd                 Install linkerd
   loki                    Install Loki for monitoring and tracing
+  metallb                 Install metallb
   metrics-server          Install metrics-server
   minio                   Install minio
   mongodb                 Install mongodb

--- a/cmd/apps/metallb_app.go
+++ b/cmd/apps/metallb_app.go
@@ -1,0 +1,104 @@
+package apps
+
+import (
+	"crypto/rand"
+	b64 "encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/k8s"
+	"github.com/alexellis/arkade/pkg/types"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallMetalLB() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "metallb",
+		Short:        "Install metallb",
+		Long:         `Install metallb for service type:LoadBalancer`,
+		Example:      `arkade install metallb`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().String("address-range", "192.168.0.0/24", "Address range for loadBalancer services")
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
+		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
+			return err
+		}
+
+		addressRange, _ := command.Flags().GetString("address-range")
+
+		err := k8s.Kubectl("apply", "-f",
+			"https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml")
+		if err != nil {
+			return err
+		}
+
+		err = k8s.Kubectl("apply", "-f",
+			"https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml")
+		if err != nil {
+			return err
+		}
+
+		token := make([]byte, 32)
+		rand.Read(token)
+
+		secret := types.K8sSecret{
+			Type:      "generic",
+			Name:      "memberlist",
+			Namespace: "metallb-system",
+			SecretData: []types.SecretsData{{
+				Type:  "string-literal",
+				Key:   "secretkey",
+				Value: b64.StdEncoding.EncodeToString(token),
+			}},
+		}
+
+		err = k8s.CreateSecret(secret)
+		if err != nil {
+			return fmt.Errorf("Create secret error: %+v", err)
+		}
+
+		configMap := fmt.Sprintf(metalLBConfigMap, addressRange)
+
+		err = k8s.KubectlIn(strings.NewReader(configMap), "apply", "-f", "-")
+		if err != nil {
+			return fmt.Errorf("Create configmap error: %+v", err)
+		}
+
+		fmt.Println(MetalLBInstallMsg)
+
+		return nil
+	}
+
+	return command
+}
+
+const MetalLBInfoMsg = `# Find out more at:
+# https://metallb.universe.tf/
+`
+
+const MetalLBInstallMsg = `=======================================================================
+= metalLB has been installed.                                  =
+=======================================================================` +
+	"\n\n" + MetalLBInfoMsg + "\n\n" + pkg.ThanksForUsing
+
+const metalLBConfigMap = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - %s
+`

--- a/cmd/apps/metallb_app.go
+++ b/cmd/apps/metallb_app.go
@@ -31,6 +31,13 @@ func MakeInstallMetalLB() *cobra.Command {
 			return err
 		}
 
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(OnlyIntelArch)
+		}
+
 		addressRange, _ := command.Flags().GetString("address-range")
 
 		err := k8s.Kubectl("apply", "-f",

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -104,6 +104,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["sealed-secret"] = NewArkadeApp(apps.MakeInstallSealedSecrets, apps.SealedSecretsInfoMsg)
 	arkadeApps["gitlab"] = NewArkadeApp(apps.MakeInstallGitLab, apps.GitlabInfoMsg)
 	arkadeApps["nginx-inc"] = NewArkadeApp(apps.MakeInstallNginxIncIngress, apps.NginxIncIngressInfoMsg)
+	arkadeApps["metallb"] = NewArkadeApp(apps.MakeInstallMetalLB, apps.MetalLBInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")

--- a/pkg/k8s/kubernetes_exec.go
+++ b/pkg/k8s/kubernetes_exec.go
@@ -65,6 +65,28 @@ func Kubectl(parts ...string) error {
 	return nil
 }
 
+func KubectlIn(stdin io.Reader, parts ...string) error {
+	task := execute.ExecTask{
+		Command:     "kubectl",
+		Args:        parts,
+		StreamStdio: true,
+		Stdin:       stdin,
+	}
+
+	res, err := task.Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if res.ExitCode != 0 {
+		return fmt.Errorf("kubectl exit code %d, stderr: %s",
+			res.ExitCode,
+			res.Stderr)
+	}
+	return nil
+}
+
 func CreateNamespace(namespace string) error {
 	nsRes, nsErr := KubectlTask("create", "namespace", namespace)
 	if nsErr != nil {


### PR DESCRIPTION
## Description
This PR adds support for metallb installation. It installs metallb in [L2 mode](https://metallb.universe.tf/concepts/layer2/) and provides an argument for configurable LB IP range (default: 192.168.0.0/24)

## Motivation and Context
Fixes #76 
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

**Notes**:
* It uses the [official](https://metallb.universe.tf/installation/) installation method, it doesn't rely on 3rd party helm charts (e.g. [bitnami](https://bitnami.com/stack/metallb/helm))
* It adds a new function [`KubectlIn`](https://github.com/alexellis/arkade/compare/master...networkop:master#diff-53f55403dea3cbf51eac6f9161c38f774e6e21d86f0d4af6afbb49d9d3468077R68) to allow YAML manifests to be passed via stdin  

## How Has This Been Tested?

Deploy to a new cluster:
```
./arkade install metallb --address-range 172.16.0.0/24
```

Any pending loadBalancer services will soon get a new IP:
```
k get svc -A
NAMESPACE              NAME                                 TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
default                ingress-nginx-controller             LoadBalancer   10.108.196.250   172.16.0.0   80:30611/TCP,443:32517/TCP   68s
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
