### PR TITLE
Fixed k3d binary template for ming os target

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -503,7 +503,7 @@ func Test_DownloadK3d(t *testing.T) {
 		{os: "mingw64_nt-10.0-18362",
 			arch:    arch64bit,
 			version: "v3.0.0",
-			url:     "https://github.com/rancher/k3d/releases/download/v3.0.0/k3d-windows-amd64"},
+			url:     "https://github.com/rancher/k3d/releases/download/v3.0.0/k3d-windows-amd64.exe"},
 		{os: "linux",
 			arch:    arch64bit,
 			version: "v3.0.0",

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -282,7 +282,7 @@ https://storage.googleapis.com/kubernetes-release/release/{{.Version}}/bin/{{$os
 			Name:        "k3d",
 			Description: "Helper to run Rancher Lab's k3s in Docker.",
 			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
-	{{.Name}}-windows-amd64
+	{{.Name}}-windows-amd64.exe
 	{{- else if eq .OS "darwin" -}}
 	{{.Name}}-darwin-amd64
 	{{- else if eq .Arch "armv6l" -}}


### PR DESCRIPTION
The k3d binary is missing `.exe` from the download link. Fixed the binary template.