### PR TITLE
Refactor `mergeFlags` into `config.MergeFlags`

### DIFF
--- a/cmd/apps/cassandra_app.go
+++ b/cmd/apps/cassandra_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
@@ -83,7 +84,7 @@ func MakeInstallCassandra() *cobra.Command {
 		}
 
 		// set custom flags
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/certmanager_app.go
+++ b/cmd/apps/certmanager_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
@@ -48,7 +49,7 @@ func MakeInstallCertManager() *cobra.Command {
 		if err != nil {
 			return err
 		}
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/consul_app.go
+++ b/cmd/apps/consul_app.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 	"strconv"
 	"strings"
 
@@ -95,7 +96,7 @@ func MakeInstallConsul() *cobra.Command {
 
 		customFlags, _ := command.Flags().GetStringArray("set")
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/cronconnector_app.go
+++ b/cmd/apps/cronconnector_app.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/k8s"
@@ -38,7 +39,7 @@ func MakeInstallCronConnector() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/crossplane_app.go
+++ b/cmd/apps/crossplane_app.go
@@ -63,7 +63,7 @@ schedule workloads to any Kubernetes cluster`,
 			return err
 		}
 		values := make(map[string]string)
-		if err := mergeFlags(values, overrideValues); err != nil {
+		if err := config.MergeFlags(values, overrideValues); err != nil {
 			return err
 		}
 

--- a/cmd/apps/falco.go
+++ b/cmd/apps/falco.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/k8s"
@@ -69,7 +70,7 @@ func MakeInstallFalco() *cobra.Command {
 		}
 
 		overrides := map[string]string{}
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/gitea_app.go
+++ b/cmd/apps/gitea_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 	"strconv"
 	"strings"
 
@@ -77,7 +78,7 @@ func MakeInstallGitea() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/grafana_app.go
+++ b/cmd/apps/grafana_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
@@ -86,7 +87,7 @@ func MakeInstallGrafana() *cobra.Command {
 		}
 
 		// set custom flags
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/inletsoperator_app.go
+++ b/cmd/apps/inletsoperator_app.go
@@ -155,7 +155,7 @@ IngressController`,
 
 		customFlags, _ := command.Flags().GetStringArray("set")
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/inletstcpclient_app.go
+++ b/cmd/apps/inletstcpclient_app.go
@@ -147,7 +147,7 @@ func MakeInstallInletsTcpClient() *cobra.Command {
 
 		customFlags, _ := command.Flags().GetStringArray("set")
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/jenkins_app.go
+++ b/cmd/apps/jenkins_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 	"strconv"
 	"strings"
 
@@ -77,7 +78,7 @@ func MakeInstallJenkins() *cobra.Command {
 		overrides["persistence.enabled"] = strings.ToLower(strconv.FormatBool(persistence))
 
 		// set custom flags
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/kafkaconnector_app.go
+++ b/cmd/apps/kafkaconnector_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/types"
@@ -69,7 +70,7 @@ functions when messages are received on a given topic on a Kafka broker.`,
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/kong_ingress_app.go
+++ b/cmd/apps/kong_ingress_app.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/types"
@@ -41,7 +42,7 @@ func MakeInstallKongIngress() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -52,7 +52,7 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 			return err
 		}
 
-		if err := mergeFlags(overrides, setVals); err != nil {
+		if err := config.MergeFlags(overrides, setVals); err != nil {
 			return err
 		}
 

--- a/cmd/apps/kyverno.go
+++ b/cmd/apps/kyverno.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/k8s"
@@ -61,7 +62,7 @@ func MakeInstallKyverno() *cobra.Command {
 		}
 
 		overrides := map[string]string{}
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/minio_app.go
+++ b/cmd/apps/minio_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 	"strconv"
 	"strings"
 
@@ -123,7 +124,7 @@ func MakeInstallMinio() *cobra.Command {
 			overrides["mode"] = "distributed"
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/mongodb_app.go
+++ b/cmd/apps/mongodb_app.go
@@ -90,7 +90,7 @@ func MakeInstallMongoDB() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/mqttconnector_app.go
+++ b/cmd/apps/mqttconnector_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 	"strconv"
 
 	"github.com/alexellis/arkade/pkg/apps"
@@ -66,7 +67,7 @@ messages are received on a given topic on an MQTT broker.`,
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/nginx_app.go
+++ b/cmd/apps/nginx_app.go
@@ -57,7 +57,7 @@ flag and the ingress-nginx docs for more info`,
 
 		customFlags, _ := command.Flags().GetStringArray("set")
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/nginx_inc_app.go
+++ b/cmd/apps/nginx_inc_app.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 	"strconv"
 
 	"github.com/alexellis/arkade/pkg/apps"
@@ -85,7 +86,7 @@ func MakeInstallNginxIncIngress() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/opa_gatekeeper.go
+++ b/cmd/apps/opa_gatekeeper.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/k8s"
@@ -66,7 +67,7 @@ for the Kubernetes API.`,
 		fmt.Printf("Node architecture: %q\n", arch)
 
 		overrides := map[string]string{}
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -5,11 +5,10 @@ package apps
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
-
 	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/types"
+	"strconv"
 
 	"github.com/alexellis/arkade/pkg/k8s"
 
@@ -183,7 +182,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		}
 
 		customFlags, _ := command.Flags().GetStringArray("set")
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 
@@ -225,17 +224,6 @@ func getValuesSuffix(arch string) string {
 		valuesSuffix = ""
 	}
 	return valuesSuffix
-}
-
-func mergeFlags(existingMap map[string]string, setOverrides []string) error {
-	for _, setOverride := range setOverrides {
-		flag := strings.Split(setOverride, "=")
-		if len(flag) != 2 {
-			return fmt.Errorf("incorrect format for custom flag `%s`", setOverride)
-		}
-		existingMap[flag[0]] = flag[1]
-	}
-	return nil
 }
 
 const OpenFaaSInfoMsg = `# Get the faas-cli

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 	"strconv"
 	"strings"
 
@@ -61,7 +62,7 @@ func MakeInstallPostgresql() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/rabbitmq_app.go
+++ b/cmd/apps/rabbitmq_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
@@ -83,7 +84,7 @@ func MakeInstallRabbitmq() *cobra.Command {
 		}
 
 		// set custom flags
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/sealed_secret_app.go
+++ b/cmd/apps/sealed_secret_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/types"
@@ -42,7 +43,7 @@ func MakeInstallSealedSecrets() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/traefik2_app.go
+++ b/cmd/apps/traefik2_app.go
@@ -90,7 +90,7 @@ func MakeInstallTraefik2() *cobra.Command {
 			return fmt.Errorf("error with --set usage: %s", err)
 		}
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/cmd/apps/waypoint_app.go
+++ b/cmd/apps/waypoint_app.go
@@ -5,6 +5,7 @@ package apps
 
 import (
 	"fmt"
+	"github.com/alexellis/arkade/pkg/config"
 
 	"github.com/alexellis/arkade/pkg/apps"
 	"github.com/alexellis/arkade/pkg/types"
@@ -44,7 +45,7 @@ func MakeInstallWaypoint() *cobra.Command {
 
 		customFlags, _ := command.Flags().GetStringArray("set")
 
-		if err := mergeFlags(overrides, customFlags); err != nil {
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,10 +51,16 @@ func GetDefaultKubeconfig() string {
 
 func MergeFlags(existingMap map[string]string, setOverrides []string) error {
 	for _, setOverride := range setOverrides {
-		flag := strings.Split(setOverride, "=")
+		// Limit the number of parts to 2 to keep `=` characters in the value.
+		flag := strings.SplitN(setOverride, "=", 2)
 		if len(flag) != 2 {
 			return fmt.Errorf("incorrect format for custom flag `%s`", setOverride)
 		}
+
+		if strings.HasPrefix(flag[1], "'") && strings.HasSuffix(flag[1], "'") {
+			flag[1] = flag[1][1 : len(flag[1])-1]
+		}
+
 		existingMap[flag[0]] = flag[1]
 	}
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -59,6 +59,18 @@ func Test_MergeFlags(t *testing.T) {
 			map[string]string{"a": "2", "b": "3"},
 			nil,
 		},
+		{"Multiple = in value",
+			map[string]string{},
+			[]string{"a=b=3=c=1=y=5"},
+			map[string]string{"a": "b=3=c=1=y=5"},
+			nil,
+		},
+		{"Quote the value string using '",
+			map[string]string{},
+			[]string{"a='b=3 c=1 y=5'"},
+			map[string]string{"a": "b=3 c=1 y=5"},
+			nil,
+		},
 
 		// check errors
 		{"Incorrect flag format, providing : as a delimiter",


### PR DESCRIPTION
- Move away from `cmd.mergeFlags` in favor of `config.MergeFlags` 
- Fix multiple equal sing handling for values in `config.MergeFlags` with tests
- Add start-end single quote removal to `config.MergeFlags` with tests
- Remove old `cmd.mergeFlags`
<!--- Provide a general summary of your changes in the Title above -->
Closes #592 
## Description
Handling of value single + double quotes and the `=` char was inconsistent and the quotes were included in the values string, this PR fixes that.

## Motivation and Context
`cmd.mergeFlags` was an exact copy of `config.MergeFlags` and multiple app used both.
It is generally a great idea to move commonly used functionality under `pkg` and remove duplicate code.
- [X] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md)) #592 


## How Has This Been Tested?
All the changes covered by the extended unit test for the `config.MergeFlags` function.

Also, I ran every previously not working command from issue #592.
<details>
<summary>Logs</summary>
<pre><code>
Using Kubeconfig: /home/shika/.kube/config
Using Kubeconfig: /home/shika/.kube/config
[Warning] unable to create namespace default, may already exist: Error from server (AlreadyExists): namespaces "default" already exists
Client: x86_64, Linux
"ingress-nginx" already exists with the same configuration, skipping
VALUES values.yaml
Command: /home/shika/.arkade/bin/helm [upgrade --install ingress-nginx ingress-nginx/ingress-nginx --namespace default --values /tmp/charts/ingress-nginx/values.yaml --set controller.extraArgs.publish-status-address=localhost --set controller.updateStrategy.rollingUpdate.maxUnavailable=1 --set controller.config.log-format-upstream=remote_addr=$remote_addr user=$remote_user ts=$time_local request="$request" status=$status body_bytes=$body_bytes_sent referer="$http_referer" user_agent="$http_user_agent" request_length=$request_length duration=$request_time upstream=$proxy_upstream_name upstream_addr=$upstream_addr upstream_resp_length=$upstream_response_length upstream_duration=$upstream_response_time upstream_status=$upstream_status traceId=$opentracing_context_uber_trace_id --set controller.hostPort.enabled=true --set controller.service.nodePorts.http=30080 --set controller.publishService.enabled=false --set controller.updateStrategy.rollingUpdate.maxSurge=0 --set controller.config.enable-opentracing=true --set controller.config.jaeger-collector-host=tempo.default.svc.cluster.local --set controller.service.type=NodePort]
Release "ingress-nginx" does not exist. Installing it now.
NAME: ingress-nginx
LAST DEPLOYED: Wed Mar  2 22:54:20 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The ingress-nginx controller has been installed.
Get the application URL by running these commands:
  export HTTP_NODE_PORT=30080
  export HTTPS_NODE_PORT=$(kubectl --namespace default get services -o jsonpath="{.spec.ports[1].nodePort}" ingress-nginx-controller)
  export NODE_IP=$(kubectl --namespace default get nodes -o jsonpath="{.items[0].status.addresses[1].address}")

  echo "Visit http://$NODE_IP:$HTTP_NODE_PORT to access your application via HTTP."
  echo "Visit https://$NODE_IP:$HTTPS_NODE_PORT to access your application via HTTPS."

An example Ingress that makes use of the controller:
  apiVersion: networking.k8s.io/v1
  kind: Ingress
  metadata:
    name: example
    namespace: foo
  spec:
    ingressClassName: nginx
    rules:
      - host: www.example.com
        http:
          paths:
            - backend:
                service:
                  name: exampleService
                  port:
                    number: 80
              path: /
    # This section is only required if TLS is to be enabled for the Ingress
    tls:
      - hosts:
        - www.example.com
        secretName: example-tls

If TLS is enabled for the Ingress, a Secret containing the certificate and key must also be provided:

  apiVersion: v1
  kind: Secret
  metadata:
    name: example-tls
    namespace: foo
  data:
    tls.crt: <base64 encoded cert>
    tls.key: <base64 encoded key>
  type: kubernetes.io/tls
=======================================================================
= ingress-nginx has been installed.                                   =
=======================================================================

# If you're using a local environment such as "minikube" or "KinD",
# then try the inlets operator with "arkade install inlets-operator"

# If you're using a managed Kubernetes service, then you'll find
# your LoadBalancer's IP under "EXTERNAL-IP" via:

kubectl get svc ingress-nginx-controller

# Find out more at:
# https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx

Thanks for using arkade!

</code></pre>
</details>

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [ ] Yes
- [X] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [X] I have tested this on arm, or have added code to prevent deployment
