### PR TITLE
Remove duplicate code for kumactl

### DIFF
--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -2179,31 +2179,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "kumahq",
-			Repo:        "kuma",
-			Name:        "kumactl",
-			Version:     "1.4.1",
-			Description: "kumactl is a CLI to interact with Kuma and its data",
-			URLTemplate: `
-			{{$osStr := ""}}
-			{{$archStr := ""}}
-			{{- if HasPrefix .OS "linux" -}}
-			{{$osStr = "ubuntu"}}
-			{{- else if eq .OS "darwin" -}}
-			{{$osStr = "darwin"}}
-			{{- end -}}
-
-			{{- if eq .Arch "x86_64" -}}
-			{{$archStr = "amd64"}}
-			{{- else -}}
-			{{$archStr = .Arch}}
-			{{- end -}}
-			https://download.konghq.com/mesh-alpine/{{.Repo}}-{{.Version}}-{{$osStr}}-{{$archStr}}.tar.gz`,
-			BinaryTemplate: `{{.Name}}`,
-		})
-
-	tools = append(tools,
-		Tool{
 			Owner:       "caddyserver",
 			Repo:        "caddy",
 			Name:        "caddy",


### PR DESCRIPTION
## Description
Removes duplicate code for `arkade get kumactl`

## Motivation and Context
This was raised in issue #704 and given the go ahead by @alexellis.

## How Has This Been Tested?
`kumactl` is skipped in the e2e test. I verified that `kumactl` still can be downloaded by running the unit test:
```
❯ go test -v -run Test_DownloadKumactl
=== RUN   Test_DownloadKumactl
=== RUN   Test_DownloadKumactl/darwin_x86_64_1.4.1
=== RUN   Test_DownloadKumactl/darwin_x86_64_1.4.1#01
=== RUN   Test_DownloadKumactl/linux_x86_64_1.4.1
=== RUN   Test_DownloadKumactl/linux_x86_64_1.4.1#01
--- PASS: Test_DownloadKumactl (0.00s)
    --- PASS: Test_DownloadKumactl/darwin_x86_64_1.4.1 (0.00s)
    --- PASS: Test_DownloadKumactl/darwin_x86_64_1.4.1#01 (0.00s)
    --- PASS: Test_DownloadKumactl/linux_x86_64_1.4.1 (0.00s)
    --- PASS: Test_DownloadKumactl/linux_x86_64_1.4.1#01 (0.00s)
PASS
ok  	github.com/alexellis/arkade/pkg/get	0.283s
```
and by running the `dagger script` for `kumactl`

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/14938367/175769677-6a7e7913-9e45-4794-8ebe-9fdef92144db.png">
 


## Are you a GitHub Sponsor yet (Yes/No?)

- [ ] Yes
- [X] No

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

N/A

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

- [ ] I have tested this on arm, or have added code to prevent deployment
