### PR TITLE
Fix download paths of `kubestr`

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -2393,7 +2393,7 @@ func Test_DownloadKanister(t *testing.T) {
 func Test_DownloadKubestr(t *testing.T) {
 	tools := MakeTools()
 	name := "kubestr"
-	v := "v0.4.17"
+	v := "0.4.17"
 	tool := getTool(name, tools)
 
 	tests := []test{
@@ -2401,13 +2401,13 @@ func Test_DownloadKubestr(t *testing.T) {
 			os:      "darwin",
 			arch:    arch64bit,
 			version: v,
-			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr-v0.4.17-darwin-amd64.tar.gz`,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr_0.4.17_Darwin_x86_64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
 			version: v,
-			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr-v0.4.17-linux-amd64.tar.gz`,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr_0.4.17_Linux_x86_64.tar.gz`,
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -968,7 +968,6 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			Owner:       "aquasecurity",
 			Repo:        "kube-bench",
 			Name:        "kube-bench",
-			Version:     "0.4.0",
 			Description: "Checks whether Kubernetes is deployed securely by running the checks documented in the CIS Kubernetes Benchmark.",
 			BinaryTemplate: `
 {{$arch := "arm"}}
@@ -1600,19 +1599,19 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			Repo:        "kubestr",
 			Name:        "kubestr",
 			Description: "Kubestr discovers, validates and evaluates your Kubernetes storage options.",
-
+			Version:     "0.4.29",
 			URLTemplate: `
 {{ $ext := "tar.gz" }}
-{{ $osStr := "linux" }}
+{{ $osStr := "Linux" }}
 
 {{- if eq .OS "darwin" -}}
-{{ $osStr = "darwin" }}
+{{ $osStr = "Darwin" }}
 {{- else if HasPrefix .OS "ming" -}}
-{{ $osStr = "windows" }}
+{{ $osStr = "Windows" }}
 {{ $ext = ".zip" }}
 {{- end -}}
 
-https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}-{{.Version}}-{{$osStr}}-amd64.{{$ext}}`,
+https://github.com/{{.Owner}}/{{.Repo}}/releases/download/v{{.Version}}/{{.Name}}_{{.Version}}_{{$osStr}}_{{.Arch}}.{{$ext}}`,
 			BinaryTemplate: `{{.Name}}`,
 		})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix download paths of `kubestr` and `kube-bench`.

```bash
➜  arkade git:(fix-krew-kubestr-kube-bench-tools) ✗ arkade get kube-bench
Downloading: kube-bench
Downloading: https://github.com/aquasecurity/kube-bench/releases/download/0.4.0/kube-bench_0.4.0_linux_amd64.tar.gz
Error: check with the vendor whether this tool is available for your system: incorrect status for downloading tool: 404

➜  arkade git:(fix-krew-kubestr-kube-bench-tools) ✗ arkade get kubestr     
Downloading: kubestr
2021/10/21 19:54:43 Looking up version for kubestr
2021/10/21 19:54:44 Found: v0.4.29
Downloading: https://github.com/kastenhq/kubestr/releases/download/v0.4.29/kubestr-v0.4.29-linux-amd64.tar.gz
Error: check with the vendor whether this tool is available for your system: incorrect status for downloading tool: 404
```

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Resolves  #550


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually
```bash
➜  arkade git:(fix-krew-kubestr-kube-bench-tools) ✗ ./arkade get --stash=false kubestr kube-bench
Downloading: kubestr
Downloading: https://github.com/kastenhq/kubestr/releases/download/v0.4.29/kubestr_0.4.29_linux_x86_64.tar.gz
9.73 MiB / 9.73 MiB [------------------------------------------------------------------------------------------] 100.00%
/tmp/kubestr_0.4.29_linux_x86_64.tar.gz written.
/tmp/LICENSE LICENSE
/tmp/README.md README.md
/tmp/kubestr kubestr
2021/10/21 19:55:35 extracted tarball into /tmp: 3 files, 0 dirs (709.953685ms)
2021/10/21 19:55:35 Extracted: /tmp/kubestr

Tool written to: /tmp/kubestr

Downloading: kube-bench
2021/10/21 19:55:35 Looking up version for kube-bench
2021/10/21 19:55:36 Found: v0.6.5
Downloading: https://github.com/aquasecurity/kube-bench/releases/download/v0.6.5/kube-bench_0.6.5_linux_amd64.tar.gz
9.88 MiB / 9.88 MiB [------------------------------------------------------------------------------------------] 100.00%
/tmp/kube-bench_0.6.5_linux_amd64.tar.gz written.
2021/10/21 19:55:37 Looking up version for kube-bench
2021/10/21 19:55:37 Found: v0.6.5
/tmp/config.yaml cfg/ack-1.0/config.yaml
/tmp/controlplane.yaml cfg/ack-1.0/controlplane.yaml
/tmp/etcd.yaml cfg/ack-1.0/etcd.yaml
/tmp/managedservices.yaml cfg/ack-1.0/managedservices.yaml
/tmp/master.yaml cfg/ack-1.0/master.yaml
/tmp/node.yaml cfg/ack-1.0/node.yaml
/tmp/policies.yaml cfg/ack-1.0/policies.yaml
/tmp/config.yaml cfg/aks-1.0/config.yaml
/tmp/controlplane.yaml cfg/aks-1.0/controlplane.yaml
/tmp/managedservices.yaml cfg/aks-1.0/managedservices.yaml
/tmp/master.yaml cfg/aks-1.0/master.yaml
/tmp/node.yaml cfg/aks-1.0/node.yaml
/tmp/policies.yaml cfg/aks-1.0/policies.yaml
/tmp/config.yaml cfg/cis-1.20/config.yaml
/tmp/controlplane.yaml cfg/cis-1.20/controlplane.yaml
/tmp/etcd.yaml cfg/cis-1.20/etcd.yaml
/tmp/master.yaml cfg/cis-1.20/master.yaml
/tmp/node.yaml cfg/cis-1.20/node.yaml
/tmp/policies.yaml cfg/cis-1.20/policies.yaml
/tmp/config.yaml cfg/cis-1.5/config.yaml
/tmp/controlplane.yaml cfg/cis-1.5/controlplane.yaml
/tmp/etcd.yaml cfg/cis-1.5/etcd.yaml
/tmp/master.yaml cfg/cis-1.5/master.yaml
/tmp/node.yaml cfg/cis-1.5/node.yaml
/tmp/policies.yaml cfg/cis-1.5/policies.yaml
/tmp/config.yaml cfg/cis-1.6/config.yaml
/tmp/controlplane.yaml cfg/cis-1.6/controlplane.yaml
/tmp/etcd.yaml cfg/cis-1.6/etcd.yaml
/tmp/master.yaml cfg/cis-1.6/master.yaml
/tmp/node.yaml cfg/cis-1.6/node.yaml
/tmp/policies.yaml cfg/cis-1.6/policies.yaml
/tmp/config.yaml cfg/config.yaml
/tmp/config.yaml cfg/eks-1.0/config.yaml
/tmp/controlplane.yaml cfg/eks-1.0/controlplane.yaml
/tmp/managedservices.yaml cfg/eks-1.0/managedservices.yaml
/tmp/master.yaml cfg/eks-1.0/master.yaml
/tmp/node.yaml cfg/eks-1.0/node.yaml
/tmp/policies.yaml cfg/eks-1.0/policies.yaml
/tmp/config.yaml cfg/gke-1.0/config.yaml
/tmp/controlplane.yaml cfg/gke-1.0/controlplane.yaml
/tmp/etcd.yaml cfg/gke-1.0/etcd.yaml
/tmp/managedservices.yaml cfg/gke-1.0/managedservices.yaml
/tmp/master.yaml cfg/gke-1.0/master.yaml
/tmp/node.yaml cfg/gke-1.0/node.yaml
/tmp/policies.yaml cfg/gke-1.0/policies.yaml
/tmp/config.yaml cfg/rh-0.7/config.yaml
/tmp/master.yaml cfg/rh-0.7/master.yaml
/tmp/node.yaml cfg/rh-0.7/node.yaml
/tmp/config.yaml cfg/rh-1.0/config.yaml
/tmp/controlplane.yaml cfg/rh-1.0/controlplane.yaml
/tmp/etcd.yaml cfg/rh-1.0/etcd.yaml
/tmp/master.yaml cfg/rh-1.0/master.yaml
/tmp/node.yaml cfg/rh-1.0/node.yaml
/tmp/policies.yaml cfg/rh-1.0/policies.yaml
/tmp/kube-bench kube-bench
2021/10/21 19:55:37 extracted tarball into /tmp: 55 files, 0 dirs (512.821021ms)
2021/10/21 19:55:37 Extracted: /tmp/kube-bench

Tool written to: /tmp/kube-bench

Run the following to copy to install the tool:

chmod +x /tmp/kubestr /tmp/kube-bench 
sudo install -m 755 /tmp/kubestr /usr/local/bin/kubestr
sudo install -m 755 /tmp/kube-bench /usr/local/bin/kube-bench
```

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
