### PR TITLE
feat: add kube-prometheus-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,64 +613,65 @@ A CLI or "tool" is a command line tool that you run directly on your own worksta
 
 |          TOOL           |                             DESCRIPTION                             |
 |-------------------------|---------------------------------------------------------------------|
-| docker-registry-ingress | Install registry ingress with TLS                                   |
-| inlets-operator         | Install inlets-operator                                             |
-| kuma                    | Install Kuma                                                        |
-| kube-state-metrics      | Install kube-state-metrics                                          |
-| cert-manager            | Install cert-manager                                                |
-| docker-registry         | Install a Docker registry                                           |
-| rabbitmq                | Install rabbitmq                                                    |
-| linkerd                 | Install linkerd                                                     |
-| redis                   | Install redis                                                       |
 | gitlab                  | Install GitLab                                                      |
-| falco                   | Install Falco                                                       |
-| registry-creds          | Install registry-creds                                              |
-| qemu-static             | Install qemu-user-static                                            |
-| metrics-server          | Install metrics-server                                              |
-| postgresql              | Install postgresql                                                  |
-| ingress-nginx           | Install ingress-nginx                                               |
-| jenkins                 | Install jenkins                                                     |
-| nginx-inc               | Install nginx-inc for OpenFaaS                                      |
-| metallb-arp             | Install MetalLB in L2 (ARP) mode                                    |
-| loki                    | Install Loki for monitoring and tracing                             |
-| nfs-provisioner         | Install nfs subdir external provisioner                             |
-| mqtt-connector          | Install mqtt-connector for OpenFaaS                                 |
-| kanister                | Install kanister for application-level data management              |
-| openfaas-ingress        | Install openfaas ingress with TLS                                   |
-| chart                   | Install the specified helm chart                                    |
-| cron-connector          | Install cron-connector for OpenFaaS                                 |
-| minio                   | Install minio                                                       |
-| openfaas                | Install openfaas                                                    |
 | kafka                   | Install Confluent Platform Kafka                                    |
-| kubernetes-dashboard    | Install kubernetes-dashboard                                        |
-| OSM                     | Install osm                                                         |
 | inlets-tcp-client       | Install inlets PRO TCP client                                       |
-| kong-ingress            | Install kong-ingress for OpenFaaS                                   |
-| sealed-secret           | Install sealed-secrets                                              |
-| cassandra               | Install cassandra                                                   |
-| waypoint                | Install Waypoint                                                    |
-| opa-gatekeeper          | Install Open Policy Agent (OPA) Gatekeeper                          |
-| mongodb                 | Install mongodb                                                     |
-| grafana                 | Install grafana                                                     |
-| kube-image-prefetch     | Install kube-image-prefetch                                         |
-| consul-connect          | Install Consul Service Mesh                                         |
-| argocd                  | Install argocd                                                      |
-| prometheus              | Install Prometheus for monitoring                                   |
-| istio                   | Install istio                                                       |
+| nfs-provisioner         | Install nfs subdir external provisioner                             |
+| kube-prometheus-stack   | Install Kube Prometheus Stack for monitoring                        |
+| chart                   | Install the specified helm chart                                    |
 | crossplane              | Install Crossplane                                                  |
+| kube-image-prefetch     | Install kube-image-prefetch                                         |
+| registry-creds          | Install registry-creds                                              |
+| consul-connect          | Install Consul Service Mesh                                         |
+| kubernetes-dashboard    | Install kubernetes-dashboard                                        |
+| inlets-operator         | Install inlets-operator                                             |
+| OSM                     | Install osm                                                         |
+| kong-ingress            | Install kong-ingress for OpenFaaS                                   |
+| kube-state-metrics      | Install kube-state-metrics                                          |
+| grafana                 | Install grafana                                                     |
+| opa-gatekeeper          | Install Open Policy Agent (OPA) Gatekeeper                          |
+| kyverno                 | Install Kyverno                                                     |
+| cassandra               | Install cassandra                                                   |
+| kanister                | Install kanister for application-level data management              |
+| qemu-static             | Install qemu-user-static                                            |
+| redis                   | Install redis                                                       |
+| openfaas                | Install openfaas                                                    |
+| loki                    | Install Loki for monitoring and tracing                             |
+| sealed-secret           | Install sealed-secrets                                              |
+| prometheus              | Install Prometheus for monitoring                                   |
+| minio                   | Install minio                                                       |
+| ingress-nginx           | Install ingress-nginx                                               |
+| argocd                  | Install argocd                                                      |
+| metallb-arp             | Install MetalLB in L2 (ARP) mode                                    |
+| kafka-connector         | Install kafka-connector for OpenFaaS                                |
+| nginx-inc               | Install nginx-inc for OpenFaaS                                      |
+| vault                   | Install vault                                                       |
+| metrics-server          | Install metrics-server                                              |
+| istio                   | Install istio                                                       |
 | cockroachdb             | Install CockroachDB                                                 |
+| cron-connector          | Install cron-connector for OpenFaaS                                 |
+| rabbitmq                | Install rabbitmq                                                    |
+| docker-registry         | Install a community maintained Docker registry chart                |
+| cert-manager            | Install cert-manager                                                |
+| nats-connector          | Install OpenFaaS connector for NATS                                 |
+| gitea                   | Install gitea                                                       |
+| postgresql              | Install postgresql                                                  |
+| falco                   | Install Falco                                                       |
+| jenkins                 | Install jenkins                                                     |
+| openfaas-ingress        | Install openfaas ingress with TLS                                   |
 | openfaas-loki           | Install Loki-OpenFaaS and Configure Loki logs provider for OpenFaaS |
 | portainer               | Install portainer to visualise and manage containers                |
+| mqtt-connector          | Install mqtt-connector for OpenFaaS                                 |
+| waypoint                | Install Waypoint                                                    |
+| kuma                    | Install Kuma                                                        |
+| linkerd                 | Install linkerd                                                     |
+| docker-registry-ingress | Install registry ingress with TLS                                   |
 | tekton                  | Install Tekton pipelines and dashboard                              |
 | traefik2                | Install traefik2                                                    |
-| kafka-connector         | Install kafka-connector for OpenFaaS                                |
-| gitea                   | Install gitea                                                       |
 | influxdb                | Install influxdb                                                    |
-| nats-connector          | Install OpenFaaS connector for NATS                                 |
-| kyverno                 | Install Kyverno                                                     |
-| vault                   | Install Vault                                                       |
+| mongodb                 | Install mongodb                                                     |
 
-There are 56 apps that you can install on your cluster.
+There are 57 apps that you can install on your cluster.
 
 > Note to contributors, run `arkade install --print-table` to generate this list
 

--- a/cmd/apps/prometheus_operator_app.go
+++ b/cmd/apps/prometheus_operator_app.go
@@ -1,0 +1,162 @@
+// Copyright (c) arkade author(s) 2021. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/types"
+)
+
+func MakeInstallPrometheusOperator() *cobra.Command {
+	var kubePromStackApp = &cobra.Command{
+		Use:          "kube-prometheus-stack",
+		Short:        "Install Kube Prometheus Stack for monitoring",
+		Long:         "Install Kube Prometheus Stack, provides Kubernetes native deployment and management of Prometheus and related monitoring components.",
+		Example:      "arkade install kube-prometheus-stack",
+		SilenceUsage: true,
+	}
+
+	kubePromStackApp.Flags().StringP("namespace", "n", "default", "The namespace to install prometheus-operator (default: default")
+	kubePromStackApp.Flags().Bool("update-repo", true, "Update the helm repo")
+	kubePromStackApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set  prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false)")
+	kubePromStackApp.Flags().Bool("alertmanager", true, "Install AlertManager (default: true)")
+	kubePromStackApp.Flags().Bool("grafana", false, "Install Grafana (default: false)")
+	kubePromStackApp.Flags().Bool("node-exporter", true, "Install Node Exporter (default: true)")
+	kubePromStackApp.Flags().Bool("kube-state-metrics", true, "Install Kube State Metrics (default: true)")
+	kubePromStackApp.Flags().Bool("prometheus-operator", true, "Install Prometheus Operator (default: true)")
+	kubePromStackApp.Flags().Bool("prometheus", true, "Install Prometheus instance (default: true)")
+
+	kubePromStackApp.PreRunE = func(command *cobra.Command, args []string) error {
+		_, err := command.Flags().GetString("namespace")
+		if err != nil {
+			return fmt.Errorf("error with --namespace usage: %s", err)
+		}
+
+		_, err = command.Flags().GetBool("alertmanager")
+		if err != nil {
+			return fmt.Errorf("error with --alertmanager usage: %s", err)
+		}
+
+		_, err = command.Flags().GetBool("grafana")
+		if err != nil {
+			return fmt.Errorf("error with --grafana usage: %s", err)
+		}
+
+		_, err = command.Flags().GetBool("node-exporter")
+		if err != nil {
+			return fmt.Errorf("error with --node-exporter usage: %s", err)
+		}
+
+		_, err = command.Flags().GetBool("kube-state-metrics")
+		if err != nil {
+			return fmt.Errorf("error with --kube-state-metrics usage: %s", err)
+		}
+
+		_, err = command.Flags().GetBool("prometheus-operator")
+		if err != nil {
+			return fmt.Errorf("error with --prometheus-operator usage: %s", err)
+		}
+
+		_, err = command.Flags().GetBool("prometheus")
+		if err != nil {
+			return fmt.Errorf("error with --prometheus usage: %s", err)
+		}
+
+		_, err = command.Flags().GetString("kubeconfig")
+		if err != nil {
+			return fmt.Errorf("error with --kubeconfig usage: %s", err)
+		}
+
+		_, err = command.Flags().GetStringArray("set")
+		if err != nil {
+			return fmt.Errorf("error with --set usage: %s", err)
+		}
+
+		return nil
+	}
+
+	kubePromStackApp.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
+		namespace, _ := kubePromStackApp.Flags().GetString("namespace")
+		installAlertManager, _ := kubePromStackApp.Flags().GetBool("alertmanager")
+		installGrafana, _ := kubePromStackApp.Flags().GetBool("grafana")
+		installNodeExporter, _ := kubePromStackApp.Flags().GetBool("node-exporter")
+		installKubeStateMetrics, _ := kubePromStackApp.Flags().GetBool("kube-state-metrics")
+		installprometheusOperator, _ := kubePromStackApp.Flags().GetBool("prometheus-operator")
+		installPrometheus, _ := kubePromStackApp.Flags().GetBool("prometheus")
+
+		overrides := map[string]string{}
+
+		if !installAlertManager {
+			overrides["alertmanager.enabled"] = "false"
+		}
+
+		if !installGrafana {
+			overrides["grafana.enabled"] = "false"
+		}
+
+		if !installNodeExporter {
+			overrides["nodeExporter.enabled"] = "false"
+		}
+
+		if !installprometheusOperator {
+			overrides["prometheusOperator.enabled"] = "false"
+		}
+
+		if !installKubeStateMetrics {
+			overrides["kubeStateMetrics.enabled"] = "false"
+		}
+
+		if !installPrometheus {
+			overrides["prometheus.enabled"] = "false"
+		}
+
+		customFlags, _ := command.Flags().GetStringArray("set")
+
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		kubePromStackOptions := types.DefaultInstallOptions().
+			WithNamespace(namespace).
+			WithHelmRepo("prometheus-community/kube-prometheus-stack").
+			WithHelmURL("https://prometheus-community.github.io/helm-charts").
+			WithOverrides(overrides).
+			WithKubeconfigPath(kubeConfigPath)
+
+		_, err := apps.MakeInstallChart(kubePromStackOptions)
+		if err != nil {
+			return err
+		}
+
+		println(kubePromInstallMsg)
+		return nil
+	}
+
+	return kubePromStackApp
+}
+
+const KubePromInfoMsg = `# Get started with kube-prometheus-stack here:
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md
+
+Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.
+
+ # Forward traffic to your localhost for prometheus
+ kubectl port-forward service/prometheus-operated 9090:9090
+
+ # Forward traffic to your localhost for alertmanager (if installed)
+ kubectl port-forward service/alertmanager-operated 9093:9093
+
+`
+
+const kubePromInstallMsg = `=======================================================================
+= kube-prometheus-stack has been installed.                           =
+=======================================================================` +
+	"\n\n" + KubePromInfoMsg + "\n\n" + pkg.SupportMessageShort

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -164,6 +164,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["kuma"] = NewArkadeApp(apps.MakeInstallKuma, apps.KumaInfoMsg)
 	arkadeApps["qemu-static"] = NewArkadeApp(apps.MakeInstallQemuStatic, apps.QemuStaticInfoMsg)
 	arkadeApps["vault"] = NewArkadeApp(apps.MakeInstallVault, apps.VaultInfoMsg)
+	arkadeApps["kube-prometheus-stack"] = NewArkadeApp(apps.MakeInstallPrometheusOperator, apps.KubePromInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")


### PR DESCRIPTION
## Description
add kube-prometheus-stack that can deploy the prometheus operator / prometheus stack



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes https://github.com/alexellis/arkade/issues/4

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment

output of the installation in my raspi home cluster

```
$ ./arkade install kube-prometheus-stack --alertmanager=false --node-exporter=false --kube-state-metrics=false --namespace monitoring --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues="false"

2021/10/23 15:37:05
Using Kubeconfig: /Users/cpanato/Documents/k3s_config
[Warning] unable to create namespace monitoring, may already exist: Error from server (AlreadyExists): namespaces "monitoring" already exists
Client: x86_64, Darwin
2021/10/23 15:37:05 User dir established as: /Users/cpanato/.arkade/
"prometheus-community" already exists with the same configuration, skipping

VALUES values.yaml
Command: /Users/cpanato/.arkade/bin/helm [upgrade --install kube-prometheus-stack prometheus-community/kube-prometheus-stack --namespace monitoring --values /var/folders/cz/_mkxxyx97n38b5p0hs3n2j2m0000gn/T/charts/kube-prometheus-stack/values.yaml --set nodeExporter.enabled=false --set kubeStateMetrics.enabled=false --set prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false --set alertmanager.enabled=false --set grafana.enabled=false]
Release "kube-prometheus-stack" does not exist. Installing it now.
W1023 15:37:10.566770   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:10.593948   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:12.779896   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:14.040563   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:28.990942   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:29.275248   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:29.289183   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:44.752281   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:49.114189   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:38:08.176979   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
NAME: kube-prometheus-stack
LAST DEPLOYED: Sat Oct 23 15:37:10 2021
NAMESPACE: monitoring
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
kube-prometheus-stack has been installed. Check its status by running:
  kubectl --namespace monitoring get pods -l "release=kube-prometheus-stack"

Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.
2021/10/23 15:38:11 stderr: W1023 15:37:10.566770   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:10.593948   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:12.779896   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:14.040563   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:28.990942   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:29.275248   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:29.289183   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:44.752281   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:37:49.114189   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1023 15:38:08.176979   98411 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+

=======================================================================
= kube-prometheus-stack has been installed.                           =
=======================================================================

# Get started with kube-prometheus-stack here:
# https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md

Visit https://github.com/prometheus-operator/kube-prometheus for instructions on how to create & configure Alertmanager and Prometheus instances using the Operator.

 # Forward traffic to your localhost for prometheus
 kubectl port-forward service/prometheus-operated 9090:9090

 # Forward traffic to your localhost for alertmanager (if installed)
 kubectl port-forward service/alertmanager-operated 9093:9093



Thanks for using arkade!
```

also tested in a Kind cluster and AWS EKS