### PR TITLE
feat: add firecracker install

### DIFF
--- a/cmd/system/firecracker.go
+++ b/cmd/system/firecracker.go
@@ -1,0 +1,119 @@
+// Copyright (c) arkade author(s) 2022. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package system
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/archive"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/get"
+	"github.com/spf13/cobra"
+)
+
+const (
+	githubDownloadTemplate = "https://github.com/%s/%s/releases/download/%s/%s"
+	githubLatest           = "latest"
+
+	firecrackerOwner = "firecracker-microvm"
+	firecrackerRepo  = "firecracker"
+
+	repoFlagName     = "repo"
+	versionFlagName  = "version"
+	pathFlagName     = "path"
+	progressFlagName = "progress"
+)
+
+func MakeInstallFirecracker() *cobra.Command {
+
+	command := &cobra.Command{
+		Use:   "firecracker",
+		Short: "Install Firecracker",
+		Long:  `Install Firecracker and its Jailer.`,
+		Example: `  arkade system install firecracker
+  arkade system install firecracker --version v1.0.0`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().StringP(versionFlagName, "v", githubLatest, "The version for Firecracker to install")
+	command.Flags().StringP(pathFlagName, "p", "/usr/local/bin", "Installation path, where a go subfolder will be created")
+	command.Flags().Bool(progressFlagName, true, "Show download progress")
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		installPath, _ := cmd.Flags().GetString(pathFlagName)
+		version, _ := cmd.Flags().GetString(versionFlagName)
+		progress, _ := cmd.Flags().GetBool(progressFlagName)
+
+		fmt.Printf("Installing Firecracker to %s\n", installPath)
+
+		if err := os.MkdirAll(installPath, 0755); err != nil && !os.IsExist(err) {
+			fmt.Printf("Error creating directory %s, error: %s\n", installPath, err.Error())
+		}
+
+		arch, osVer := env.GetClientArch()
+
+		if strings.ToLower(osVer) != "linux" {
+			return fmt.Errorf("this app only supports Linux")
+		}
+
+		if arch != "x86_64" && arch != "aarch64" {
+			return fmt.Errorf("this app only supports x86_64 and aarch64 and not %s", arch)
+		}
+
+		if version == githubLatest {
+			v, err := get.FindGitHubRelease(firecrackerOwner, firecrackerRepo)
+			if err != nil {
+				return err
+			}
+
+			version = v
+		} else if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
+
+		fmt.Printf("Installing version: %s for: %s\n", version, arch)
+
+		filename := fmt.Sprintf("firecracker-%s-%s.tgz", version, arch)
+		dlURL := fmt.Sprintf(githubDownloadTemplate, firecrackerOwner, firecrackerRepo, version, filename)
+
+		fmt.Printf("Downloading from: %s\n", dlURL)
+		outPath, err := get.DownloadFileP(dlURL, progress)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Downloaded to: %s\n", outPath)
+
+		f, err := os.OpenFile(outPath, os.O_RDONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		tempUnpackPath, err := os.MkdirTemp(os.TempDir(), "firecracker*")
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Unpacking Firecracker to: %s\n", tempUnpackPath)
+		if err := archive.Untar(f, tempUnpackPath, true); err != nil {
+			return err
+		}
+
+		fmt.Printf("Copying Firecracker binaries to: %s\n", installPath)
+		filesToCopy := map[string]string{
+			fmt.Sprintf("%s/firecracker-%s-%s", tempUnpackPath, version, arch): fmt.Sprintf("%s/firecracker", installPath),
+			fmt.Sprintf("%s/jailer-%s-%s", tempUnpackPath, version, arch):      fmt.Sprintf("%s/jailer", installPath),
+		}
+		for src, dst := range filesToCopy {
+			if _, copyErr := get.CopyFile(src, dst); copyErr != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	return command
+}

--- a/cmd/system/install.go
+++ b/cmd/system/install.go
@@ -22,6 +22,7 @@ func MakeInstall() *cobra.Command {
 	}
 
 	command.AddCommand(MakeInstallGo())
+	command.AddCommand(MakeInstallFirecracker())
 
 	return command
 }

--- a/pkg/get/download.go
+++ b/pkg/get/download.go
@@ -75,7 +75,7 @@ func Download(tool *Tool, arch, operatingSystem, version string, downloadMode in
 		if !quiet {
 			log.Printf("Copying %s to %s\n", outFilePath, localPath)
 		}
-		_, err = copyFile(outFilePath, localPath)
+		_, err = CopyFile(outFilePath, localPath)
 		if err != nil {
 			return "", "", err
 		}
@@ -123,7 +123,7 @@ func downloadFile(downloadURL string, displayProgress bool) (string, error) {
 	return outFilePath, nil
 }
 
-func copyFile(src, dst string) (int64, error) {
+func CopyFile(src, dst string) (int64, error) {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
 		return 0, err

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -129,7 +129,7 @@ func (tool Tool) GetURL(os, arch, version string, quiet bool) (string, error) {
 			log.Printf("Looking up version for %s", tool.Name)
 		}
 
-		v, err := findGitHubRelease(tool.Owner, tool.Repo)
+		v, err := FindGitHubRelease(tool.Owner, tool.Repo)
 		if err != nil {
 			return "", err
 		}
@@ -175,7 +175,7 @@ func getURLByGithubTemplate(tool Tool, os, arch, version string) (string, error)
 	return getBinaryURL(tool.Owner, tool.Repo, version, downloadName), nil
 }
 
-func findGitHubRelease(owner, repo string) (string, error) {
+func FindGitHubRelease(owner, repo string) (string, error) {
 	url := fmt.Sprintf("https://github.com/%s/%s/releases/latest", owner, repo)
 
 	timeout := time.Second * 5


### PR DESCRIPTION
This adds the ability to download and install Firecracker.

## Description
This adds the following to enable user to install Firecracker as a system package:

```bash
arkade system install firecracker
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Relates to #654 

## How Has This Been Tested?
Local testing in my development env but not on arm:

```bash
➜ go build && ./arkade system install firecracker --path ./out
Installing Firecracker to ./out
Installing version: v1.0.0 for: x86_64
Downloading from: https://github.com/firecracker-microvm/firecracker/releases/download/v1.0.0/firecracker-v1.0.0-x86_64.tgz
1.59 MiB / 1.59 MiB [------------------------------------------------------------------------------------------------------------------------------------] 100.00%
Downloaded to: /tmp/firecracker-v1.0.0-x86_64.tgz
Unpacking Firecracker to: /tmp/firecracker3308092613
Copying Firecracker binaries to: ./out

➜ out/firecracker --version
Firecracker v1.0.0

Supported snapshot data format versions: v0.23.0, v0.24.0, v0.25.0, v1.0.0
```

## Are you a GitHub Sponsor (Yes/No?)

<!--- Check at https://github.com/sponsors/alexellis         -->
<!--- Sponsors get priority because they support the project -->

- [ ] Yes
- [x] No

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] I have tested this on arm, or have added code to prevent deployment
