### PR TITLE
Add comma escaping for --set flag

### DIFF
--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -233,6 +233,10 @@ func mergeFlags(existingMap map[string]string, setOverrides []string) error {
 		if len(flag) != 2 {
 			return fmt.Errorf("incorrect format for custom flag `%s`", setOverride)
 		}
+
+		if strings.ContainsAny(flag[1], ",") {
+			flag[1] = strings.ReplaceAll(flag[1], ",", "\\,")
+		}
 		existingMap[flag[0]] = flag[1]
 	}
 	return nil

--- a/cmd/apps/openfaas_app_test.go
+++ b/cmd/apps/openfaas_app_test.go
@@ -4,6 +4,7 @@
 package apps
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -21,4 +22,22 @@ func Test_getValuesSuffix_aarch64(t *testing.T) {
 	if want != got {
 		t.Errorf("suffix, want: %s, got: %s", want, got)
 	}
+}
+
+func Test_mergeFlags(t *testing.T) {
+	existingMap := map[string]string{}
+
+	want := map[string]string{
+		"httpRetryCodes":    `429\,502\,500\,504\,408`,
+		"queueWorker.image": "alexellis2/pro-queue-worker-demo:0.1.1",
+	}
+
+	mergeFlags(existingMap, []string{"queueWorker.image=alexellis2/pro-queue-worker-demo:0.1.1", "httpRetryCodes=429,502,500,504,408"})
+
+	eq := reflect.DeepEqual(existingMap, want)
+
+	if !eq {
+		t.Errorf("want: %s, got: %s", want, existingMap)
+	}
+
 }


### PR DESCRIPTION
Helm splits comma-separated values passed with --set.
Add escape character to escape comma to prevent the default behavior.

Fixes #475 

Signed-off-by: Yankee Maharjan <yankee.exe@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Helm splitting comma-separated values seem to be a known issue https://github.com/helm/helm/issues/1556
Adding an escape character for a comma fixes the issue. 
This change looks for a comma in a string and adds escape characters before it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Installed OpenFaas on a local cluster with the following command. 
```bash
go run . install openfaas \
  --set queueWorker.image=alexellis2/pro-queue-worker-demo:0.1.1 \
  --set httpRetryCodes=429,502,500,504,408
```

<details>
<summary><strong>Successful Installation with Comma Separated Values</strong></summary>
<img src="https://user-images.githubusercontent.com/13623913/126887228-bef5eb56-b8d0-42c3-8957-58e0c548d1a9.png" />
</details>

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
