### PR TITLE
Add cilium hubble clis

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ Note to contributors, run `arkade install --print-table` to generate this list
 | autok3s          | Run Rancher Lab's lightweight Kubernetes distribution k3s everywhere.                                                                     |
 | buildx           | Docker CLI plugin for extended build capabilities with BuildKit.                                                                          |
 | caddy            | Caddy is an extensible server platform that uses TLS by default                                                                           |
+| cilium           | CLI to install, manage & troubleshoot Kubernetes clusters running Cilium.                                                                 |
 | civo             | CLI for interacting with your Civo resources.                                                                                             |
 | clusterctl       | The clusterctl CLI tool handles the lifecycle of a Cluster API management cluster                                                         |
 | cosign           | Container Signing, Verification and Storage in an OCI registry.                                                                           |
@@ -567,6 +568,7 @@ Note to contributors, run `arkade install --print-table` to generate this list
 | helmfile         | Deploy Kubernetes Helm Charts                                                                                                             |
 | hey              | Load testing tool                                                                                                                         |
 | hostctl          | Dev tool to manage /etc/hosts like a pro!                                                                                                 |
+| hubble           | Hubble - Network, Service & Security Observability for Kubernetes using eBPF                                                              |
 | hugo             | Static HTML and CSS website generator.                                                                                                    |
 | influx           | InfluxDB’s command line interface (influx) is an interactive shell for the HTTP API.                                                      |
 | inlets-pro       | Cloud Native Tunnel for HTTP and TCP traffic.                                                                                             |

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -2242,5 +2242,59 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 		},
 	)
 
+	tools = append(tools,
+		Tool{
+			Owner:       "cilium",
+			Repo:        "cilium-cli",
+			Name:        "cilium",
+			Description: "CLI to install, manage & troubleshoot Kubernetes clusters running Cilium.",
+			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
+{{.Name}}-windows-amd64
+{{- else if eq .OS "darwin" -}}
+	{{- if eq .Arch "aarch64" -}}
+	{{.Name}}-darwin-arm64.tar.gz
+	{{- else if eq .Arch "arm64" -}}
+	{{.Name}}-darwin-arm64.tar.gz
+	{{- else -}}
+	{{.Name}}-darwin-amd64.tar.gz
+	{{- end -}}
+{{- else if eq .Arch "armv6l" -}}
+{{.Name}}-linux-arm.tar.gz
+{{- else if eq .Arch "armv7l" -}}
+{{.Name}}-linux-arm.tar.gz
+{{- else if eq .Arch "aarch64" -}}
+{{.Name}}-linux-arm64.tar.gz
+{{- else -}}
+{{.Name}}-linux-amd64.tar.gz
+{{- end -}}`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "cilium",
+			Repo:        "hubble",
+			Name:        "hubble",
+			Description: "Hubble - Network, Service & Security Observability for Kubernetes using eBPF",
+			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
+{{.Name}}-windows-amd64
+{{- else if eq .OS "darwin" -}}
+	{{- if eq .Arch "aarch64" -}}
+	{{.Name}}-darwin-arm64.tar.gz
+	{{- else if eq .Arch "arm64" -}}
+	{{.Name}}-darwin-arm64.tar.gz
+	{{- else -}}
+	{{.Name}}-darwin-amd64.tar.gz
+	{{- end -}}
+{{- else if eq .Arch "armv6l" -}}
+{{.Name}}-linux-arm.tar.gz
+{{- else if eq .Arch "armv7l" -}}
+{{.Name}}-linux-arm.tar.gz
+{{- else if eq .Arch "aarch64" -}}
+{{.Name}}-linux-arm64.tar.gz
+{{- else -}}
+{{.Name}}-linux-amd64.tar.gz
+{{- end -}}`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
## Description
Adde the cilium and hubble CLIs to `arkade get`.

## Motivation and Context

The cilium and hubble CLIs are used in conjunction with the cilium CNI in Kubernetes.

## How Has This Been Tested?
Ran `make e2e`. Output:

```
...
    --- PASS: Test_CheckTools/Download_of_hubble (0.75s)
    --- PASS: Test_CheckTools/Download_of_cilium (0.74s)
...
```

as well as `make build` and the corresponding `arkade get {cilium,hubble}` commands:

```
❯ ./arkade get cilium
Downloading: cilium
2022/06/19 10:42:38 Looking up version for cilium
2022/06/19 10:42:38 Found: v0.11.9
Downloading: https://github.com/cilium/cilium-cli/releases/download/v0.11.9/cilium-darwin-amd64.tar.gz
22.95 MiB / 22.95 MiB [---------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/nz/79xvvg853p7dxf4gkc8xstq40000gn/T/cilium-darwin-amd64.tar.gz written.
2022/06/19 10:42:43 Looking up version for cilium
2022/06/19 10:42:43 Found: v0.11.9
2022/06/19 10:42:44 Extracted: /var/folders/nz/79xvvg853p7dxf4gkc8xstq40000gn/T/cilium
2022/06/19 10:42:44 Copying /var/folders/nz/79xvvg853p7dxf4gkc8xstq40000gn/T/cilium to /Users/foo/.arkade/bin/cilium

Wrote: /Users/foo/.arkade/bin/cilium (72.96MB)

❯ /Users/foo/.arkade/bin/cilium version
cilium-cli: v0.11.9 compiled with go1.18.3 on darwin/amd64

❯ ./arkade get hubble
Downloading: hubble
2022/06/19 10:44:51 Looking up version for hubble
2022/06/19 10:44:52 Found: v0.9.0
Downloading: https://github.com/cilium/hubble/releases/download/v0.9.0/hubble-darwin-amd64.tar.gz
6.79 MiB / 6.79 MiB [-----------------------------------------------------------------------------------------------------------------] 100.00%
/var/folders/nz/79xvvg853p7dxf4gkc8xstq40000gn/T/hubble-darwin-amd64.tar.gz written.
2022/06/19 10:44:52 Looking up version for hubble
2022/06/19 10:44:53 Found: v0.9.0
2022/06/19 10:44:53 Extracted: /var/folders/nz/79xvvg853p7dxf4gkc8xstq40000gn/T/hubble
2022/06/19 10:44:53 Copying /var/folders/nz/79xvvg853p7dxf4gkc8xstq40000gn/T/hubble to /Users/foo/.arkade/bin/hubble

Wrote: /Users/foo/.arkade/bin/hubble (22.55MB)

❯ /Users/foo/.arkade/bin/hubble version
hubble 0.9.0 compiled with go1.17.3 on darwin/amd64
```

## Are you a GitHub Sponsor yet (Yes/No?)

- [ ] Yes
- [X] No

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [X] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

- [ ] I have tested this on arm, or have added code to prevent deployment  👈  _arm binaries are available for these two CLIs_  


