### PR TITLE
Fix kubestr template

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -2528,7 +2528,7 @@ func Test_DownloadKanister(t *testing.T) {
 func Test_DownloadKubestr(t *testing.T) {
 	tools := MakeTools()
 	name := "kubestr"
-	v := "v0.4.17"
+	v := "v0.4.31"
 	tool := getTool(name, tools)
 
 	tests := []test{
@@ -2536,13 +2536,31 @@ func Test_DownloadKubestr(t *testing.T) {
 			os:      "darwin",
 			arch:    arch64bit,
 			version: v,
-			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr-v0.4.17-darwin-amd64.tar.gz`,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_amd64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    "arm64",
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_arm64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
 			version: v,
-			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.17/kubestr-v0.4.17-linux-amd64.tar.gz`,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_amd64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_arm64.tar.gz`,
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Windows_amd64.tar.gz`,
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1653,16 +1653,24 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 
 			URLTemplate: `
 {{ $ext := "tar.gz" }}
-{{ $osStr := "linux" }}
+{{ $osStr := "Linux" }}
+{{ $arch := .Arch }}
 
-{{- if eq .OS "darwin" -}}
-{{ $osStr = "darwin" }}
-{{- else if HasPrefix .OS "ming" -}}
-{{ $osStr = "windows" }}
-{{ $ext = ".zip" }}
+{{- if eq .Arch "x86_64" -}}
+{{$arch = "amd64"}}
 {{- end -}}
 
-https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}-{{.Version}}-{{$osStr}}-amd64.{{$ext}}`,
+{{- if eq .Arch "aarch64" -}}
+{{$arch = "arm64"}}
+{{- end -}}
+
+{{- if eq .OS "darwin" -}}
+{{ $osStr = "MacOS" }}
+{{- else if HasPrefix .OS "ming" -}}
+{{ $osStr = "Windows" }}
+{{- end -}}
+
+https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_{{.VersionNumber}}_{{$osStr}}_{{$arch}}.{{$ext}}`,
 			BinaryTemplate: `{{.Name}}`,
 		})
 


### PR DESCRIPTION
Signed-off-by: Han Verstraete <welteki@pm.me>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #630

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated the unit tests and tested on x86_64-darwin
```
go run . get kubectl
```

<details><summary>Output</summary>

```
Downloading: kubestr
2022/02/27 14:06:54 Looking up version for kubestr
2022/02/27 14:06:55 Found: v0.4.31
Downloading: https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_amd64.tar.gz
10.25 MiB / 10.25 MiB [--------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr_0.4.31_MacOS_amd64.tar.gz written.
2022/02/27 14:06:58 Looking up version for kubestr
2022/02/27 14:06:58 Found: v0.4.31
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/LICENSE LICENSE
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/README.md README.md
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr kubestr
2022/02/27 14:06:59 extracted tarball into /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T: 3 files, 0 dirs (262.938674ms)
2022/02/27 14:06:59 Extracted: /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr
2022/02/27 14:06:59 Copying /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr to /Users/welteki/.arkade/bin/kubestr

Tool written to: /Users/welteki/.arkade/bin/kubestr

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/welteki/.arkade/bin/kubestr

# Or install with:
sudo mv /Users/welteki/.arkade/bin/kubestr /usr/local/bin/
```

```
$ file  /Users/welteki/.arkade/bin/kubestr
/Users/welteki/.arkade/bin/kubestr: Mach-O 64-bit executable x86_64
```
</details>

```
go run . get kubestr --arch arm64
```
<details><summary>Output</summary>

```
Downloading: kubestr
2022/02/27 14:21:54 Looking up version for kubestr
2022/02/27 14:21:54 Found: v0.4.31
Downloading: https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_arm64.tar.gz
10.07 MiB / 10.07 MiB [-----------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr_0.4.31_MacOS_arm64.tar.gz written.
2022/02/27 14:22:00 Looking up version for kubestr
2022/02/27 14:22:01 Found: v0.4.31
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/LICENSE LICENSE
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/README.md README.md
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr kubestr
2022/02/27 14:22:01 extracted tarball into /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T: 3 files, 0 dirs (250.739943ms)
2022/02/27 14:22:01 Extracted: /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr
2022/02/27 14:22:01 Copying /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr to /Users/welteki/.arkade/bin/kubestr

Tool written to: /Users/welteki/.arkade/bin/kubestr

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/welteki/.arkade/bin/kubestr

# Or install with:
sudo mv /Users/welteki/.arkade/bin/kubestr /usr/local/bin/
```

```
$ file /Users/welteki/.arkade/bin/kubestr
/Users/welteki/.arkade/bin/kubestr: Mach-O 64-bit executable arm64
```

</details>

```
go run . get kubestr --os linux
```

<details><summary>Output</summary>

```
Downloading: kubestr
2022/02/27 14:24:49 Looking up version for kubestr
2022/02/27 14:24:50 Found: v0.4.31
Downloading: https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_amd64.tar.gz
9.73 MiB / 9.73 MiB [-----------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr_0.4.31_Linux_amd64.tar.gz written.
2022/02/27 14:24:57 Looking up version for kubestr
2022/02/27 14:24:57 Found: v0.4.31
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/LICENSE LICENSE
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/README.md README.md
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr kubestr
2022/02/27 14:24:58 extracted tarball into /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T: 3 files, 0 dirs (240.991786ms)
2022/02/27 14:24:58 Extracted: /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr
2022/02/27 14:24:58 Copying /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr to /Users/welteki/.arkade/bin/kubestr

Tool written to: /Users/welteki/.arkade/bin/kubestr

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/welteki/.arkade/bin/kubestr

# Or install with:
sudo mv /Users/welteki/.arkade/bin/kubestr /usr/local/bin/
```

```
$ file /Users/welteki/.arkade/bin/kubestr
/Users/welteki/.arkade/bin/kubestr: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=o6un0WJM68PXyA7P1ac0/JKDkJXrGoJHU7h4CSSZg/DPRuPetkMemhEnpG2uOe/W4LQxXNkIclWqiE9JLwv, stripped
```

</details>

```
go run . get kubestr --arch aarch64 --os linux
```

<details><summary>Output</summary>

```
Downloading: kubestr
2022/02/27 14:30:07 Looking up version for kubestr
2022/02/27 14:30:08 Found: v0.4.31
Downloading: https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_arm64.tar.gz
8.74 MiB / 8.74 MiB [-----------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr_0.4.31_Linux_arm64.tar.gz written.
2022/02/27 14:30:15 Looking up version for kubestr
2022/02/27 14:30:15 Found: v0.4.31
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/LICENSE LICENSE
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/README.md README.md
/var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr kubestr
2022/02/27 14:30:15 extracted tarball into /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T: 3 files, 0 dirs (220.900447ms)
2022/02/27 14:30:15 Extracted: /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr
2022/02/27 14:30:15 Copying /var/folders/9v/tgcnwm6j5d35mm_gy478rrlr0000gn/T/kubestr to /Users/welteki/.arkade/bin/kubestr

Tool written to: /Users/welteki/.arkade/bin/kubestr

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/welteki/.arkade/bin/kubestr

# Or install with:
sudo mv /Users/welteki/.arkade/bin/kubestr /usr/local/bin/
```

```
$ file /Users/welteki/.arkade/bin/kubestr
/Users/welteki/.arkade/bin/kubestr: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=vIx8c6rsztXlRZnw-lxD/n4YuhM-4L63DKV3lAzqb/XYYSAAmpqvgbQk2UlTAf/GHtapFnrxX9xnIcnSEyD, stripped
```

</details>

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
