### PR TITLE
feat: add inlets PRO client app to arkade

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ A CLI or "tool" is a command line tool that you run directly on your own worksta
 | jenkins                 | Install jenkins                                                     |
 | tekton                  | Install Tekton pipelines and dashboard                              |
 | consul-connect          | Install Consul Service Mesh                                         |
+| inlets-tcp-client       | Install inlets PRO TCP client                                       |
 
 There are 52 apps that you can install on your cluster.
 

--- a/cmd/apps/inletstcpclient_app.go
+++ b/cmd/apps/inletstcpclient_app.go
@@ -1,0 +1,180 @@
+// Copyright (c) arkade author(s) 2020. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/k8s"
+	"github.com/alexellis/arkade/pkg/types"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallInletsTcpClient() *cobra.Command {
+	var inletsProClient = &cobra.Command{
+		Use:          "inlets-tcp-client",
+		Short:        "Install inlets PRO TCP client",
+		Long:         `Install an inlets PRO TCP client to any Kubernetes cluster`,
+		Example:      `  arkade install inlets-tcp-client`,
+		SilenceUsage: true,
+	}
+
+	inletsProClient.Flags().StringP("namespace", "n", "default", "The namespace used for installation")
+	inletsProClient.Flags().Bool("update-repo", true, "Update the helm repo")
+
+	inletsProClient.Flags().String("url", "", "URL for remote server's control-plane, i.e. wss://127.0.0.1:8123")
+	inletsProClient.Flags().Bool("auto-tls", true, "Toggle use of automated TLS, fetching CA from the server on start-up. Disable when providing your own TLS termination on the server")
+	inletsProClient.Flags().String("upstream", "localhost", "Forward traffic from the server here, give a hostname or IP address")
+	inletsProClient.Flags().IntSlice("ports", []int{}, "Publish a TCP port on the server")
+
+	inletsProClient.Flags().String("license", "", "License JWT or Gumroad token")
+	inletsProClient.Flags().String("license-file", "", "Path to license JWT file or Gumroad token")
+
+	inletsProClient.Flags().String("token", "", "Authentication token")
+	inletsProClient.Flags().String("token-file", "", "Read the authentication token from a file")
+
+	inletsProClient.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set image=org/repo:tag)")
+
+	inletsProClient.PreRunE = func(command *cobra.Command, args []string) error {
+		tokenFile, err := command.Flags().GetString("token-file")
+		if err != nil {
+			return fmt.Errorf("error with --token-file usage: %s", err)
+		}
+		tokenString, err := command.Flags().GetString("token")
+		if err != nil {
+			return fmt.Errorf("error with --token usage: %s", err)
+		}
+
+		if tokenString == "" && tokenFile == "" {
+			return fmt.Errorf("either --token or --token-file is required")
+		}
+
+		licenseFile, err := command.Flags().GetString("license-file")
+		if err != nil {
+			return fmt.Errorf("error with --license-file usage: %s", err)
+		}
+		licenseString, err := command.Flags().GetString("license")
+		if err != nil {
+			return fmt.Errorf("error with --license usage: %s", err)
+		}
+
+		if licenseString == "" && licenseFile == "" {
+			return fmt.Errorf("either --license or --license-file is required")
+		}
+
+		ports, err := command.Flags().GetIntSlice("ports")
+		if err != nil {
+			return fmt.Errorf("error with --ports usage: %s", err)
+		}
+
+		if len(ports) == 0 {
+			return fmt.Errorf("you must specify at least one remote TCP port with --ports")
+		}
+
+		return nil
+	}
+
+	inletsProClient.RunE = func(command *cobra.Command, args []string) error {
+		kubeConfigPath, _ := command.Flags().GetString("kubeconfig")
+		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
+			return err
+		}
+
+		arch := k8s.GetNodeArchitecture()
+		fmt.Printf("Node architecture: %q\n", arch)
+
+		appOpts := types.DefaultInstallOptions()
+
+		updateRepo, _ := inletsProClient.Flags().GetBool("update-repo")
+		namespace, _ := inletsProClient.Flags().GetString("namespace")
+		overrides := map[string]string{}
+
+		url, _ := command.Flags().GetString("url")
+		autoTLS, _ := command.Flags().GetBool("auto-tls")
+		upstream, _ := command.Flags().GetString("upstream")
+		ports, _ := command.Flags().GetIntSlice("ports")
+
+		overrides["url"] = url
+		overrides["autoTLS"] = strings.ToLower(strconv.FormatBool(autoTLS))
+		overrides["upstream"] = upstream
+		overrides["ports"] = strings.Trim(strings.Join(strings.Fields(fmt.Sprint(ports)), ","), "[]")
+		overrides["tokenSecretName"] = "inlets-pro-token"
+
+		tokenFile, _ := command.Flags().GetString("token-file")
+		tokenString, _ := command.Flags().GetString("token")
+
+		if len(tokenFile) > 0 {
+			secretData := []types.SecretsData{
+				{Type: types.FromFileSecret, Key: "token", Value: tokenFile},
+			}
+
+			tokenSecret := types.NewGenericSecret("inlets-pro-token", namespace, secretData)
+			appOpts.WithSecret(tokenSecret)
+		} else {
+			secretData := []types.SecretsData{
+				{Type: types.StringLiteralSecret, Key: "token", Value: tokenString},
+			}
+
+			tokenSecret := types.NewGenericSecret("inlets-pro-token", namespace, secretData)
+			appOpts.WithSecret(tokenSecret)
+		}
+
+		licenseFile, _ := command.Flags().GetString("license-file")
+		licenseString, _ := command.Flags().GetString("license")
+
+		if len(licenseFile) > 0 {
+			secretData := []types.SecretsData{
+				{Type: types.FromFileSecret, Key: "license", Value: licenseFile},
+			}
+
+			licenseSecret := types.NewGenericSecret("inlets-license", namespace, secretData)
+			appOpts.WithSecret(licenseSecret)
+		} else {
+			secretData := []types.SecretsData{
+				{Type: types.StringLiteralSecret, Key: "license", Value: licenseString},
+			}
+
+			licenseSecret := types.NewGenericSecret("inlets-license", namespace, secretData)
+			appOpts.WithSecret(licenseSecret)
+		}
+
+		customFlags, _ := command.Flags().GetStringArray("set")
+
+		if err := mergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		options := appOpts.
+			WithNamespace(namespace).
+			WithHelmRepo("inlets-pro/inlets-pro-client").
+			WithHelmURL("https://inlets.github.io/inlets-pro/charts").
+			WithOverrides(overrides).
+			WithHelmUpdateRepo(updateRepo).
+			WithKubeconfigPath(kubeConfigPath)
+
+		_, err := apps.MakeInstallChart(options)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(inletsTcpClientInstallMsg)
+		return nil
+	}
+
+	return inletsProClient
+}
+
+const InletsTcpClientInfoMsg = `# Find out more at:
+# https://inlets.dev`
+
+const inletsTcpClientInstallMsg = `=======================================================================
+= inlets PRO TCP client has been installed.                           =
+=======================================================================` +
+	"\n\n" + InletsTcpClientInfoMsg + "\n\n" + pkg.ThanksForUsing

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -160,6 +160,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["prometheus"] = NewArkadeApp(apps.MakeInstallPrometheus, apps.PrometheusInfoMsg)
 	arkadeApps["waypoint"] = NewArkadeApp(apps.MakeInstallWaypoint, apps.WaypointInfoMsg)
 	arkadeApps["kanister"] = NewArkadeApp(apps.MakeInstallKanister, apps.KanisterInfoMsg)
+	arkadeApps["inlets-tcp-client"] = NewArkadeApp(apps.MakeInstallInletsTcpClient, apps.InletsTcpClientInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")


### PR DESCRIPTION
Signed-off-by: Johan Siebens <johan.siebens@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add support for installing an inlets PRO client using the Helm chart

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Create an exit server, e.g. with `inletsctl`:

```
$ inletsctl create --access-token-file ~/do-access-token 
Using provider: digitalocean
Requesting host: clever-lumiere3 in lon1, from digitalocean
2021/11/08 20:56:20 Provisioning host with DigitalOcean
Host: 272789673, status: 
[1/500] Host: 272789673, status: new
[15/500] Host: 272789673, status: active
inlets PRO TCP (0.8.6) server summary:
  IP: <redacted>
  Auth-token: KvzYudSigSsii6lB5vULT1KdkGxB23tUbh3CSjjNETrVzQJt6zN407emwLZfXISx

Command:

# Obtain a license at https://inlets.dev
# Store it at $HOME/.inlets/LICENSE or use --help for more options
export LICENSE="$HOME/.inlets/LICENSE"

# Give a single value or comma-separated
export PORTS="8000"

# Where to route traffic from the inlets server
export UPSTREAM="localhost"

inlets-pro tcp client --url "wss://<redacted>:8123" \
  --token "KvzYudSigSsii6lB5vULT1KdkGxB23tUbh3CSjjNETrVzQJt6zN407emwLZfXISx" \
  --upstream $UPSTREAM \
  --ports $PORTS
```

Next, install an inlets PRO client with settings from above:

```
$ ./arkade install inlets-pro-client --url "wss://<redacted>:8123" \
    --license-file $HOME/.inlets/LICENSE \
    --token "KvzYudSigSsii6lB5vULT1KdkGxB23tUbh3CSjjNETrVzQJt6zN407emwLZfXISx" \
    --upstream prometheus \
    --ports 9000 
Using Kubeconfig: /home/jsiebens/.kube/config
Node architecture: "amd64"
Using Kubeconfig: /home/jsiebens/.kube/config
[Warning] unable to create namespace default, may already exist: Error from server (AlreadyExists): namespaces "default" already exists
[Warning] unable to create secret inlets-pro-token, may already exist: Error from server (AlreadyExists): secrets "inlets-pro-token" already exists
Client: x86_64, Linux
2021/11/08 21:14:58 User dir established as: /home/jsiebens/.arkade/
"inlets-pro" already exists with the same configuration, skipping

Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "inlets-pro" chart repository
...Successfully got an update from the "inlets" chart repository
...Successfully got an update from the "ingress-nginx" chart repository
...Successfully got an update from the "hashicorp" chart repository
...Successfully got an update from the "halkeye" chart repository
...Successfully got an update from the "traefik" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "mvisonneau" chart repository
Update Complete. ⎈Happy Helming!⎈

VALUES values.yaml
Command: /home/jsiebens/.arkade/bin/helm [upgrade --install inlets-pro-client inlets-pro/inlets-pro-client --namespace default --values /tmp/charts/inlets-pro-client/values.yaml --set url=wss://<redacted>:8123 --set autoTLS=true --set upstream=prometheus --set ports=9000 --set tokenSecretName=inlets-pro-token]
Release "inlets-pro-client" does not exist. Installing it now.
NAME: inlets-pro-client
LAST DEPLOYED: Mon Nov  8 21:14:59 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Installation complete
=======================================================================
= inlets PRO client has been installed.                                        =
=======================================================================

# Find out more at:
# https://inlets.dev

Thanks for using arkade!
```
Verify pods and logs:

```
$ kubectl get pods
NAME                                 READY   STATUS    RESTARTS   AGE
inlets-pro-client-7845ff47b4-92qzg   1/1     Running   0          7s

$ kubectl logs inlets-pro-client-7845ff47b4-92qzg
Starting TCP client. Version: 0.9.1 - 99e1785a9599ba43e149edc748c47319a325f9c9
2021/11/08 20:15:00 Licensed to: <redacted> (Gumroad subscription)
2021/11/08 20:15:00 Upstream server: prometheus, for ports: 9000
inlets-pro TCP client. Copyright OpenFaaS Ltd 2021
time="2021/11/08 20:15:00" level=info msg="Connecting to proxy" url="wss://<redacted>:8123/connect"
time="2021/11/08 20:15:00" level=info msg="Connection established" client_id=f5bf6d8331644dcda65b12adb6b22515

```

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [x] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
