### PR TITLE
Add CLI tools for K10 project

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Use "arkade get TOOL" to download a tool or application:
   kubeseal
   kubetail
   kustomize
+  k10multicluster
+  k10tools
   linkerd2
   mc
   minikube

--- a/pkg/get/download.go
+++ b/pkg/get/download.go
@@ -33,7 +33,11 @@ func Download(tool *Tool, arch, operatingSystem, version string, downloadMode in
 		return "", "", err
 	}
 
-	if tool.IsArchive() {
+	if isArchive, err := tool.IsArchive(); isArchive {
+		if err != nil {
+			return "", "", err
+		}
+
 		archiveFile, err := os.Open(outFilePath)
 		if err != nil {
 			return "", "", err

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1515,8 +1515,8 @@ func Test_DownloadFluxCli(t *testing.T) {
 			t.Errorf("want: %s, got: %s", tc.url, got)
 		}
 	}
-
 }
+
 func Test_DownloadPolarisCli(t *testing.T) {
 	tools := MakeTools()
 	name := "polaris"
@@ -1899,4 +1899,140 @@ func Test_DownloadPorterCli(t *testing.T) {
 		})
 	}
 
+}
+
+func Test_DownloadKanister(t *testing.T) {
+	tools := MakeTools()
+	name := "kanister"
+	v := "0.63.0"
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kanisterio/kanister/releases/download/0.63.0/kanister_0.63.0_darwin_amd64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kanisterio/kanister/releases/download/0.63.0/kanister_0.63.0_linux_amd64.tar.gz`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}
+
+func Test_DownloadKubestr(t *testing.T) {
+	tools := MakeTools()
+	name := "kubestr"
+	v := "v0.4.17"
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr-v0.4.17-darwin-amd64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr-v0.4.17-linux-amd64.tar.gz`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}
+
+func Test_DownloadK10multicluster(t *testing.T) {
+	tools := MakeTools()
+	name := "k10multicluster"
+	v := "4.0.6"
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/external-tools/releases/download/4.0.6/k10multicluster_4.0.6_macOS_amd64`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/external-tools/releases/download/4.0.6/k10multicluster_4.0.6_linux_amd64`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}
+
+func Test_DownloadK10tools(t *testing.T) {
+	tools := MakeTools()
+	name := "k10tools"
+	v := "4.0.6"
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/external-tools/releases/download/4.0.6/k10tools_4.0.6_macOS_amd64`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/external-tools/releases/download/4.0.6/k10tools_4.0.6_linux_amd64`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want:\n%s\ngot:\n%s", tc.url, got)
+			}
+		})
+	}
 }

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1247,42 +1247,42 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Description: "An opinionated way of installing Argo-CD and managing GitOps repositories.",
 			Version:     "0.2.1",
 			URLTemplate: `
-			{{$arch := ""}}
-			{{- if eq .Arch "x86_64" -}}
-			{{$arch = "amd64"}}
-			{{- else if eq .Arch "aarch64" -}}
-			{{$arch = "arm64"}}
-			{{- end -}}
+{{$arch := ""}}
+{{- if eq .Arch "x86_64" -}}
+{{$arch = "amd64"}}
+{{- else if eq .Arch "aarch64" -}}
+{{$arch = "arm64"}}
+{{- end -}}
 
-			{{$osString := ""}}
-			{{ if HasPrefix .OS "ming" -}}
-			{{$osString = "windows"}}
-			{{- else if eq .OS "linux" -}}
-			{{$osString = "linux"}}
-			{{- else if eq .OS "darwin" -}}
-			{{$osString = "darwin"}}
-			{{- end -}}
-			{{$ext := ".tar.gz"}}
-			https://github.com/{{.Owner}}/{{.Repo}}/releases/download/v{{.Version}}/{{.Name}}-{{$osString}}-{{$arch}}{{$ext}}
-			`,
+{{$osString := ""}}
+{{ if HasPrefix .OS "ming" -}}
+{{$osString = "windows"}}
+{{- else if eq .OS "linux" -}}
+{{$osString = "linux"}}
+{{- else if eq .OS "darwin" -}}
+{{$osString = "darwin"}}
+{{- end -}}
+{{$ext := ".tar.gz"}}
+https://github.com/{{.Owner}}/{{.Repo}}/releases/download/v{{.Version}}/{{.Name}}-{{$osString}}-{{$arch}}{{$ext}}
+`,
 			BinaryTemplate: `
-			{{$arch := ""}}
-			{{- if eq .Arch "x86_64" -}}
-			{{$arch = "amd64"}}
-			{{- else if eq .Arch "aarch64" -}}
-			{{$arch = "arm64"}}
-			{{- end -}}
+{{$arch := ""}}
+{{- if eq .Arch "x86_64" -}}
+{{$arch = "amd64"}}
+{{- else if eq .Arch "aarch64" -}}
+{{$arch = "arm64"}}
+{{- end -}}
 
-			{{$osString := ""}}
-			{{ if HasPrefix .OS "ming" -}}
-			{{$osString = "windows"}}
-			{{- else if eq .OS "linux" -}}
-			{{$osString = "linux"}}
-			{{- else if eq .OS "darwin" -}}
-			{{$osString = "darwin"}}
-			{{- end -}}
-			{{.Name}}-{{$osString}}-{{$arch}}
-			`,
+{{$osString := ""}}
+{{ if HasPrefix .OS "ming" -}}
+{{$osString = "windows"}}
+{{- else if eq .OS "linux" -}}
+{{$osString = "linux"}}
+{{- else if eq .OS "darwin" -}}
+{{$osString = "darwin"}}
+{{- end -}}
+{{.Name}}-{{$osString}}-{{$arch}}
+`,
 		},
 	)
 
@@ -1354,14 +1354,14 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			BinaryTemplate: `
 			{{ $ext := "" }}
 			{{ $osStr := "linux" }}
-			{{ if HasPrefix .OS "ming" -}}
+			{{- if HasPrefix .OS "ming" -}}
 			{{	$osStr = "windows" }}
 			{{ $ext = ".exe" }}
 			{{- else if eq .OS "darwin" -}}
 			{{  $osStr = "darwin" }}
 			{{- end -}}
 			{{ $archStr := "amd64" }}
-			{{ if eq .Arch "armv7l" -}}
+			{{- if eq .Arch "armv7l" -}}
 			{{$archStr = "armv7"}}
 			{{- else if eq .Arch "aarch64" -}}
 			{{$archStr = "arm64"}}
@@ -1429,6 +1429,92 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 	{{.Name}}-{{$os}}-{{$arch}}{{$ext}}`,
 		},
 	)
+
+	tools = append(tools,
+		Tool{
+			Owner:       "kanisterio",
+			Repo:        "kanister",
+			Name:        "kanister",
+			Version:     "0.63.0",
+			Description: "Framework for application-level data management on Kubernetes.",
+			URLTemplate: `
+{{ $osStr := "linux" }}
+{{- if eq .OS "darwin" -}}
+{{ $osStr = "darwin" }}
+{{- end -}}
+
+https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_{{$.Version}}_{{$osStr}}_amd64.tar.gz`,
+			BinaryTemplate: `{{.Name}}`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "kastenhq",
+			Repo:        "kubestr",
+			Name:        "kubestr",
+			Version:     "v0.4.17",
+			Description: "Kubestr discovers, validates and evaluates your Kubernetes storage options.",
+
+			URLTemplate: `
+{{ $ext := "tar.gz" }}
+{{ $osStr := "linux" }}
+
+{{- if eq .OS "darwin" -}}
+{{ $osStr = "darwin" }}
+{{- else if HasPrefix .OS "ming" -}}
+{{ $osStr = "windows" }}
+{{ $ext = ".zip" }}
+{{- end -}}
+
+https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}-{{.Version}}-{{$osStr}}-amd64.{{$ext}}`,
+			BinaryTemplate: `{{.Name}}`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "kastenhq",
+			Repo:        "external-tools",
+			Name:        "k10multicluster",
+			Version:     "4.0.6",
+			Description: "Multi-cluster support for K10.",
+
+			BinaryTemplate: `
+	{{ $osStr := "linux" }}
+	{{ $archStr := "amd64" }}
+
+	{{- if eq .Arch "aarch64" -}}
+	{{ $archStr = "arm64" }}
+	{{- end -}}
+
+	{{- if eq .OS "darwin" -}}
+	{{ $osStr = "macOS" }}
+	{{- end -}}
+
+	{{.Name}}_{{.Version}}_{{$osStr}}_{{$archStr}}`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "kastenhq",
+			Repo:        "external-tools",
+			Name:        "k10tools",
+			Version:     "4.0.6",
+			Description: "Tools for evaluating and debugging K10.",
+
+			BinaryTemplate: `
+	{{ $osStr := "linux" }}
+	{{ $archStr := "amd64" }}
+
+	{{- if eq .Arch "aarch64" -}}
+	{{ $archStr = "arm64" }}
+	{{- end -}}
+
+	{{- if eq .OS "darwin" -}}
+	{{ $osStr = "macOS" }}
+	{{- end -}}
+
+	{{.Name}}_{{.Version}}_{{$osStr}}_{{$archStr}}`,
+		})
 
 	return tools
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add CLI tools for K10 project

## Motivation and Context

Fixes: #465

## How Has This Been Tested?

Tested with unit tests and running the tool locally. I'm still waiting for a confirmation on the `kanister` tool from the K10 team.

```bash
+------------------+--------------------------------------------------------------+
| k10multicluster  | Multi-cluster support for K10.                               |
+------------------+--------------------------------------------------------------+
| k10tools         | Tools for evaluating and debugging K10.                      |
+------------------+--------------------------------------------------------------+
| kubestr          | Kubestr discovers, validates and evaluates your Kubernetes   |
|                  | storage options.                                             |
+------------------+--------------------------------------------------------------+
| kanister         | Framework for application-level data management on           |
|                  | Kubernetes.                                                  |
+------------------+--------------------------------------------------------------+
```
