### PR TITLE
Default the inlets-pro license location

### DIFF
--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -37,8 +37,9 @@ IngressController`,
 	}
 
 	inletsOperator.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
-	inletsOperator.Flags().StringP("license", "l", "", "The license key for inlets-pro")
-	inletsOperator.Flags().StringP("license-file", "f", "", "Text file containing license key, used for inlets-pro")
+	inletsOperator.Flags().StringP("license", "l", "", "The license key for inlets PRO")
+	inletsOperator.Flags().StringP("license-file", "f", "$HOME/.inlets/LICENSE", "Path to license JWT file for inlets PRO")
+
 	inletsOperator.Flags().StringP("provider", "p", "digitalocean", "Your infrastructure provider - 'equinix-metal', 'digitalocean', 'scaleway', 'linode', 'civo', 'gce', 'ec2', 'azure', 'hetzner'")
 	inletsOperator.Flags().StringP("zone", "z", "us-central1-a", "The zone to provision the exit node (GCE)")
 	inletsOperator.Flags().String("project-id", "", "Project ID to be used (for GCE and Equinix Metal)")

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -179,6 +179,7 @@ IngressController`,
 
 		license, _ := command.Flags().GetString("license")
 		licenseFile, _ := command.Flags().GetString("license-file")
+		fileFlagChanged := command.Flags().Changed("license-file")
 
 		noLicenseErr := fmt.Errorf("--license or --license-file is required for inlets PRO")
 		if len(license) == 0 {
@@ -187,9 +188,10 @@ IngressController`,
 
 				res, err := ioutil.ReadFile(licenseFile)
 				if err != nil {
-					if command.Flags().Changed("license-file") == false {
+					if fileFlagChanged == false {
 						return noLicenseErr
 					}
+
 					return fmt.Errorf("unable to open license file: %s", err.Error())
 				}
 				license = strings.TrimSpace(string(res))


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Default the inlets-pro license location

## Motivation and Context

This change looks for an inlets pro license in $HOME/.inlets
when a license value isn't given and the flag for a file has
not been changed.

## How Has This Been Tested?

The code was adapted from inlets PRO.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
