### PR TITLE
feat: update completion command description

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -14,32 +14,34 @@ import (
 const completionCmd = `Use "arkade completion SHELL" to generate SHELL completion for:
     - bash
     - zsh
+    - fish
+    - powershell
 `
 
 func MakeShellCompletion() *cobra.Command {
 
 	completion := &cobra.Command{
 		Use:   "completion SHELL",
-		Short: "Output shell completion for the given shell (bash or zsh)",
+		Short: "Output shell completion for the given shell (bash, zsh, fish or powershell)",
 		Long: `
-Outputs shell completion for the given shell (bash or zsh)
-This depends on the bash-completion binary.  Example installation instructions:
-OS X:
-	$ brew install bash-completion
-	$ source $(brew --prefix)/etc/bash_completion
+Outputs shell completion for the given shell (bash, zsh, fish or powershell)
+For bash, this depends on the bash-completion binary.  Example installation instructions:
+macOS:
+	$ brew install bash-completion                   # for bash users
+	$ source $(brew --prefix)/etc/bash_completion    # for bash users
 	$ arkade completion bash > ~/.arkade-completion  # for bash users
 	$ arkade completion zsh > ~/.arkade-completion   # for zsh users
 	$ source ~/.arkade-completion
 Ubuntu:
-	$ apt-get install bash-completion
-	$ source /etc/bash-completion
+	$ apt-get install bash-completion  # for bash users
+	$ source /etc/bash-completion      # for bash users
 	$ source <(arkade completion bash) # for bash users
 	$ source <(arkade completion zsh)  # for zsh users
-Additionally, you may want to output the completion to a file and source in your .bashrc
+Additionally, you may want to output the completion to a file and source in your .bashrc / .zshrc / config.fish / profile.ps1
 `,
 		Example:      completionCmd,
 		SilenceUsage: true,
-		ValidArgs:    []string{"bash", "zsh"},
+		ValidArgs:    []string{"bash", "zsh", "fish", "powershell"},
 	}
 
 	completion.RunE = func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update command description and help text to reflect already-present functionality.
This issue was noticed whilst adding `arkade` to Homebrew/core (https://github.com/Homebrew/homebrew-core/pull/92403)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Issue already existed, Fixes #540, existing PR was closed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
$ arkade completion -h

Outputs shell completion for the given shell (bash, zsh, fish or powershell)
For bash, this depends on the bash-completion binary.  Example installation instructions:
macOS:
	$ brew install bash-completion                   # for bash users
	$ source $(brew --prefix)/etc/bash_completion	 # for bash users
	$ arkade completion bash > ~/.arkade-completion  # for bash users
	$ arkade completion zsh > ~/.arkade-completion   # for zsh users
	$ source ~/.arkade-completion
Ubuntu:
	$ apt-get install bash-completion  # for bash users
	$ source /etc/bash-completion	   # for bash users
	$ source <(arkade completion bash) # for bash users
	$ source <(arkade completion zsh)  # for zsh users
Additionally, you may want to output the completion to a file and source in your .bashrc / .zshrc / config.fish / profile.ps1

Usage:
  arkade completion SHELL [flags]

Examples:
Use "arkade completion SHELL" to generate SHELL completion for:
    - bash
    - zsh
    - fish
    - powershell


Flags:
  -h, --help   help for completion
```
## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [x] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
