### PR TITLE
If archive have a new name, try to get it from Github release page

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -25,6 +25,15 @@ type test struct {
 	url     string
 }
 
+type testArchive struct {
+	message        string
+	archive        string
+	os             string
+	arch           string
+	osCompatible   bool
+	archCompatible bool
+}
+
 func getTool(name string, tools []Tool) *Tool {
 	var tool *Tool
 	for _, target := range tools {
@@ -3063,6 +3072,170 @@ func Test_DownloadvCluster(t *testing.T) {
 		}
 		if got != tc.url {
 			t.Fatalf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
+func Test_AutodetectArchive(t *testing.T) {
+	tests := []testArchive{
+		{
+			message:        "Linux amd64 compatible",
+			os:             "linux",
+			arch:           arch64bit,
+			archive:        "mytool-linux-amd64",
+			osCompatible:   true,
+			archCompatible: true,
+		},
+		{
+			message:        "Linux arm64 both os and arch incompatibles",
+			os:             "linux",
+			arch:           arch64bit,
+			archive:        "mytool-darwin-arm64",
+			osCompatible:   false,
+			archCompatible: false,
+		},
+		{
+			message:        "Linux amd64 os incompatible",
+			os:             "linux",
+			arch:           arch64bit,
+			archive:        "mytool-darwin-amd64",
+			osCompatible:   false,
+			archCompatible: true,
+		},
+		{
+			message:        "Linux arm64 arch incompatible",
+			os:             "linux",
+			arch:           archARM64,
+			archive:        "mytool-linux-amd64",
+			osCompatible:   true,
+			archCompatible: false,
+		},
+		{
+			message:        "Windows compatible",
+			os:             "mingw",
+			arch:           arch64bit,
+			archive:        "mytool-windows-amd64",
+			osCompatible:   true,
+			archCompatible: true,
+		},
+		{
+			message:        "Windows compatible",
+			os:             "mingw",
+			arch:           arch64bit,
+			archive:        "mytool-win64.exe",
+			osCompatible:   true,
+			archCompatible: true,
+		},
+		{
+			message:        "Windows incompatible os",
+			os:             "mingw",
+			arch:           arch64bit,
+			archive:        "mytool-linux-amd64",
+			osCompatible:   false,
+			archCompatible: true,
+		},
+		{
+			message:        "Windows incompatible arch",
+			os:             "mingw",
+			arch:           arch64bit,
+			archive:        "mytool-win32.exe",
+			osCompatible:   true,
+			archCompatible: false,
+		},
+		{
+			message:        "Windows both incompatible",
+			os:             "mingw",
+			arch:           archARM64,
+			archive:        "mytool-linux-amd64",
+			osCompatible:   false,
+			archCompatible: false,
+		},
+		{
+			message:        "Darwin compatible",
+			os:             "darwin",
+			arch:           arch64bit,
+			archive:        "mytool-darwin-amd64",
+			osCompatible:   true,
+			archCompatible: true,
+		},
+		{
+			message:        "Darwin ARM64 compatible",
+			os:             "darwin",
+			arch:           archARM64,
+			archive:        "mytool-darwin-arm64",
+			osCompatible:   true,
+			archCompatible: true,
+		},
+		{
+			message:        "Darwin os incompatible",
+			os:             "darwin",
+			arch:           arch64bit,
+			archive:        "mytool-linux-amd64",
+			osCompatible:   false,
+			archCompatible: true,
+		},
+		{
+			message:        "Darwin both incompatible",
+			os:             "darwin",
+			arch:           arch64bit,
+			archive:        "mytool-linux-arm64",
+			osCompatible:   false,
+			archCompatible: false,
+		},
+		{
+			message:        "Arm compatible",
+			os:             "linux",
+			arch:           archARM7,
+			archive:        "mytool-linux-armv7",
+			osCompatible:   true,
+			archCompatible: true,
+		},
+		{
+			message:        "Arm os incompatible",
+			os:             "darwin",
+			arch:           archARM7,
+			archive:        "mytool-linux-armv7",
+			osCompatible:   false,
+			archCompatible: true,
+		},
+		{
+			message:        "Arm both incompatible",
+			os:             "darwin",
+			arch:           archARM7,
+			archive:        "mytool-linux-arm64",
+			osCompatible:   false,
+			archCompatible: false,
+		},
+		{
+			message:        "Invalid os foo",
+			os:             "foo",
+			arch:           arch64bit,
+			archive:        "mytool-linux-amd64",
+			osCompatible:   false,
+			archCompatible: true,
+		},
+		{
+			message:        "Invalid arch foo",
+			os:             "linux",
+			arch:           "foo",
+			archive:        "mytool-linux-amd64",
+			osCompatible:   true,
+			archCompatible: false,
+		},
+	}
+	for _, tc := range tests {
+		println(tc.message, tc.os, tc.arch, tc.archive, tc.osCompatible, tc.archCompatible)
+		osComp := isOsCompatible(tc.archive, tc.os)
+		archComp := isArchCompatible(tc.archive, tc.arch)
+		if osComp != tc.osCompatible {
+			println("Expected compatibility:", tc.osCompatible)
+			println("Observed compatibility:", osComp)
+			t.Fatal("Error while testing isOsCompatible:", tc.message)
+		}
+		if archComp != tc.archCompatible {
+			println("Expected arch compatibility:", tc.archCompatible)
+			println("Observed arch compatibility:", archComp)
+			t.Fatal("Error while testing isArchCompatible:", tc.message)
 		}
 	}
 }


### PR DESCRIPTION


## Description

If you try to download kubeseal with arkde 0.8.12, you get v0.14.1. Now trying to get v0.17.1, you get an error:

```
arkade get kubeseal@v0.17.1
```

```
Downloading: kubeseal
Downloading: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.1/kubeseal-linux-amd64
Error: incorrect status for downloading tool: 404
```

## Motivation and Context
- [X] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

Download kubeseal version v0.14.1 (direct download of the binary):

```
arkade get kubeseal@v0.14.1
Downloading: kubeseal
Downloading: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.14.1/kubeseal-linux-amd64
33.56 MiB / 33.56 MiB [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/kubeseal-linux-amd64 written.
...
```

```
file /home/yannig/.arkade/bin/kubeseal
/home/yannig/.arkade/bin/kubeseal: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=uDciUD6TUaSCxCVMfL3S/R9gWKA3w-zpjU2-Sy7KK/jwzKqQMM1X-dRjEmggjY/cW09PaeFey-p85_XeuNW, not stripped
```

Now download version v0.17.1 (embedded inside a tar.gz archive):
```
arkade get kubeseal@v0.17.1

Downloading: kubeseal
Downloading: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.1/kubeseal-linux-amd64
Error while downloading template URL (https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.1/kubeseal-linux-amd64)
Try to autodetect archive url in Github release
Archive /bitnami-labs/sealed-secrets/releases/download/v0.17.1/kubeseal-0.17.1-linux-amd64.tar.gz seems to be compatible with linux/x86_64
Autodetect archive name inside Github: https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.1/kubeseal-0.17.1-linux-amd64.tar.gz
13.97 MiB / 13.97 MiB [----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/kubeseal-0.17.1-linux-amd64.tar.gz written.
/tmp/LICENSE LICENSE
/tmp/README.md README.md
/tmp/kubeseal kubeseal
2022/01/20 14:48:06 extracted tarball into /tmp: 3 files, 0 dirs (252.940385ms)
2022/01/20 14:48:06 Extracted: /tmp/kubeseal
2022/01/20 14:48:06 Copying /tmp/kubeseal to /home/yannig/.arkade/bin/kubeseal

Tool written to: /home/yannig/.arkade/bin/kubeseal
...
```

```
file /home/yannig/.arkade/bin/kubeseal
/home/yannig/.arkade/bin/kubeseal: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=3tbTRrSgy9uJfZVH27iS/uugQD8256WqGh51DVHiq/FE2T9o6gXx--tLPAxez6/zTb2jyY8RMvwQ2pxJytN, not stripped
```

You can download both version as you want.

In reality, these new functions should make it possible to avoid some declaration for simple cases. The OS/Arch auto-detection feature relies on the contents of the release page.

## Are you a GitHub Sponsor (Yes/No?)

- [ ] Yes
- [X] No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
