### PR TITLE
Enable `get.sh` to work with darwin arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ dist:
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade
 	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade-darwin
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -mod=vendor -a -ldflags $(LDFLAGS) -installsuffix cgo -o bin/arkade-darwin-arm64
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade-armhf
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade-arm64
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade.exe

--- a/get.sh
+++ b/get.sh
@@ -52,12 +52,12 @@ checkHash(){
     targetFileDir=${targetFile%/*}
 
     (cd "$targetFileDir" && curl -sSL $url.sha256|$sha_cmd -c >/dev/null)
-   
+
         if [ "$?" != "0" ]; then
             rm "$targetFile"
             echo "Binary checksum didn't match. Exiting"
             exit 1
-        fi   
+        fi
     fi
 }
 
@@ -68,8 +68,19 @@ getPackage() {
     suffix=""
     case $uname in
     "Darwin")
-    suffix="-darwin"
+        arch=$(uname -m)
+        case $arch in
+        "x86_64")
+        suffix="-darwin"
+        ;;
+        esac
+        case $arch in
+        "arm64")
+        suffix="-darwin-arm64"
+        ;;
+        esac
     ;;
+
     "MINGW"*)
     suffix=".exe"
     BINLOCATION="$HOME/bin"
@@ -93,7 +104,7 @@ getPackage() {
     esac
 
     targetFile="/tmp/$REPO$suffix"
-    
+
     if [ "$userid" != "0" ]; then
         targetFile="$(pwd)/$REPO$suffix"
     fi
@@ -116,7 +127,7 @@ getPackage() {
     chmod +x "$targetFile"
 
     echo "Download complete."
-       
+
     if [ ! -w "$BINLOCATION" ]; then
 
             echo
@@ -127,11 +138,11 @@ getPackage() {
             echo "============================================================"
             echo
             echo "  sudo cp $REPO$suffix $BINLOCATION/$REPO"
-            
+
             if [ -n "$ALIAS_NAME" ]; then
                 echo "  sudo ln -sf $BINLOCATION/$REPO $BINLOCATION/$ALIAS_NAME"
             fi
-            
+
             echo
 
         else
@@ -145,7 +156,7 @@ getPackage() {
             echo "================================================================"
             echo "  $BINLOCATION/$REPO already exists and is not writeable"
             echo "  by the current user.  Please adjust the binary ownership"
-            echo "  or run sh/bash with sudo." 
+            echo "  or run sh/bash with sudo."
             echo "================================================================"
             echo
             exit 1
@@ -153,7 +164,7 @@ getPackage() {
             fi
 
             mv "$targetFile" $BINLOCATION/$REPO
-        
+
             if [ "$?" = "0" ]; then
                 echo "New version of $REPO installed to $BINLOCATION"
             fi


### PR DESCRIPTION
## Description

Update get.sh to perform a the same check for linux on Darwin machines
Update makefile to build a arkade-darwin-arm64 binary, I wasn't able to just use the arkade-arm64 version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `get.sh` locally which installed `arkade-arm64` which showed the logic in the script was working as expected but arkade still didn't work, I was getting `zsh: exec format error: k3sup`

Added the build for `arkade-darwin-arm64` into the makefile, installed that binary and arkade worked as expected

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
