### PR TITLE
Get latest HashiCorp releases

### DIFF
--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -708,7 +708,6 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:       "hashicorp",
 			Repo:        "terraform",
 			Name:        "terraform",
-			Version:     "1.1.9",
 			Description: "Infrastructure as Code for major cloud providers.",
 			URLTemplate: `
 			{{$arch := ""}}
@@ -766,7 +765,6 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:       "hashicorp",
 			Repo:        "vagrant",
 			Name:        "vagrant",
-			Version:     "2.2.19",
 			Description: "Tool for building and distributing development environments.",
 			URLTemplate: `{{$arch := .Arch}}
 
@@ -788,7 +786,6 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			Owner:       "hashicorp",
 			Repo:        "packer",
 			Name:        "packer",
-			Version:     "1.8.0",
 			Description: "Build identical machine images for multiple platforms from a single source configuration.",
 			URLTemplate: `
 			{{$arch := ""}}
@@ -813,7 +810,6 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			Owner:       "hashicorp",
 			Repo:        "waypoint",
 			Name:        "waypoint",
-			Version:     "0.8.1",
 			Description: "Easy application deployment for Kubernetes and Amazon ECS",
 			URLTemplate: `
 			{{$arch := ""}}
@@ -2717,7 +2713,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Owner:       "hashicorp",
 			Repo:        "vault",
 			Name:        "vault",
-			Version:     "1.11.2",
 			Description: "A tool for secrets management, encryption as a service, and privileged access management.",
 			URLTemplate: `
 			{{$arch := ""}}


### PR DESCRIPTION
Related to #560

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In case a tool has a `URLTemplate` including https://releases.hashicorp.com ,
it will fetch its latest release via the https://api.releases.hashicorp.com/v1/releases API querying for artifact
with an "oss" license class.

At the moment, `terraform`, `vagrant`, `vault`, `waypoint`, and `packer` are being supported.

This PR follows #560 request to have minimal changes to the `tools.go` module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running the unit tests and e2e, and installing manually

<details>

```
➜  arkade git:(get-latest-hashicorp-releases) make build
go build
➜  arkade git:(get-latest-hashicorp-releases) ./arkade get --stash=false terraform vagrant packer waypoint
Downloading: terraform
2022/05/29 17:56:19 Looking up version for terraform on HashiCorp
2022/05/29 17:56:19 Found: 1.2.1
Downloading: https://releases.hashicorp.com/terraform/1.2.1/terraform_1.2.1_linux_amd64.zip
18.96 MiB / 18.96 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/terraform_1.2.1_linux_amd64.zip written.
2022/05/29 17:56:20 Looking up version for terraform on HashiCorp
2022/05/29 17:56:21 Found: 1.2.1
Name: terraform_1.2.1_linux_amd64.zip, size: 198816182022/05/29 17:56:22 Extracted: /tmp/terraform

Wrote: /tmp/terraform (62.87MB)

Downloading: vagrant
2022/05/29 17:56:22 Looking up version for vagrant on HashiCorp
2022/05/29 17:56:22 Found: 2.2.19
Downloading: https://releases.hashicorp.com/vagrant/2.2.19/vagrant_2.2.19_linux_amd64.zip
14.37 MiB / 14.37 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/vagrant_2.2.19_linux_amd64.zip written.
2022/05/29 17:56:23 Looking up version for vagrant on HashiCorp
2022/05/29 17:56:23 Found: 2.2.19
Name: vagrant_2.2.19_linux_amd64.zip, size: 150642482022/05/29 17:56:23 Extracted: /tmp/vagrant

Wrote: /tmp/vagrant (15.35MB)

Downloading: packer
2022/05/29 17:56:23 Looking up version for packer on HashiCorp
2022/05/29 17:56:24 Found: 1.8.1
Downloading: https://releases.hashicorp.com/packer/1.8.1/packer_1.8.1_linux_amd64.zip
31.51 MiB / 31.51 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/packer_1.8.1_linux_amd64.zip written.
2022/05/29 17:56:25 Looking up version for packer on HashiCorp
2022/05/29 17:56:25 Found: 1.8.1
Name: packer_1.8.1_linux_amd64.zip, size: 330370262022/05/29 17:56:26 Extracted: /tmp/packer

Wrote: /tmp/packer (158.4MB)

Downloading: waypoint
Downloading: https://releases.hashicorp.com/waypoint/0.6.1/waypoint_0.6.1_linux_amd64.zip
68.63 MiB / 68.63 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/waypoint_0.6.1_linux_amd64.zip written.
Name: waypoint_0.6.1_linux_amd64.zip, size: 719675172022/05/29 17:56:28 Extracted: /tmp/waypoint

Wrote: /tmp/waypoint (134.7MB)

Run the following to copy to install the tool:

chmod +x /tmp/terraform /tmp/vagrant /tmp/packer /tmp/waypoint 
sudo install -m 755 /tmp/terraform /usr/local/bin/terraform
sudo install -m 755 /tmp/vagrant /usr/local/bin/vagrant
sudo install -m 755 /tmp/packer /usr/local/bin/packer
sudo install -m 755 /tmp/waypoint /usr/local/bin/waypoint

🐳 arkade needs your support, learn more: https://my.arkade.dev
```

</details>

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
