### PR TITLE
Fix get.sh for CentOS9

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -9,8 +9,8 @@ export VERIFY_CHECKSUM=0
 export ALIAS_NAME="ark"
 export OWNER=alexellis
 export REPO=arkade
-export SUCCESS_CMD="$REPO version"
 export BINLOCATION="/usr/local/bin"
+export SUCCESS_CMD="$BINLOCATION/$REPO version"
 
 ###############################
 # Content common across repos #


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
When running `curl -sLS https://get.arkade.dev | sudo sh` on CentOS9 the script exits with a non-zero exit code. Despite this arkade is installed.

This seems to be affecting use of the command under `sudo` as calling `arkade` outside of sudo returns successfully.  This would seem to be due to the PATH setting in `/etc/sudoers` not looking in the installed directory.

This change updates the `get.sh` variable for `SUCCESS_CMD` so be explicit about the binary's location.

## Motivation and Context
Fixes #683 
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer 

## How Has This Been Tested?
Downloaded the get script:
```
# curl -sLS https://get.arkade.dev > get.sh
```
Made it executable:
```
# chmod +x get.sh
```
Called the script with sudo:
```
# sudo ./get.sh 
x86_64
Downloading package https://github.com/alexellis/arkade/releases/download/0.8.23/arkade as /tmp/arkade
Download complete.

Running with sufficient permissions to attempt to move arkade to /usr/local/bin
New version of arkade installed to /usr/local/bin
which: no ark in (/sbin:/bin:/usr/sbin:/usr/bin)
Creating alias 'ark' for 'arkade'.
main: line 187: arkade: command not found
```
Made the change and retried:
```
# sudo ./get.sh 
x86_64
Downloading package https://github.com/alexellis/arkade/releases/download/0.8.23/arkade as /tmp/arkade
Download complete.

Running with sufficient permissions to attempt to move arkade to /usr/local/bin
New version of arkade installed to /usr/local/bin
There is already a command 'ark' in the path, NOT creating alias
            _             _      
  __ _ _ __| | ____ _  __| | ___ 
 / _` | '__| |/ / _` |/ _` |/ _ \
| (_| | |  |   < (_| | (_| |  __/
 \__,_|_|  |_|\_\__,_|\__,_|\___|

Open Source Marketplace For Developer Tools

Version: 0.8.23
Git Commit: be5a8cc594cbe860055ede8ec36635fcf36ae283

 🐳 arkade needs your support, learn more: https://my.arkade.dev
```

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

