### PR TITLE
Fix #409 for arm64 usage

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -260,69 +260,6 @@ func Test_DownloadFaaSCLIWindows(t *testing.T) {
 	}
 }
 
-func Test_DownloadHelmDarwin(t *testing.T) {
-	tools := MakeTools()
-	name := "helm"
-	var tool *Tool
-	for _, target := range tools {
-		if name == target.Name {
-			tool = &target
-			break
-		}
-	}
-
-	got, err := tool.GetURL("darwin", arch64bit, tool.Version)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "https://get.helm.sh/helm-v3.5.2-darwin-amd64.tar.gz"
-	if got != want {
-		t.Fatalf("want: %s, got: %s", want, got)
-	}
-}
-
-func Test_DownloadHelmLinux(t *testing.T) {
-	tools := MakeTools()
-	name := "helm"
-	var tool *Tool
-	for _, target := range tools {
-		if name == target.Name {
-			tool = &target
-			break
-		}
-	}
-
-	got, err := tool.GetURL("linux", arch64bit, tool.Version)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "https://get.helm.sh/helm-v3.5.2-linux-amd64.tar.gz"
-	if got != want {
-		t.Fatalf("want: %s, got: %s", want, got)
-	}
-}
-
-func Test_DownloadHelmWindows(t *testing.T) {
-	tools := MakeTools()
-	name := "helm"
-	var tool *Tool
-	for _, target := range tools {
-		if name == target.Name {
-			tool = &target
-			break
-		}
-	}
-
-	got, err := tool.GetURL("mingw64_nt-10.0-18362", arch64bit, tool.Version)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "https://get.helm.sh/helm-v3.5.2-windows-amd64.zip"
-	if got != want {
-		t.Fatalf("want: %s, got: %s", want, got)
-	}
-}
-
 func Test_DownloadKubeseal(t *testing.T) {
 	tools := MakeTools()
 	name := "kubeseal"
@@ -1502,6 +1439,51 @@ func Test_DownloandFluxCli(t *testing.T) {
 			arch:    arch64bit,
 			version: "0.13.4",
 			url:     `https://github.com/fluxcd/flux2/releases/download/v0.13.4/flux_0.13.4_darwin_amd64.tar.gz`,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+
+}
+
+func Test_DownloandHelm(t *testing.T) {
+	tools := MakeTools()
+	name := "helm"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: "3.5.4",
+			url:     `https://get.helm.sh/helm-3.5.4-linux-amd64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: "3.5.4",
+			url:     `https://get.helm.sh/helm-3.5.4-linux-arm.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: "3.5.4",
+			url:     `https://get.helm.sh/helm-3.5.4-linux-arm64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: "3.5.4",
+			url:     `https://get.helm.sh/helm-3.5.4-darwin-amd64.tar.gz`,
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -54,6 +54,10 @@ func MakeTools() Tools {
 {{$arch = "amd64"}}
 {{- end -}}
 
+{{- if eq .Arch "aarch64" -}}
+{{$arch = "arm64"}}
+{{- end -}}
+
 {{$os := .OS}}
 {{$ext := "tar.gz"}}
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix #409 for arm64 usage

## Motivation and Context

This should only affect users who install arkade on their
Kubernetes nodes, which is an unexpected way to use a client
installer tool like arkade.

arkade is a client and should be run on a desktop / laptop with a valid KUBECONFIG file, which could be pointing at an ARM, ARM64 or `x86_64` cluster

Fixes: #409

## How Has This Been Tested?

A failing unit test that was made to pass after a code change.
