### PR TITLE
Add kgctl cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Use "arkade get TOOL" to download a tool or application:
   k3sup
   k9s
   kail
+  kgctl
   kim
   kind
   kops

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1749,5 +1749,60 @@ func Test_DownloadKubetailCli(t *testing.T) {
 			}
 		})
 	}
+}
 
+func Test_DownloadKgctl(t *testing.T) {
+	tools := MakeTools()
+	name := "kgctl"
+	tool := getTool(name, tools)
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: "0.3.0",
+			url:     `https://github.com/squat/kilo/releases/download/0.3.0/kgctl-darwin-amd64`,
+		},
+		{
+			os:      "darwin",
+			arch:    archARM64,
+			version: "0.3.0",
+			url:     `https://github.com/squat/kilo/releases/download/0.3.0/kgctl-darwin-arm64`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: "0.3.0",
+			url:     `https://github.com/squat/kilo/releases/download/0.3.0/kgctl-linux-amd64`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: "0.3.0",
+			url:     `https://github.com/squat/kilo/releases/download/0.3.0/kgctl-linux-arm`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: "0.3.0",
+			url:     `https://github.com/squat/kilo/releases/download/0.3.0/kgctl-linux-arm64`,
+		},
+		{
+			os:      "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: "0.3.0",
+			url:     `https://github.com/squat/kilo/releases/download/0.3.0/kgctl-windows-amd64`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
 }

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1319,5 +1319,28 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Description: "Bash script to tail Kubernetes logs from multiple pods at the same time.",
 			URLTemplate: `https://raw.githubusercontent.com/{{.Owner}}/{{.Repo}}/{{.Version}}/{{.Name}}`,
 		})
+
+	tools = append(tools,
+		Tool{
+
+			Owner:       "squat",
+			Repo:        "kilo",
+			Name:        "kgctl",
+			Version:     "0.3.0",
+			Description: "A CLI to manage Kilo, a multi-cloud network overlay built on WireGuard and designed for Kubernetes.",
+			BinaryTemplate: `
+{{$os := .OS}}
+{{ if HasPrefix .OS "ming" -}}
+{{$os = "windows"}}
+{{- end -}}
+{{$arch := "amd64"}}
+{{ if eq .Arch "armv7l" -}}
+{{$arch = "arm"}}
+{{- else if eq .Arch "aarch64" -}}
+{{$arch = "arm64"}}
+{{- end -}}
+{{.Name}}-{{$os}}-{{$arch}}`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
This commit introduces support for installing `kgctl`, the companion CLI
tool for Kilo, via arkade.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

## Description
Add the `kgctl` CLI tool

## Motivation and Context
Fixes #450
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
```shell
$ docker container run --rm -v $(pwd):/workspace -ti golang:1.16.3-alpine sh
# cd /workspace
# go build
# ./arkade get kgctl
```
![image](https://user-images.githubusercontent.com/20484159/125313342-6e67cb80-e335-11eb-898c-080c4e0f7753.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
