### PR TITLE
Fix arkade get kustomize

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -598,23 +598,23 @@ func Test_DownloadKustomize(t *testing.T) {
 		}
 	}
 
-	ver := "kustomize/v3.8.1"
+	ver := "v3.8.8"
 
 	tests := []test{
 		{os: "linux",
 			arch:    arch64bit,
 			version: ver,
-			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_linux_amd64.tar.gz",
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_linux_amd64.tar.gz",
 		},
 		{os: "darwin",
 			arch:    arch64bit,
 			version: ver,
-			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_darwin_amd64.tar.gz",
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_darwin_amd64.tar.gz",
 		},
 		{os: "linux",
-			arch:    "arm64",
+			arch:    archARM64,
 			version: ver,
-			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.1/kustomize_v3.8.1_.tar.gz",
+			url:     "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.8/kustomize_v3.8.8_linux_arm64.tar.gz",
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -332,17 +332,19 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:   "kubernetes-sigs",
 			Repo:    "kustomize",
 			Name:    "kustomize",
-			Version: "kustomize/v4.0.0",
+			Version: "v4.0.0",
 			URLTemplate: `
 	{{$osStr := ""}}
 	{{- if eq .OS "linux" -}}
 	{{- if eq .Arch "x86_64" -}}
 	{{$osStr = "linux_amd64"}}
+	{{- else if eq .Arch "aarch64" -}}
+  {{$osStr = "linux_arm64"}}
 	{{- end -}}
 	{{- else if eq .OS "darwin" -}}
 	{{$osStr = "darwin_amd64"}}
 	{{- end -}}
-	https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_v3.8.1_{{$osStr}}.tar.gz`,
+	https://github.com/{{.Owner}}/{{.Repo}}/releases/download/kustomize%2F{{.Version}}/{{.Name}}_{{.Version}}_{{$osStr}}.tar.gz`,
 		})
 
 	tools = append(tools,


### PR DESCRIPTION
This PR is a follow-up to #300 with resolved merge conflict, fixed tests and a successful test on a real ARM64 system.
It fixes #299 and closes #342 

# Description
Various fixes for get kustomize.

* Fixes the problem that `arkade get kustomize` is broken by the changes introduced in https://github.com/alexellis/arkade/commit/6a810bf2d441c2af1846ea5e96359ef3069570ba:

```
https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.0.0/kustomize_v3.8.1_linux_amd64.tar.gz
Error: check with the vendor whether this tool is available for your system: incorrect status for downloading tool: 404
```
* Allows to use a different version but 4.0.0
* Adds linux arm64 support (tested on my Raspi 4b Kubernetes cluster)

# How Has This Been Tested?

New test cases in PR, test on ARM64 Raspi 4b

Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)

Checklist:
 - [x] My code follows the code style of this project.
- [ ]   My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x]  I have tested this on arm, or have added code to prevent deployment