### PR TITLE
feat: add prometheus to arkade

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Apps:
 | chart                   | Install the specified helm chart                                    |
 | metallb-arp             | Install MetalLB in L2 (ARP) mode                                    |
 | cockroachdb             | Install CockroachDB                                                 |
+| prometheus              | Install Prometheus                                                  |
 
 There are 47 apps that you can install on your cluster.
 

--- a/cmd/apps/prometheus_app.go
+++ b/cmd/apps/prometheus_app.go
@@ -1,0 +1,103 @@
+// Copyright (c) arkade author(s) 2021. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/types"
+)
+
+func MakeInstallPrometheus() *cobra.Command {
+	var kubePrometheusApp = &cobra.Command{
+		Use:          "prometheus",
+		Short:        "Install Prometheus for monitoring",
+		Long:         "Install Prometheus, provides Kubernetes native deployment and management of Prometheus and related monitoring components.",
+		Example:      "arkade install prometheus",
+		SilenceUsage: true,
+	}
+
+	kubePrometheusApp.Flags().StringP("namespace", "n", "default", "The namespace to install prometheus (default: default")
+	kubePrometheusApp.Flags().Bool("update-repo", true, "Update the helm repo")
+	kubePrometheusApp.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set grafana.enabled=true)")
+	kubePrometheusApp.Flags().Bool("alertmanager", true, "Install AlertManager (default: true)")
+	kubePrometheusApp.Flags().Bool("node-exporter", true, "Install Node Exporter (default: true)")
+	kubePrometheusApp.Flags().Bool("kube-state-metrics", true, "Install Kube State Metrics (default: true)")
+	kubePrometheusApp.Flags().Bool("pushgateway", true, "Install Push Gateway (default: true)")
+	kubePrometheusApp.Flags().Bool("prometheus", true, "Install Prometheus instance (default: true)")
+
+	kubePrometheusApp.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
+		log.Println(kubeConfigPath)
+		namespace, _ := kubePrometheusApp.Flags().GetString("namespace")
+		installAlertManager, _ := kubePrometheusApp.Flags().GetBool("alertmanager")
+		installNodeExporter, _ := kubePrometheusApp.Flags().GetBool("node-exporter")
+		installKubeStateMetrics, _ := kubePrometheusApp.Flags().GetBool("kube-state-metrics")
+		installPushGateway, _ := kubePrometheusApp.Flags().GetBool("pushgateway")
+		installPrometheus, _ := kubePrometheusApp.Flags().GetBool("prometheus")
+
+		overrides := map[string]string{}
+
+		if !installAlertManager {
+			overrides["alertmanager.enabled"] = "false"
+		}
+
+		if !installNodeExporter {
+			overrides["nodeExporter.enabled"] = "false"
+		}
+
+		if !installPushGateway {
+			overrides["pushgateway.enabled"] = "false"
+		}
+
+		if !installKubeStateMetrics {
+			overrides["kubeStateMetrics.enabled"] = "false"
+		}
+
+		if !installPrometheus {
+			overrides["server.enabled"] = "false"
+		}
+
+		customFlags, _ := command.Flags().GetStringArray("set")
+
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		kubePromStackOptions := types.DefaultInstallOptions().
+			WithNamespace(namespace).
+			WithHelmRepo("prometheus-community/prometheus").
+			WithHelmURL("https://prometheus-community.github.io/helm-charts").
+			WithOverrides(overrides).
+			WithKubeconfigPath(kubeConfigPath)
+
+		_, err := apps.MakeInstallChart(kubePromStackOptions)
+		if err != nil {
+			return err
+		}
+
+		println(PrometheusInstallMsg)
+		return nil
+	}
+
+	return kubePrometheusApp
+}
+
+const PrometheusInfoMsg = `# Get started with Prometheus here:
+# https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/README.md
+
+ # Forward traffic to your localhost for prometheus
+ kubectl port-forward service/prometheus-server 8080:80
+
+`
+
+const PrometheusInstallMsg = `=======================================================================
+= prometheus has been installed.                                      =
+=======================================================================` +
+	"\n\n" + PrometheusInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -157,6 +157,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["cassandra"] = NewArkadeApp(apps.MakeInstallCassandra, apps.CassandraInfoMsg)
 	arkadeApps["metallb-arp"] = NewArkadeApp(apps.MakeInstallMetalLB, apps.MetalLBInfoMsg)
 	arkadeApps["cockroachdb"] = NewArkadeApp(apps.MakeInstallCockroachdb, apps.CockroachdbInfoMsg)
+	arkadeApps["prometheus"] = NewArkadeApp(apps.MakeInstallPrometheus, apps.PrometheusInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")


### PR DESCRIPTION
Signed-off-by: Carlos Panato <ctadeu@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
related to https://github.com/alexellis/arkade/pull/561


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
$ ./arkade install prometheus --alertmanager=false --node-exporter=false --kube-state-metrics=false --namespace monitoring
2021/10/24 16:27:28
Using Kubeconfig: /Users/cpanato/.kube/config
Client: x86_64, Darwin
2021/10/24 16:27:28 User dir established as: /Users/cpanato/.arkade/
"prometheus-community" already exists with the same configuration, skipping

VALUES values.yaml
Command: /Users/cpanato/.arkade/bin/helm [upgrade --install prometheus prometheus-community/prometheus --namespace monitoring --values /var/folders/cz/_mkxxyx97n38b5p0hs3n2j2m0000gn/T/charts/prometheus/values.yaml --set alertmanager.enabled=false --set nodeExporter.enabled=false --set kubeStateMetrics.enabled=false]
Release "prometheus" does not exist. Installing it now.
NAME: prometheus
LAST DEPLOYED: Sun Oct 24 16:27:31 2021
NAMESPACE: monitoring
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The Prometheus server can be accessed via port 80 on the following DNS name from within your cluster:
prometheus-server.monitoring.svc.cluster.local


Get the Prometheus server URL by running these commands in the same shell:
  export POD_NAME=$(kubectl get pods --namespace monitoring -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}")
  kubectl --namespace monitoring port-forward $POD_NAME 9090


#################################################################################
######   WARNING: Pod Security Policy has been moved to a global property.  #####
######            use .Values.podSecurityPolicy.enabled with pod-based      #####
######            annotations                                               #####
######            (e.g. .Values.nodeExporter.podSecurityPolicy.annotations) #####
#################################################################################


The Prometheus PushGateway can be accessed via port 9091 on the following DNS name from within your cluster:
prometheus-pushgateway.monitoring.svc.cluster.local


Get the PushGateway URL by running these commands in the same shell:
  export POD_NAME=$(kubectl get pods --namespace monitoring -l "app=prometheus,component=pushgateway" -o jsonpath="{.items[0].metadata.name}")
  kubectl --namespace monitoring port-forward $POD_NAME 9091

For more information on running Prometheus, visit:
https://prometheus.io/
=======================================================================
= prometheus has been installed.                                      =
=======================================================================

# Get started with Prometheus here:
# https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/README.md

 # Forward traffic to your localhost for prometheus
 kubectl port-forward service/prometheus-server 8080:80

Thanks for using arkade!


$ k get po
NAME                                      READY   STATUS    RESTARTS   AGE
prometheus-pushgateway-68b8b68999-sp4tl   1/1     Running   0          110s
prometheus-server-74ccdfcc-kc8kf          2/2     Running   0          109s
```

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [x] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
