### PR TITLE
Add dagger tool as a downloadable package

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -3362,3 +3362,59 @@ func Test_DownloadSOPS(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadDagger(t *testing.T) {
+	tools := MakeTools()
+	name := "dagger"
+
+	var tool *Tool
+	for _, target := range tools {
+		if name == target.Name {
+			tool = &target
+			break
+		}
+	}
+	version := "v0.2.4"
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    archARM64,
+			version: version,
+			url:     "https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_darwin_arm64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: version,
+			url:     "https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_linux_arm64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_darwin_amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_linux_amd64.tar.gz",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_windows_amd64.tar.gz",
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Fatalf("want:\n%s\ngot:\n%s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -2048,5 +2048,30 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			{{- end -}}
 			`,
 		})
+
+	// 	https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_linux_amd64.tar.gz
+
+	tools = append(tools,
+		Tool{
+			Owner:       "dagger",
+			Repo:        "dagger",
+			Name:        "dagger",
+			Description: "A portable devkit for CI/CD pipelines.",
+			URLTemplate: `
+	{{ $os := .OS }}
+	{{- if HasPrefix .OS "ming" -}}
+	{{ $os = "windows" }}
+	{{- end -}}
+
+	{{ $arch := .Arch }}
+	{{- if eq .Arch "x86_64" -}}
+	{{ $arch = "amd64" }}
+	{{- else if eq .Arch "aarch64" -}}
+	{{ $arch = "arm64" }}
+	{{- end -}}
+
+	https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/dagger_{{.Version}}_{{$os}}_{{$arch}}.tar.gz`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add dagger tool as a downloadable package

https://dagger.io/

## Motivation and Context

Newly released CI tool by @shykes and team

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With new unit tests plus e2e test:

```bash
#!/bin/bash

go build 

./arkade get dagger --arch arm64 --os darwin
file $HOME/.arkade/bin/dagger

./arkade get dagger --arch x86_64 --os darwin
file $HOME/.arkade/bin/dagger

./arkade get dagger --arch x86_64 --os linux
file $HOME/.arkade/bin/dagger

./arkade get dagger --arch arm64 --os linux
file $HOME/.arkade/bin/dagger

./arkade get dagger --arch amd64 --os windows
file $HOME/.arkade/bin/dagger
```

Output:

```bash
Downloading: dagger
2022/04/03 11:07:45 Looking up version for dagger
2022/04/03 11:07:45 Found: v0.2.4
Downloading: https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_darwin_arm64.tar.gz
9.61 MiB / 9.61 MiB [-------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger_v0.2.4_darwin_arm64.tar.gz written.
2022/04/03 11:07:47 Looking up version for dagger
2022/04/03 11:07:47 Found: v0.2.4
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/LICENSE LICENSE
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger dagger
2022/04/03 11:07:47 extracted tarball into /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T: 2 files, 0 dirs (208.923083ms)
2022/04/03 11:07:47 Extracted: /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger
2022/04/03 11:07:47 Copying /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger to /Users/alex/.arkade/bin/dagger

Tool written to: /Users/alex/.arkade/bin/dagger

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/alex/.arkade/bin/dagger

# Or install with:
sudo mv /Users/alex/.arkade/bin/dagger /usr/local/bin/
/Users/alex/.arkade/bin/dagger: Mach-O 64-bit executable arm64
Downloading: dagger
2022/04/03 11:07:47 Looking up version for dagger
2022/04/03 11:07:47 Found: v0.2.4
Downloading: https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_darwin_amd64.tar.gz
9.83 MiB / 9.83 MiB [-------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger_v0.2.4_darwin_amd64.tar.gz written.
2022/04/03 11:07:49 Looking up version for dagger
2022/04/03 11:07:49 Found: v0.2.4
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/LICENSE LICENSE
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger dagger
2022/04/03 11:07:49 extracted tarball into /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T: 2 files, 0 dirs (205.925209ms)
2022/04/03 11:07:49 Extracted: /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger
2022/04/03 11:07:49 Copying /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger to /Users/alex/.arkade/bin/dagger

Tool written to: /Users/alex/.arkade/bin/dagger

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/alex/.arkade/bin/dagger

# Or install with:
sudo mv /Users/alex/.arkade/bin/dagger /usr/local/bin/
/Users/alex/.arkade/bin/dagger: Mach-O 64-bit executable x86_64
Downloading: dagger
2022/04/03 11:07:49 Looking up version for dagger
2022/04/03 11:07:49 Found: v0.2.4
Downloading: https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_linux_amd64.tar.gz
9.38 MiB / 9.38 MiB [-------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger_v0.2.4_linux_amd64.tar.gz written.
2022/04/03 11:07:51 Looking up version for dagger
2022/04/03 11:07:51 Found: v0.2.4
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/LICENSE LICENSE
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger dagger
2022/04/03 11:07:51 extracted tarball into /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T: 2 files, 0 dirs (205.855458ms)
2022/04/03 11:07:51 Extracted: /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger
2022/04/03 11:07:51 Copying /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger to /Users/alex/.arkade/bin/dagger

Tool written to: /Users/alex/.arkade/bin/dagger

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/alex/.arkade/bin/dagger

# Or install with:
sudo mv /Users/alex/.arkade/bin/dagger /usr/local/bin/
/Users/alex/.arkade/bin/dagger: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=91UpESLatAv2LDw3UyTF/QQym2WdYP69qJ1S697X5/joF4TX4ThTc6jZqZX7u5/Z4IQs0Er8QteObM-A8qb, stripped
Downloading: dagger
2022/04/03 11:07:51 Looking up version for dagger
2022/04/03 11:07:52 Found: v0.2.4
Downloading: https://github.com/dagger/dagger/releases/download/v0.2.4/dagger_v0.2.4_linux_arm64.tar.gz
8.50 MiB / 8.50 MiB [-------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger_v0.2.4_linux_arm64.tar.gz written.
2022/04/03 11:07:53 Looking up version for dagger
2022/04/03 11:07:53 Found: v0.2.4
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/LICENSE LICENSE
/var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger dagger
2022/04/03 11:07:54 extracted tarball into /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T: 2 files, 0 dirs (173.879042ms)
2022/04/03 11:07:54 Extracted: /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger
2022/04/03 11:07:54 Copying /var/folders/3d/hy7q1wgs38x0qn7ff04p4vrc0000gn/T/dagger to /Users/alex/.arkade/bin/dagger

Tool written to: /Users/alex/.arkade/bin/dagger

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/alex/.arkade/bin/dagger

# Or install with:
sudo mv /Users/alex/.arkade/bin/dagger /usr/local/bin/
/Users/alex/.arkade/bin/dagger: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=6gRrW_ZyYE1jDD-UvX9k/4PhtBN-qe1ASokFEvgCs/CPcvwoqQL1c9rWKaK6K4/LRqYrH-aKrXF5F2n0DgZ, stripped
Error: operating system "windows" is not supported. Available prefixes: linux, darwin, ming.
/Users/alex/.arkade/bin/dagger: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=6gRrW_ZyYE1jDD-UvX9k/4PhtBN-qe1ASokFEvgCs/CPcvwoqQL1c9rWKaK6K4/LRqYrH-aKrXF5F2n0DgZ, stripped
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment

I haven't updated the README as not to block #653 with a rebase.