### PR TITLE
Add kubetail CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Use "arkade get TOOL" to download a tool or application:
   kubectx
   kubens
   kubeseal
+  kubetail
   kustomize
   linkerd2
   mc

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1704,3 +1704,50 @@ func Test_DownloandNovaCli(t *testing.T) {
 	}
 
 }
+
+func Test_DownloadKubetailCli(t *testing.T) {
+	tools := MakeTools()
+	name := "kubetail"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: "1.6.13",
+			url:     `https://raw.githubusercontent.com/johanhaleby/kubetail/1.6.13/kubetail`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: "1.6.13",
+			url:     `https://raw.githubusercontent.com/johanhaleby/kubetail/1.6.13/kubetail`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: "1.6.13",
+			url:     `https://raw.githubusercontent.com/johanhaleby/kubetail/1.6.13/kubetail`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: "1.6.13",
+			url:     `https://raw.githubusercontent.com/johanhaleby/kubetail/1.6.13/kubetail`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1310,5 +1310,14 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				`,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:       "johanhaleby",
+			Repo:        "kubetail",
+			Name:        "kubetail",
+			Version:     "1.6.13",
+			Description: "Bash script to tail Kubernetes logs from multiple pods at the same time.",
+			URLTemplate: `https://raw.githubusercontent.com/{{.Owner}}/{{.Repo}}/{{.Version}}/{{.Name}}`,
+		})
 	return tools
 }


### PR DESCRIPTION
This commit adds support for downloading `kubetail` a CLI tool for
aggregating and tailing Kubernetes logs. This tool is a bash script, so
it's platform- and architecture-agnoistic.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

## Description
Add the kubetail CLI tool

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: #377

## How Has This Been Tested?
```shell
docker container run --rm -v $(pwd):/workspace -ti golang:1.16.3-alpine sh
cd /workspace
go build
# Install kubectl dependency for kubetail.
./arkade get kubectl > /dev/null 2>&1 && mv /root/.arkade/bin/kubectl /usr/local/bin/
# Install Bash dependency for kubetail.
apk add --no-cache bash > /dev/null
# Install kubetail.
./arkade get kubetail
mv /root/.arkade/bin/kubetail /usr/local/bin/
kubetail --version
```
![image](https://user-images.githubusercontent.com/20484159/125340600-f01a2200-e352-11eb-83f6-ecec718625e1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
