### PR TITLE
Download easily last version of tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ arkade get kubectl
 # Download a specific version of that tool
 arkade get kubectl@v1.22.0
 
+# Download last version of this tool
+arkade get kubectl@latest
+
 # Download multiple tools at once
 arkade get kubectl \
   helm \
@@ -117,6 +120,9 @@ arkade get kubectl \
 # Download multiple specific versions
 arkade get faas-cli@0.13.15 \
   kubectl@v1.22.0
+
+# Download last version of several tools at once
+arkage get helm kubectl --version latest
 
 # Override machine os/arch
 arkade get faas-cli \

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/cobra v1.2.1
+	github.com/tidwall/gjson v1.13.0 // indirect
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/mod v0.5.1
 )

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,12 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tidwall/gjson v1.13.0 h1:3TFY9yxOQShrvmjdM76K+jc66zJeT6D3/VFFYCGQf7M=
+github.com/tidwall/gjson v1.13.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
When specifying latest as version value (--version latest), retrieve last known version from Github API and then try to download it.

## Description
If using latest as value, we try to detect last version from Github API and then download the corresponding version.

## Motivation and Context

Download easily the latest version without having to worry of the last version.

## How Has This Been Tested?

Try to download a package with the latest version value:

    arkade get kubectl@latest

Or using --version for example:

    arkade get helm kubectl --version latest

## Are you a GitHub Sponsor (Yes/No?)

- [ ] Yes
- [X] No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
