### PR TITLE
Support --arch and --os flags for arkade get

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ arkade get APP@VERSION
 arkade get APP1 APP2 APP3
 
 arkade get APP1 APP2@VERSION APP3
+
+# Override machine os/arch
+arkade get APP --arch ARCH --os OS
 ```
 
 |       TOOL       |                                                                DESCRIPTION                                                                |

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -44,10 +44,13 @@ and provides a fast and easy alternative to a package manager.`,
 		ValidArgs:    validToolOptions,
 	}
 
+	clientArch, clientOS := env.GetClientArch()
 	command.Flags().Bool("progress", true, "Display a progress bar")
 	command.Flags().StringP("output", "o", "", "Output format of the list of tools (table/markdown/list)")
 	command.Flags().Bool("stash", true, "When set to true, stash binary in HOME/.arkade/bin/, otherwise store in /tmp/")
 	command.Flags().StringP("version", "v", "", "Download a specific version")
+	command.Flags().String("arch", clientArch, "CPU architecture for the tool")
+	command.Flags().String("os", clientOS, "Operating system for the tool")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -80,8 +83,6 @@ and provides a fast and easy alternative to a package manager.`,
 			return err
 		}
 
-		arch, operatingSystem := env.GetClientArch()
-
 		stash, _ := command.Flags().GetBool("stash")
 		progress, _ := command.Flags().GetBool("progress")
 		if p, ok := os.LookupEnv("ARKADE_PROGRESS"); ok {
@@ -108,6 +109,15 @@ and provides a fast and easy alternative to a package manager.`,
 
 		var outFilePath string
 		var localToolsStore []get.ToolLocal
+
+		arch, _ := command.Flags().GetString("arch")
+		if err := get.ValidateArch(arch); err != nil {
+			return err
+		}
+		operatingSystem, _ := command.Flags().GetString("os")
+		if err := get.ValidateOS(operatingSystem); err != nil {
+			return err
+		}
 
 		for _, tool := range downloadURLs {
 			fmt.Printf("Downloading: %s\n", tool.Name)

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func Test_GetCommand(t *testing.T) {
+	tests := []struct {
+		args          []string
+		expectedError string
+	}{
+		{
+			args:          []string{"kind", "--arch", "dummy"},
+			expectedError: "cpu architecture \"dummy\" is not supported",
+		},
+		{
+			args:          []string{"kind", "--os", "dummy"},
+			expectedError: "operating system \"dummy\" is not supported",
+		},
+	}
+
+	for _, tc := range tests {
+		cmd := MakeGet()
+		cmd.SetArgs(tc.args)
+		err := cmd.Execute()
+		if !strings.Contains(err.Error(), tc.expectedError) {
+			t.Fatalf("for args %q\n want: %q\n but got: %q", tc.args, tc.expectedError, err)
+		}
+	}
+}

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -15,6 +15,9 @@ import (
 	"github.com/alexellis/arkade/pkg/env"
 )
 
+var supportedOS = [...]string{"linux", "darwin", "ming"}
+var supportedArchitectures = [...]string{"x86_64", "arm", "amd64", "armv6l", "armv7l", "aarch64"}
+
 // Tool describes how to download a CLI tool from a binary
 // release - whether a single binary, or an archive.
 type Tool struct {
@@ -370,4 +373,27 @@ sudo mv {{.Path}} /usr/local/bin/
 	}
 
 	return tpl.Bytes(), err
+}
+
+// ValidateOS returns whether a given operating system is supported
+func ValidateOS(name string) error {
+	for _, os := range supportedOS {
+		if strings.HasPrefix(strings.ToLower(name), os) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("operating system %q is not supported. Available prefixes: %s.",
+		name, strings.Join(supportedOS[:], ", "))
+}
+
+// ValidateArch returns whether a given cpu architecture is supported
+func ValidateArch(name string) error {
+	for _, arch := range supportedArchitectures {
+		if arch == strings.ToLower(name) {
+			return nil
+		}
+	}
+	return fmt.Errorf("cpu architecture %q is not supported. Available: %s.",
+		name, strings.Join(supportedArchitectures[:], ", "))
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

By default, the `arkade get` command will use the client
cpu architecture and os (using `uname` command).
The new flags will allow to override the default behavior, and download
different binaries for different platforms.

In case of an unsupported architecture or OS, an appropriate message
would be shown with all the options available.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Resolves https://github.com/alexellis/arkade/issues/536


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```text
Flags:
      --arch string      CPU architecture for the tool (default "x86_64")
      --os string        Operating system for the tool (default "Linux")
```

```bash
➜  arkade git:(get-override-arch) ✗ ./arkade get yq --arch dummy
Downloading: yq
Error: CPU Architecture "dummy" is not supported. Available: i686, x86_64, arm, amd64, armv6l, armv7l, aarch64.

➜  arkade git:(get-override-arch) ✗ ./arkade get yq --arch amd64 --os darwin
Downloading: yq
2021/10/13 17:54:17 Looking up version for yq
2021/10/13 17:54:18 Found: v4.13.4
Downloading: https://github.com/mikefarah/yq/releases/download/v4.13.4/yq_darwin_amd64
...
```

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
