### PR TITLE
Rename flags for inlets-operator

### DIFF
--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -51,7 +51,9 @@ IngressController`,
 	inletsOperator.Flags().StringP("secret-key-file", "s", "", "Text file containing secret key, used for providers like ec2")
 	inletsOperator.Flags().Bool("update-repo", true, "Update the helm repo")
 
-	inletsOperator.Flags().String("pro-client-image", "", "Docker image for inlets-pro's client")
+	inletsOperator.Flags().String("client-image", "", "Container image for tunnel clients")
+	inletsOperator.Flags().String("inlets-release", "", "Specific version of inlets to use for tunnel servers")
+
 	inletsOperator.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set image=org/repo:tag)")
 
 	inletsOperator.PreRunE = func(command *cobra.Command, args []string) error {
@@ -187,8 +189,11 @@ IngressController`,
 
 		overrides["inletsProLicense"] = license
 
-		if val, _ := command.Flags().GetString("pro-client-image"); len(val) > 0 {
-			overrides["proClientImage"] = val
+		if val, _ := command.Flags().GetString("client-image"); len(val) > 0 {
+			overrides["inletsClientImage"] = val
+		}
+		if val, _ := command.Flags().GetString("inlets-release"); len(val) > 0 {
+			overrides["inletsRelease"] = val
 		}
 
 		err = helm.Helm3Upgrade("inlets/inlets-operator",


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Rename flags for inlets-operator

## Motivation and Context

As part of 0.15.0, the flags for client images and server
versions have changed names. This commit sets them in the
new fields in the helm chart.

## How Has This Been Tested?

The flags match the new field names in the operator repo. https://github.com/inlets/inlets-operator/compare/dynamic_tunnel_version?expand=1
