### PR TITLE
Add new tools: ekstctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ arkade get faas-cli \
 | dive             | A tool for exploring each layer in a docker image                                                                                         |
 | docker-compose   | Define and run multi-container applications with Docker.                                                                                  |
 | doctl            | Official command line interface for the DigitalOcean API.                                                                                 |
+| eksctl           | Amazon EKS Kubernetes cluster management                                                                                                  |
 | faas-cli         | Official CLI for OpenFaaS.                                                                                                                |
 | flux             | Continuous Delivery solution for Kubernetes powered by GitOps Toolkit.                                                                    |
 | gh               | GitHub’s official command line tool.                                                                                                      |

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -914,6 +914,52 @@ func Test_DownloadDigitalOcean(t *testing.T) {
 	}
 }
 
+func Test_DownloadEKSCTL(t *testing.T) {
+	tools := MakeTools()
+	name := "eksctl"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v0.79.0"
+
+	tests := []test{
+		{os: "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Windows_amd64.zip"},
+		{os: "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Linux_amd64.tar.gz"},
+		{os: "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Linux_arm64.tar.gz"},
+		{os: "darwin",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Darwin_arm64.tar.gz"},
+		{os: "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Darwin_amd64.tar.gz"},
+		{os: "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     "https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Linux_armv7.tar.gz"},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
 func Test_DownloadK9s(t *testing.T) {
 	tools := MakeTools()
 	name := "k9s"

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -521,6 +521,39 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 
 	tools = append(tools,
 		Tool{
+			Owner:       "weaveworks",
+			Repo:        "eksctl",
+			Name:        "eksctl",
+			Version:     "v0.79.0",
+			Description: "Amazon EKS Kubernetes cluster management",
+			URLTemplate: `
+			{{$arch := ""}}
+			{{$extStr := "tar.gz"}}
+			{{- if eq .Arch "x86_64" -}}
+			{{$arch = "amd64"}}
+			{{- else if eq .Arch "aarch64" -}}
+			{{$arch = "arm64"}}
+			{{- else if eq .Arch "armv7l" -}}
+			{{$arch = "armv7"}}
+			{{- else if eq .Arch "armv6l" -}}
+			{{$arch = "armv6"}}
+			{{- end -}}
+
+			{{$os := ""}}
+			{{ if HasPrefix .OS "ming" -}}
+			{{$os = "Windows"}}
+			{{$extStr = "zip"}}
+			{{- else if eq .OS "linux" -}}
+			{{$os = "Linux"}}
+			{{- else if eq .OS "darwin" -}}
+			{{$os = "Darwin"}}
+			{{- end -}}
+
+			https://github.com/weaveworks/eksctl/releases/download/{{ .Version }}/{{.Name}}_{{$os}}_{{$arch}}.{{$extStr}}`,
+		})
+
+	tools = append(tools,
+		Tool{
 			Owner:       "derailed",
 			Repo:        "k9s",
 			Name:        "k9s",


### PR DESCRIPTION
This tools help to create and manage Amazon EKS kubernetes cluster

## Description
Add new entry for eksctl.

## Motivation and Context

Fixes: #605

## How Has This Been Tested?

Run fine when trying it with the following command:

    arkade get eksctl

```
./bin/arkade get eksctl           
Downloading: eksctl
Downloading: https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Linux_amd64.tar.gz
18.64 MiB / 18.64 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/eksctl_Linux_amd64.tar.gz written.
/tmp/eksctl eksctl
2022/01/19 12:06:22 extracted tarball into /tmp: 1 files, 0 dirs (487.370723ms)
2022/01/19 12:06:22 Extracted: /tmp/eksctl
2022/01/19 12:06:22 Copying /tmp/eksctl to /home/yannig/.arkade/bin/eksctl

Tool written to: /home/yannig/.arkade/bin/eksctl

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/home/yannig/.arkade/bin/eksctl

# Or install with:
sudo mv /home/yannig/.arkade/bin/eksctl /usr/local/bin/
```

```
    file ~/.arkade/bin/eksctl
    /home/yannig/.arkade/bin/eksctl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=4lrTx4ruPf-e2iY9i4an/iOTYPmA0intb1rIGOHs7/DBZ-vbBH8QxkEG0N2Yhh/xa1cm8B9u7EMjzBvIz-W, stripped
```

```
    type eksctl
    eksctl is /home/yannig/.arkade/bin/eksctl
```

```
    eksctl version
    0.79.0
```

MacOS + aarch64 download:

    ./bin/arkade get eksctl --os darwin --arch aarch64 

    Downloading: eksctl
    Downloading: https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Darwin_arm64.tar.gz
    20.27 MiB / 20.27 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
    /tmp/eksctl_Darwin_arm64.tar.gz written.
    /tmp/eksctl eksctl
    2022/01/19 12:12:00 extracted tarball into /tmp: 1 files, 0 dirs (578.130588ms)
    2022/01/19 12:12:00 Extracted: /tmp/eksctl
    2022/01/19 12:12:00 Copying /tmp/eksctl to /home/yannig/.arkade/bin/eksctl

    Tool written to: /home/yannig/.arkade/bin/eksctl

    # Add arkade binary directory to your PATH variable
    export PATH=$PATH:$HOME/.arkade/bin/

    # Test the binary:
    /home/yannig/.arkade/bin/eksctl

    # Or install with:
    sudo mv /home/yannig/.arkade/bin/eksctl /usr/local/bin/


```
    file ~/.arkade/bin/eksctl
    /home/yannig/.arkade/bin/eksctl: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
```

MacOS download:

    ./bin/arkade get eksctl --os darwin

    Downloading: eksctl
    Downloading: https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Darwin_amd64.tar.gz
    19.76 MiB / 19.76 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
    /tmp/eksctl_Darwin_amd64.tar.gz written.
    /tmp/eksctl eksctl
    2022/01/19 12:12:08 extracted tarball into /tmp: 1 files, 0 dirs (553.76884ms)
    2022/01/19 12:12:08 Extracted: /tmp/eksctl
    2022/01/19 12:12:08 Copying /tmp/eksctl to /home/yannig/.arkade/bin/eksctl

    Tool written to: /home/yannig/.arkade/bin/eksctl

    # Add arkade binary directory to your PATH variable
    export PATH=$PATH:$HOME/.arkade/bin/

    # Test the binary:
    /home/yannig/.arkade/bin/eksctl

    # Or install with:
    sudo mv /home/yannig/.arkade/bin/eksctl /usr/local/bin/

```
    file ~/.arkade/bin/eksctl
    /home/yannig/.arkade/bin/eksctl: Mach-O 64-bit x86_64 executable
```

Windows download:

    ./bin/arkade get eksctl --os mingw

    Downloading: eksctl
    Downloading: https://github.com/weaveworks/eksctl/releases/download/v0.79.0/eksctl_Windows_amd64.zip
    18.91 MiB / 18.91 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
    /tmp/eksctl_Windows_amd64.zip written.
    Name: eksctl_Windows_amd64.zip, size: 19825514/tmp/eksctl.exe
    2022/01/19 12:12:13 extracted zip into /tmp: 1 files, 0 dirs (556.574877ms)
    2022/01/19 12:12:13 Extracted: /tmp/eksctl
    2022/01/19 12:12:13 Copying /tmp/eksctl to /home/yannig/.arkade/bin/eksctl

    Tool written to: /home/yannig/.arkade/bin/eksctl

    # Add arkade binary directory to your PATH variable
    export PATH=$PATH:$HOME/.arkade/bin/

    # Test the binary:
    /home/yannig/.arkade/bin/eksctl

    # Or install with:
    sudo mv /home/yannig/.arkade/bin/eksctl /usr/local/bin/

```
    file ~/.arkade/bin/eksctl.exe
    /home/yannig/.arkade/bin/eksctl.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```

## Are you a GitHub Sponsor (Yes/No?)

- [ ] Yes
- [X] No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [X] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
