### PR TITLE
Update docker registry to twun.io's registry chart

### DIFF
--- a/cmd/apps/registry_app.go
+++ b/cmd/apps/registry_app.go
@@ -23,9 +23,11 @@ import (
 
 func MakeInstallRegistry() *cobra.Command {
 	var registry = &cobra.Command{
-		Use:          "docker-registry",
-		Short:        "Install a Docker registry",
-		Long:         `Install a Docker registry`,
+		Use:   "docker-registry",
+		Short: "Install a community maintained Docker registry chart",
+		Long: `Install a community maintained Docker registry chart for more info
+Check out the project's repo https://github.com/twuni/docker-registry.helm
+Or the Open Source Docker registry https://github.com/distribution/distribution`,
 		Example:      `  arkade install registry --namespace default`,
 		SilenceUsage: true,
 	}
@@ -92,13 +94,13 @@ func MakeInstallRegistry() *cobra.Command {
 
 		htPasswd := fmt.Sprintf("%s:%s\n", username, string(val))
 
-		err = helm.AddHelmRepo("stable", "https://charts.helm.sh/stable", updateRepo)
+		err = helm.AddHelmRepo("twuni", "https://twuni.github.io/docker-registry.helm", updateRepo)
 		if err != nil {
 			return err
 		}
 
 		chartPath := path.Join(os.TempDir(), "charts")
-		err = helm.FetchChart("stable/docker-registry", defaultVersion)
+		err = helm.FetchChart("twuni/docker-registry", defaultVersion)
 
 		if err != nil {
 			return err
@@ -130,7 +132,7 @@ func MakeInstallRegistry() *cobra.Command {
 
 		ns := "default"
 
-		err = helm.Helm3Upgrade("stable/docker-registry", ns,
+		err = helm.Helm3Upgrade("twuni/docker-registry", ns,
 			"values.yaml",
 			defaultVersion,
 			overrides,
@@ -171,8 +173,10 @@ docker login $IP:5000 --username admin --password $PASSWORD
 docker tag alpine:3.11 $IP:5000/alpine:3.11
 docker push $IP:5000/alpine:3.11
 
+# This chart is community maintained.
 # Find out more at:
-# https://github.com/helm/charts/tree/master/stable/registry`
+# https://github.com/twuni/docker-registry.helm
+# https://github.com/distribution/distribution`
 
 const registryInstallMsg = `=======================================================================
 = docker-registry has been installed.                                 =


### PR DESCRIPTION
Signed-off-by: Czékus Máté <mate@picloud.hu>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Docker Registry used the old `stable` chart which was outdated and the only still updated 1:1 feature comaptible one was twuni's chart.

## Motivation and Context
- [X] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md)) #274 


## How Has This Been Tested?
Manually by running `arkade install docker-registry` with all the flags.

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [X] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [X] I have tested this on arm, or have added code to prevent deployment
