### PR TITLE
feat: add waypoint app to arkade

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,9 @@ Apps:
 | metallb-arp             | Install MetalLB in L2 (ARP) mode                                    |
 | cockroachdb             | Install CockroachDB                                                 |
 | prometheus              | Install Prometheus                                                  |
+| waypoint                | Install Waypoint                                                    |
 
-There are 47 apps that you can install on your cluster.
+There are 48 apps that you can install on your cluster.
 
 Note to contributors, run `arkade install --print-table` to generate this list
 

--- a/cmd/apps/waypoint_app.go
+++ b/cmd/apps/waypoint_app.go
@@ -1,0 +1,78 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/types"
+
+	"github.com/alexellis/arkade/pkg/k8s"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallWaypoint() *cobra.Command {
+	var waypoint = &cobra.Command{
+		Use:          "waypoint",
+		Short:        "Install Waypoint",
+		Long:         `Install Waypoint to any Kubernetes cluster`,
+		Example:      `  arkade install waypoint`,
+		SilenceUsage: true,
+	}
+
+	waypoint.Flags().StringP("namespace", "n", "waypoint", "The namespace used for installation")
+	waypoint.Flags().Bool("update-repo", true, "Update the helm repo")
+	waypoint.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set image=org/repo:tag)")
+
+	waypoint.RunE = func(command *cobra.Command, args []string) error {
+		updateRepo, _ := waypoint.Flags().GetBool("update-repo")
+
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		if arch != IntelArch {
+			return fmt.Errorf(OnlyIntelArch)
+		}
+
+		namespace, _ := waypoint.Flags().GetString("namespace")
+
+		overrides := map[string]string{}
+
+		customFlags, _ := command.Flags().GetStringArray("set")
+
+		if err := mergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
+
+		waypointOptions := types.DefaultInstallOptions().
+			WithNamespace(namespace).
+			WithHelmRepo("hashicorp/waypoint").
+			WithHelmURL("https://helm.releases.hashicorp.com").
+			WithOverrides(overrides).
+			WithHelmUpdateRepo(updateRepo).
+			WithKubeconfigPath(kubeConfigPath)
+
+		_, err := apps.MakeInstallChart(waypointOptions)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(waypointInstallMsg)
+		return nil
+	}
+
+	return waypoint
+}
+
+const WaypointInfoMsg = `# Find out more at:
+# https://learn.hashicorp.com/collections/waypoint/get-started-kubernetes`
+
+const waypointInstallMsg = `=======================================================================
+= Waypoint has been installed.                                        =
+=======================================================================` +
+	"\n\n" + WaypointInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -158,6 +158,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["metallb-arp"] = NewArkadeApp(apps.MakeInstallMetalLB, apps.MetalLBInfoMsg)
 	arkadeApps["cockroachdb"] = NewArkadeApp(apps.MakeInstallCockroachdb, apps.CockroachdbInfoMsg)
 	arkadeApps["prometheus"] = NewArkadeApp(apps.MakeInstallPrometheus, apps.PrometheusInfoMsg)
+	arkadeApps["waypoint"] = NewArkadeApp(apps.MakeInstallWaypoint, apps.WaypointInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")


### PR DESCRIPTION
Signed-off-by: Johan Siebens <johan.siebens@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add the HashiCorp Waypoint application to arkade using the recommended Helm chart

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$ ./arkade install waypoint
Node architecture: "amd64"
Using Kubeconfig: /home/jsiebens/.kube/config
Client: x86_64, Linux
2021/11/02 15:59:18 User dir established as: /home/jsiebens/.arkade/
"hashicorp" already exists with the same configuration, skipping

Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "ingress-nginx" chart repository
...Successfully got an update from the "hashicorp" chart repository
...Successfully got an update from the "mvisonneau" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "halkeye" chart repository
...Successfully got an update from the "openfaas" chart repository
Update Complete. ⎈Happy Helming!⎈

VALUES values.yaml
Command: /home/jsiebens/.arkade/bin/helm [upgrade --install waypoint hashicorp/waypoint --namespace waypoint --values /tmp/charts/waypoint/values.yaml]
Release "waypoint" does not exist. Installing it now.
NAME: waypoint
LAST DEPLOYED: Tue Nov  2 15:59:19 2021
NAMESPACE: waypoint
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing HashiCorp Waypoint!

Waypoint will take a few minutes to bootstrap. Once it is bootstrapped, you
can log in to the local CLI by running the following command. If this command
fails, please wait a few more minutes and try again.

  $ waypoint login -from-kubernetes

Once logged in, you can use the "waypoint ui" command to open the web interface.
Alternately, you can visit the address of the load balancer service configured.

If anything fails to configure properly you can uninstall this release:

  $ helm uninstall waypoint
=======================================================================
= Waypoint has been installed.                                        =
=======================================================================

# Find out more at:
# https://learn.hashicorp.com/collections/waypoint/get-started-kubernetes

Thanks for using arkade!


$ kubectl get deployments,statefulsets,services --namespace waypoint
NAME                                        READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/waypoint-runner             1/1     1            1           5m46s

NAME                               READY   AGE
statefulset.apps/waypoint-server   1/1     5m46s

NAME                      TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                    AGE
service/waypoint-server   ClusterIP      None            <none>        9702/TCP,9701/TCP                                          5m46s
service/waypoint-ui       LoadBalancer   10.96.201.237   <redacted>    80:30221/TCP,443:30260/TCP,9701:31262/TCP,9702:32607/TCP   5m46s

```


## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [x] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
