### PR TITLE
Add MetalLB app for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Apps:
 | inlets-operator         | Install inlets-operator                                             |
 | rabbitmq                | Install rabbitmq                                                    |
 | chart                   | Install the specified helm chart                                    |
+| metallb-arp             | Install MetalLB in L2 (ARP) mode                                    |
 
 There are 47 apps that you can install on your cluster.
 

--- a/cmd/apps/metallb_app.go
+++ b/cmd/apps/metallb_app.go
@@ -1,0 +1,104 @@
+package apps
+
+import (
+	"crypto/rand"
+	b64 "encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/k8s"
+	"github.com/alexellis/arkade/pkg/types"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallMetalLB() *cobra.Command {
+	var command = &cobra.Command{
+		Use:          "metallb",
+		Short:        "Install metallb",
+		Long:         `Install metallb for service type:LoadBalancer`,
+		Example:      `arkade install metallb`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().String("address-range", "192.168.0.0/24", "Address range for loadBalancer services")
+
+	command.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
+		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
+			return err
+		}
+
+		addressRange, _ := command.Flags().GetString("address-range")
+
+		err := k8s.Kubectl("apply", "-f",
+			"https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/namespace.yaml")
+		if err != nil {
+			return err
+		}
+
+		err = k8s.Kubectl("apply", "-f",
+			"https://raw.githubusercontent.com/metallb/metallb/v0.9.5/manifests/metallb.yaml")
+		if err != nil {
+			return err
+		}
+
+		token := make([]byte, 32)
+		rand.Read(token)
+
+		secret := types.K8sSecret{
+			Type:      "generic",
+			Name:      "memberlist",
+			Namespace: "metallb-system",
+			SecretData: []types.SecretsData{{
+				Type:  "string-literal",
+				Key:   "secretkey",
+				Value: b64.StdEncoding.EncodeToString(token),
+			}},
+		}
+
+		err = k8s.CreateSecret(secret)
+		if err != nil {
+			return fmt.Errorf("Create secret error: %+v", err)
+		}
+
+		configMap := fmt.Sprintf(metalLBConfigMap, addressRange)
+
+		err = k8s.KubectlIn(strings.NewReader(configMap), "apply", "-f", "-")
+		if err != nil {
+			return fmt.Errorf("Create configmap error: %+v", err)
+		}
+
+		fmt.Println(MetalLBInstallMsg)
+
+		return nil
+	}
+
+	return command
+}
+
+const MetalLBInfoMsg = `# Find out more at:
+# https://metallb.universe.tf/
+`
+
+const MetalLBInstallMsg = `=======================================================================
+= metalLB has been installed.                                  =
+=======================================================================` +
+	"\n\n" + MetalLBInfoMsg + "\n\n" + pkg.ThanksForUsing
+
+const metalLBConfigMap = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - %s
+`

--- a/cmd/apps/metallb_app.go
+++ b/cmd/apps/metallb_app.go
@@ -31,6 +31,13 @@ func MakeInstallMetalLB() *cobra.Command {
 			return err
 		}
 
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(OnlyIntelArch)
+		}
+
 		addressRange, _ := command.Flags().GetString("address-range")
 
 		err := k8s.Kubectl("apply", "-f",

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -144,6 +144,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["kyverno"] = NewArkadeApp(apps.MakeInstallKyverno, apps.KyvernoInfoMsg)
 	arkadeApps["rabbitmq"] = NewArkadeApp(apps.MakeInstallRabbitmq, apps.RabbitmqInfoMsg)
 	arkadeApps["cassandra"] = NewArkadeApp(apps.MakeInstallCassandra, apps.CassandraInfoMsg)
+	arkadeApps["metallb"] = NewArkadeApp(apps.MakeInstallMetalLB, apps.MetalLBInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -144,7 +144,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["kyverno"] = NewArkadeApp(apps.MakeInstallKyverno, apps.KyvernoInfoMsg)
 	arkadeApps["rabbitmq"] = NewArkadeApp(apps.MakeInstallRabbitmq, apps.RabbitmqInfoMsg)
 	arkadeApps["cassandra"] = NewArkadeApp(apps.MakeInstallCassandra, apps.CassandraInfoMsg)
-	arkadeApps["metallb"] = NewArkadeApp(apps.MakeInstallMetalLB, apps.MetalLBInfoMsg)
+	arkadeApps["metallb-arp"] = NewArkadeApp(apps.MakeInstallMetalLB, apps.MetalLBInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")

--- a/pkg/k8s/kubernetes_exec.go
+++ b/pkg/k8s/kubernetes_exec.go
@@ -91,6 +91,28 @@ func Kubectl(parts ...string) error {
 	return nil
 }
 
+func KubectlIn(stdin io.Reader, parts ...string) error {
+	task := execute.ExecTask{
+		Command:     "kubectl",
+		Args:        parts,
+		StreamStdio: true,
+		Stdin:       stdin,
+	}
+
+	res, err := task.Execute()
+
+	if err != nil {
+		return err
+	}
+
+	if res.ExitCode != 0 {
+		return fmt.Errorf("kubectl exit code %d, stderr: %s",
+			res.ExitCode,
+			res.Stderr)
+	}
+	return nil
+}
+
 func CreateNamespace(namespace string) error {
 	nsRes, nsErr := KubectlTask("create", "namespace", namespace)
 	if nsErr != nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR is based on PR #329 and adds support for metallb installation. It installs metallb in L2 mode and provides an argument for configurable LB IP range (default: 192.168.0.0/24)

## Motivation and Context
Fixes #76

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Installed MetalLB on KinD (based on https://kind.sigs.k8s.io/docs/user/loadbalancer/)

Create new KinD cluster:
```
$ kind create cluster
Creating cluster "kind" ...
 ✓ Ensuring node image (kindest/node:v1.21.1) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
Set kubectl context to "kind-kind"
You can now use your cluster with:

kubectl cluster-info --context kind-kind

Thanks for using kind! 😊
```
Find address pool used by loadbalancers:
```
$ docker network inspect -f '{{.IPAM.Config}}' kind
[{172.20.0.0/16  172.20.0.1 map[]} {fc00:f853:ccd:e793::/64  fc00:f853:ccd:e793::1 map[]}]
```
We want our loadbalancer IP range to come from this subclass. We can configure metallb, for instance, to use 172.20.255.200 to 172.20.255.250
```
$ ./arkade install metallb-arp --address-range "172.20.255.200-172.20.255.250"
```

Install ingress-nginx, with a LoadBalancer:
```
./arkade install ingress-nginx
```
Any pending LoadBalancer services will soon get a new IP:

```
$ kubectl get services
NAME                                 TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                      AGE
ingress-nginx-controller             LoadBalancer   10.96.193.143   172.20.255.200   80:30185/TCP,443:32426/TCP   7m42s
ingress-nginx-controller-admission   ClusterIP      10.96.38.194    <none>           443/TCP                      7m42s
kubernetes                           ClusterIP      10.96.0.1       <none>           443/TCP                      10m
```

Checking my MetalLB controller logs:
```
$ kubectl logs -n metallb-system controller-6b78bff7d9-jf869
...
{"caller":"main.go:49","event":"startUpdate","msg":"start of service update","service":"default/ingress-nginx-controller","ts":"2021-08-30T07:04:07.391156882Z"}
{"caller":"service.go:114","event":"ipAllocated","ip":"172.20.255.200","msg":"IP address assigned by controller","service":"default/ingress-nginx-controller","ts":"2021-08-30T07:04:07.391425073Z"}
{"caller":"main.go:88","event":"serviceUpdated","msg":"updated service object","service":"default/ingress-nginx-controller","ts":"2021-08-30T07:04:07.409003146Z"}
{"caller":"main.go:90","event":"endUpdate","msg":"end of service update","service":"default/ingress-nginx-controller","ts":"2021-08-30T07:04:07.409057203Z"}
{"caller":"main.go:49","event":"startUpdate","msg":"start of service update","service":"default/ingress-nginx-controller","ts":"2021-08-30T07:04:07.409085505Z"}
{"caller":"main.go:75","event":"noChange","msg":"service converged, no change","service":"default/ingress-nginx-controller","ts":"2021-08-30T07:04:07.409442264Z"}
{"caller":"main.go:76","event":"endUpdate","msg":"end of service update","service":"default/ingress-nginx-controller","ts":"2021-08-30T07:04:07.409473032Z"}
...
```

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [x] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
