### PR TITLE
remove duplicate log message

### DIFF
--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -28,11 +28,7 @@ func MakeInstallCronConnector() *cobra.Command {
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
-
 		updateRepo, _ := command.Flags().GetBool("update-repo")
-
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
-
 		namespace, _ := command.Flags().GetString("namespace")
 
 		overrides := map[string]string{}

--- a/cmd/apps/falco.go
+++ b/cmd/apps/falco.go
@@ -61,7 +61,6 @@ func MakeInstallFalco() *cobra.Command {
 		sidekickEnabled, _ := command.Flags().GetBool("sidekick")
 		webUIEnabled, _ := command.Flags().GetBool("webui")
 
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -95,7 +95,6 @@ func MakeInstallMinio() *cobra.Command {
 		dist, _ := command.Flags().GetBool("distributed")
 		customFlags, _ := command.Flags().GetStringArray("set")
 
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -35,7 +35,6 @@ func MakeInstallMongoDB() *cobra.Command {
 
 	command.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}

--- a/cmd/apps/opa_gatekeeper.go
+++ b/cmd/apps/opa_gatekeeper.go
@@ -62,7 +62,6 @@ for the Kubernetes API.`,
 		updateRepo, _ := command.Flags().GetBool("update-repo")
 		customFlags, _ := command.Flags().GetStringArray("set")
 
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alexellis/arkade/pkg/k8s"
 
 	"github.com/alexellis/arkade/pkg"
-	"github.com/alexellis/arkade/pkg/config"
 	"github.com/sethvargo/go-password/password"
 
 	"github.com/spf13/cobra"
@@ -62,9 +61,6 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		}
 
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
-		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
-			return err
-		}
 		namespace, _ := command.Flags().GetString("namespace")
 
 		basicAuthEnabled, err := command.Flags().GetBool("basic-auth")

--- a/cmd/apps/osm_app.go
+++ b/cmd/apps/osm_app.go
@@ -38,7 +38,6 @@ service mesh created by Microsoft Azure.`,
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)

--- a/cmd/apps/portainer_app.go
+++ b/cmd/apps/portainer_app.go
@@ -34,8 +34,6 @@ func MakeInstallPortainer() *cobra.Command {
 			return err
 		}
 
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
-
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -35,8 +35,6 @@ func MakeInstallPostgresql() *cobra.Command {
 
 	postgresql.RunE = func(command *cobra.Command, args []string) error {
 		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
-
 		updateRepo, _ := postgresql.Flags().GetBool("update-repo")
 
 		arch := k8s.GetNodeArchitecture()

--- a/cmd/apps/registry_creds_app.go
+++ b/cmd/apps/registry_creds_app.go
@@ -39,7 +39,6 @@ and ARM64 clusters.`,
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		var (
 			username string

--- a/cmd/apps/registry_ingress_app.go
+++ b/cmd/apps/registry_ingress_app.go
@@ -52,7 +52,6 @@ to your email - this email is used by letsencrypt for domain expiry etc.`,
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		email, _ := command.Flags().GetString("email")
 		domain, _ := command.Flags().GetString("domain")

--- a/cmd/apps/tekton_app.go
+++ b/cmd/apps/tekton_app.go
@@ -28,7 +28,6 @@ func MakeInstallTekton() *cobra.Command {
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)

--- a/cmd/apps/traefik2_app.go
+++ b/cmd/apps/traefik2_app.go
@@ -37,7 +37,6 @@ func MakeInstallTraefik2() *cobra.Command {
 		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
 			return err
 		}
-		fmt.Printf("Using kubeconfig: %s\n", kubeConfigPath)
 
 		updateRepo, _ := traefik2.Flags().GetBool("update-repo")
 		namespace, _ := traefik2.Flags().GetString("namespace")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -22,7 +22,7 @@ func MakeInstall() *cobra.Command {
 		Short:   "Install Kubernetes apps from helm charts or YAML files",
 		Aliases: []string{"i"},
 		Long: `Install Kubernetes apps from helm charts or YAML files using the "install"
-command. 
+command.
 
 You can also find the post-install message for each app with the "info"
 command.`,


### PR DESCRIPTION
## Description
This PR fix a message being output twice 

Before, one app for example 
```
$ arkade install openfaas
Using Kubeconfig: /Users/cpanato/.kube/config
Using Kubeconfig: /Users/cpanato/.kube/config
[Warning] unable to create secret basic-auth, may already exist: Error from server (AlreadyExists): secrets "basic-auth" already exists
Client: x86_64, Darwin
```

after the fix:

```
$ ./arkade install openfaas
Using Kubeconfig: /Users/cpanato/.kube/config
[Warning] unable to create secret basic-auth, may already exist: Error from server (AlreadyExists): secrets "basic-auth" already exists
Client: x86_64, Darwin
2021/04/01 11:31:12 User dir established as: /Users/cpanato/.arkade/
```

removed the duplication of the message `Using Kubeconfig: ...`




## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: https://github.com/alexellis/arkade/issues/360

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment

/assign @alexellis 