### PR TITLE
Add talosctl as a new CLI tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ There are 54 apps that you can install on your cluster.
 | rekor-cli        | Secure Supply Chain - Transparency Log                                                                                                    |
 | sops             | Simple and flexible tool for managing secrets                                                                                             |
 | stern            | Multi pod and container log tailing for Kubernetes.                                                                                       |
+| talosctl         | The cli tool for managing Talos Linux OS.                                                                                                 |
 | terraform        | Infrastructure as Code for major cloud providers.                                                                                         |
 | terragrunt       | Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules                          |
 | tfsec            | Security scanner for your Terraform code                                                                                                  |

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -4123,3 +4123,62 @@ func Test_DownloadGomplate(t *testing.T) {
 		})
 	}
 }
+
+func Test_DownloadTalosctl(t *testing.T) {
+	tools := MakeTools()
+	name := "talosctl"
+	version := "v1.1.2"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: version,
+			url:     `https://github.com/siderolabs/talos/releases/download/v1.1.2/talosctl-darwin-amd64`,
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: version,
+			url:     `https://github.com/siderolabs/talos/releases/download/v1.1.2/talosctl-darwin-arm64`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: version,
+			url:     `https://github.com/siderolabs/talos/releases/download/v1.1.2/talosctl-linux-amd64`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: version,
+			url:     `https://github.com/siderolabs/talos/releases/download/v1.1.2/talosctl-linux-arm64`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: version,
+			url:     `https://github.com/siderolabs/talos/releases/download/v1.1.2/talosctl-linux-armv7`,
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: version,
+			url:     `https://github.com/siderolabs/talos/releases/download/v1.1.2/talosctl-windows-amd64.exe`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -2413,5 +2413,42 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				`,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:       "siderolabs",
+			Repo:        "talos",
+			Name:        "talosctl",
+			Description: "The command-line tool for managing Talos Linux OS.",
+			URLTemplate: `
+				{{ $os := "linux" }}
+				{{ $arch := "amd64" }}
+				{{ $ext := "" }}
+
+				{{- if eq .Arch "aarch64" -}}
+				{{ $arch = "arm64" }}
+				{{- else if eq .Arch "arm64" -}}
+				{{ $arch = "arm64" }}
+				{{- else if eq .Arch "armv7l" -}}
+				{{ $arch = "armv7" }}
+				{{- end -}}
+
+				{{ if HasPrefix .OS "ming" -}}
+				{{ $os = "windows" }}
+				{{ $ext = ".exe" }}
+				{{- else if eq .OS "darwin" -}}
+				{{  $os = "darwin" }}
+				{{- end -}}
+
+				https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{ .Version }}/{{ .Name }}-{{ $os }}-{{ $arch }}{{ $ext }}
+					`,
+			BinaryTemplate: `
+				{{ if HasPrefix .OS "ming" -}}
+				{{ .Name }}.exe
+				{{- else -}}
+				{{ .Name }}
+				{{- end -}}
+				`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
Signed-off-by: Matthew Richardson <M.Richardson@ed.ac.uk>

## Description
Add talosctl command-line tool for managing Talos Linux OS clusters.

## Motivation and Context
Fixes https://github.com/alexellis/arkade/issues/720

- [X] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
`make test && make e2e`

<details>
<summary>Test results</summary>
<pre>
fatal: No names found, cannot describe anything.
CGO_ENABLED=0 go test github.com/alexellis/arkade github.com/alexellis/arkade/cmd github.com/alexellis/arkade/cmd/apps github.com/alexellis/arkade/cmd/kasten github.com/alexellis/arkade/cmd/system github.com/alexellis/arkade/cmd/venafi github.com/alexellis/arkade/pkg github.com/alexellis/arkade/pkg/apps github.com/alexellis/arkade/pkg/archive github.com/alexellis/arkade/pkg/config github.com/alexellis/arkade/pkg/env github.com/alexellis/arkade/pkg/get github.com/alexellis/arkade/pkg/helm github.com/alexellis/arkade/pkg/k8s github.com/alexellis/arkade/pkg/types -cover
?   	github.com/alexellis/arkade	[no test files]
ok  	github.com/alexellis/arkade/cmd	(cached)	coverage: 17.4% of statements
ok  	github.com/alexellis/arkade/cmd/apps	(cached)	coverage: 2.0% of statements
?   	github.com/alexellis/arkade/cmd/kasten	[no test files]
?   	github.com/alexellis/arkade/cmd/system	[no test files]
ok  	github.com/alexellis/arkade/cmd/venafi	(cached)	coverage: 3.2% of statements
?   	github.com/alexellis/arkade/pkg	[no test files]
?   	github.com/alexellis/arkade/pkg/apps	[no test files]
?   	github.com/alexellis/arkade/pkg/archive	[no test files]
ok  	github.com/alexellis/arkade/pkg/config	(cached)	coverage: 22.9% of statements
?   	github.com/alexellis/arkade/pkg/env	[no test files]
ok  	github.com/alexellis/arkade/pkg/get	(cached)	coverage: 49.9% of statements
ok  	github.com/alexellis/arkade/pkg/helm	(cached)	coverage: 6.2% of statements
?   	github.com/alexellis/arkade/pkg/k8s	[no test files]
?   	github.com/alexellis/arkade/pkg/types	[no test files]
fatal: No names found, cannot describe anything.
CGO_ENABLED=0 go test github.com/alexellis/arkade/pkg/get -cover --tags e2e -v
=== RUN   Test_MakeSureToolsAreSorted
--- PASS: Test_MakeSureToolsAreSorted (0.00s)
=== RUN   Test_PostInstallationMsg
=== RUN   Test_PostInstallationMsg/yq
=== RUN   Test_PostInstallationMsg/yq#01
--- PASS: Test_PostInstallationMsg (0.00s)
    --- PASS: Test_PostInstallationMsg/yq (0.00s)
    --- PASS: Test_PostInstallationMsg/yq#01 (0.00s)
=== RUN   Test_DownloadFaaSCLIDarwin
2022/07/28 11:15:08 Looking up version for faas-cli
2022/07/28 11:15:08 Found: 0.14.2
--- PASS: Test_DownloadFaaSCLIDarwin (0.16s)
=== RUN   Test_GetDownloadURLs
=== RUN   Test_GetDownloadURLs/kubectl
=== RUN   Test_GetDownloadURLs/kubectl#01
=== RUN   Test_GetDownloadURLs/kubectl#02
=== RUN   Test_GetDownloadURLs/kubectl#03
=== RUN   Test_GetDownloadURLs/kubectl#04
=== RUN   Test_GetDownloadURLs/faas-cli
=== RUN   Test_GetDownloadURLs/terraform
--- PASS: Test_GetDownloadURLs (0.00s)
    --- PASS: Test_GetDownloadURLs/kubectl (0.00s)
    --- PASS: Test_GetDownloadURLs/kubectl#01 (0.00s)
    --- PASS: Test_GetDownloadURLs/kubectl#02 (0.00s)
    --- PASS: Test_GetDownloadURLs/kubectl#03 (0.00s)
    --- PASS: Test_GetDownloadURLs/kubectl#04 (0.00s)
    --- PASS: Test_GetDownloadURLs/faas-cli (0.00s)
    --- PASS: Test_GetDownloadURLs/terraform (0.00s)
=== RUN   Test_DownloadArkade
--- PASS: Test_DownloadArkade (0.00s)
=== RUN   Test_DownloadKubectl
--- PASS: Test_DownloadKubectl (0.00s)
=== RUN   Test_DownloadKubectx
--- PASS: Test_DownloadKubectx (0.00s)
=== RUN   Test_DownloadKubens
--- PASS: Test_DownloadKubens (0.00s)
=== RUN   Test_DownloadFaaSCLIArmhf
2022/07/28 11:15:08 Looking up version for faas-cli
2022/07/28 11:15:08 Found: 0.14.2
--- PASS: Test_DownloadFaaSCLIArmhf (0.13s)
=== RUN   Test_DownloadFaaSCLIArm64
2022/07/28 11:15:08 Looking up version for faas-cli
2022/07/28 11:15:08 Found: 0.14.2
--- PASS: Test_DownloadFaaSCLIArm64 (0.14s)
=== RUN   Test_DownloadFaaSCLIWindows
2022/07/28 11:15:08 Looking up version for faas-cli
2022/07/28 11:15:08 Found: 0.14.2
--- PASS: Test_DownloadFaaSCLIWindows (0.13s)
=== RUN   Test_DownloadKubeseal
--- PASS: Test_DownloadKubeseal (0.00s)
=== RUN   Test_DownloadKind
--- PASS: Test_DownloadKind (0.00s)
=== RUN   Test_DownloadK3d
--- PASS: Test_DownloadK3d (0.00s)
=== RUN   Test_DownloadK3s
--- PASS: Test_DownloadK3s (0.00s)
=== RUN   Test_DownloadDevspace
--- PASS: Test_DownloadDevspace (0.00s)
=== RUN   Test_DownloadTilt
--- PASS: Test_DownloadTilt (0.00s)
=== RUN   Test_DownloadK3sup
--- PASS: Test_DownloadK3sup (0.00s)
=== RUN   Test_DownloadAutok3s
--- PASS: Test_DownloadAutok3s (0.00s)
=== RUN   Test_DownloadInletsctl
--- PASS: Test_DownloadInletsctl (0.00s)
=== RUN   Test_DownloadKubebuilder
--- PASS: Test_DownloadKubebuilder (0.00s)
=== RUN   Test_DownloadKustomize
--- PASS: Test_DownloadKustomize (0.00s)
=== RUN   Test_DownloadDigitalOcean
--- PASS: Test_DownloadDigitalOcean (0.00s)
=== RUN   Test_DownloadEKSCTL
--- PASS: Test_DownloadEKSCTL (0.00s)
=== RUN   Test_DownloadK9s
--- PASS: Test_DownloadK9s (0.00s)
=== RUN   Test_DownloadCivo
--- PASS: Test_DownloadCivo (0.00s)
=== RUN   Test_DownloadWaypoint
--- PASS: Test_DownloadWaypoint (0.00s)
=== RUN   Test_DownloadTerraform
--- PASS: Test_DownloadTerraform (0.00s)
=== RUN   Test_DownloadPacker
--- PASS: Test_DownloadPacker (0.00s)
=== RUN   Test_DownloadGH
--- PASS: Test_DownloadGH (0.00s)
=== RUN   Test_DownloadPack
--- PASS: Test_DownloadPack (0.00s)
=== RUN   Test_DownloadBuildx
--- PASS: Test_DownloadBuildx (0.00s)
=== RUN   Test_DownloadDockerCompose
--- PASS: Test_DownloadDockerCompose (0.00s)
=== RUN   Test_DownloadHelmfile
--- PASS: Test_DownloadHelmfile (0.00s)
=== RUN   Test_DownloadOpa
--- PASS: Test_DownloadOpa (0.00s)
=== RUN   Test_getBinaryURL_SlashInDownloadPath
--- PASS: Test_getBinaryURL_SlashInDownloadPath (0.00s)
=== RUN   Test_getBinaryURL_NoSlashInDownloadPath
--- PASS: Test_getBinaryURL_NoSlashInDownloadPath (0.00s)
=== RUN   Test_DownloadMinikube
--- PASS: Test_DownloadMinikube (0.00s)
=== RUN   Test_DownloadMinio
=== RUN   Test_DownloadMinio/ming_amd64_
=== RUN   Test_DownloadMinio/linux_amd64_
=== RUN   Test_DownloadMinio/linux_arm_
=== RUN   Test_DownloadMinio/linux_armv6l_
=== RUN   Test_DownloadMinio/linux_armv7l_
=== RUN   Test_DownloadMinio/linux_aarch64_
=== RUN   Test_DownloadMinio/darwin_amd64_
--- PASS: Test_DownloadMinio (0.01s)
    --- PASS: Test_DownloadMinio/ming_amd64_ (0.00s)
    --- PASS: Test_DownloadMinio/linux_amd64_ (0.00s)
    --- PASS: Test_DownloadMinio/linux_arm_ (0.00s)
    --- PASS: Test_DownloadMinio/linux_armv6l_ (0.00s)
    --- PASS: Test_DownloadMinio/linux_armv7l_ (0.00s)
    --- PASS: Test_DownloadMinio/linux_aarch64_ (0.00s)
    --- PASS: Test_DownloadMinio/darwin_amd64_ (0.00s)
=== RUN   Test_DownloadNats
--- PASS: Test_DownloadNats (0.00s)
=== RUN   Test_DownloadLinkerd
--- PASS: Test_DownloadLinkerd (0.00s)
=== RUN   Test_DownloadArgocd
--- PASS: Test_DownloadArgocd (0.00s)
=== RUN   Test_DownloadNerdctl
--- PASS: Test_DownloadNerdctl (0.00s)
=== RUN   Test_DownloadIstioCtl
=== RUN   Test_DownloadIstioCtl/ming_amd64_1.9.1
=== RUN   Test_DownloadIstioCtl/linux_x86_64_1.9.1
=== RUN   Test_DownloadIstioCtl/linux_amd64_1.9.1
=== RUN   Test_DownloadIstioCtl/linux_arm_1.9.1
=== RUN   Test_DownloadIstioCtl/linux_armv6l_1.9.1
=== RUN   Test_DownloadIstioCtl/linux_armv7l_1.9.1
=== RUN   Test_DownloadIstioCtl/linux_aarch64_1.9.1
=== RUN   Test_DownloadIstioCtl/darwin_amd64_1.9.1
--- PASS: Test_DownloadIstioCtl (0.01s)
    --- PASS: Test_DownloadIstioCtl/ming_amd64_1.9.1 (0.00s)
    --- PASS: Test_DownloadIstioCtl/linux_x86_64_1.9.1 (0.00s)
    --- PASS: Test_DownloadIstioCtl/linux_amd64_1.9.1 (0.00s)
    --- PASS: Test_DownloadIstioCtl/linux_arm_1.9.1 (0.00s)
    --- PASS: Test_DownloadIstioCtl/linux_armv6l_1.9.1 (0.00s)
    --- PASS: Test_DownloadIstioCtl/linux_armv7l_1.9.1 (0.00s)
    --- PASS: Test_DownloadIstioCtl/linux_aarch64_1.9.1 (0.00s)
    --- PASS: Test_DownloadIstioCtl/darwin_amd64_1.9.1 (0.00s)
=== RUN   Test_DownloadTektonCli
--- PASS: Test_DownloadTektonCli (0.00s)
=== RUN   Test_DownloadInfluxCli
--- PASS: Test_DownloadInfluxCli (0.00s)
=== RUN   Test_DownloadInletsProCli
--- PASS: Test_DownloadInletsProCli (0.00s)
=== RUN   Test_DownloadKim
=== RUN   Test_DownloadKim/Download_for:_ming_x86_64_v0.1.0-alpha.12
=== RUN   Test_DownloadKim/Download_for:_linux_x86_64_v0.1.0-alpha.12
=== RUN   Test_DownloadKim/Download_for:_linux_aarch64_v0.1.0-alpha.12
=== RUN   Test_DownloadKim/Download_for:_darwin_x86_64_v0.1.0-alpha.12
--- PASS: Test_DownloadKim (0.00s)
    --- PASS: Test_DownloadKim/Download_for:_ming_x86_64_v0.1.0-alpha.12 (0.00s)
    --- PASS: Test_DownloadKim/Download_for:_linux_x86_64_v0.1.0-alpha.12 (0.00s)
    --- PASS: Test_DownloadKim/Download_for:_linux_aarch64_v0.1.0-alpha.12 (0.00s)
    --- PASS: Test_DownloadKim/Download_for:_darwin_x86_64_v0.1.0-alpha.12 (0.00s)
=== RUN   Test_DownloadTrivyCli
--- PASS: Test_DownloadTrivyCli (0.00s)
=== RUN   Test_DownloadFluxCli
--- PASS: Test_DownloadFluxCli (0.00s)
=== RUN   Test_DownloadPolarisCli
=== RUN   Test_DownloadPolarisCli/darwin_x86_64_v3.2.1
=== RUN   Test_DownloadPolarisCli/linux_x86_64_v3.2.1
=== RUN   Test_DownloadPolarisCli/linux_aarch64_v3.2.1
=== RUN   Test_DownloadPolarisCli/linux_armv7l_v3.2.1
--- PASS: Test_DownloadPolarisCli (0.00s)
    --- PASS: Test_DownloadPolarisCli/darwin_x86_64_v3.2.1 (0.00s)
    --- PASS: Test_DownloadPolarisCli/linux_x86_64_v3.2.1 (0.00s)
    --- PASS: Test_DownloadPolarisCli/linux_aarch64_v3.2.1 (0.00s)
    --- PASS: Test_DownloadPolarisCli/linux_armv7l_v3.2.1 (0.00s)
=== RUN   Test_DownloadHelm
=== RUN   Test_DownloadHelm/linux_x86_64_3.5.4
=== RUN   Test_DownloadHelm/linux_armv7l_3.5.4
=== RUN   Test_DownloadHelm/linux_aarch64_3.5.4
=== RUN   Test_DownloadHelm/darwin_x86_64_3.5.4
=== RUN   Test_DownloadHelm/darwin_aarch64_3.5.4
--- PASS: Test_DownloadHelm (0.00s)
    --- PASS: Test_DownloadHelm/linux_x86_64_3.5.4 (0.00s)
    --- PASS: Test_DownloadHelm/linux_armv7l_3.5.4 (0.00s)
    --- PASS: Test_DownloadHelm/linux_aarch64_3.5.4 (0.00s)
    --- PASS: Test_DownloadHelm/darwin_x86_64_3.5.4 (0.00s)
    --- PASS: Test_DownloadHelm/darwin_aarch64_3.5.4 (0.00s)
=== RUN   Test_DownloadArgoCDAutopilotCli
--- PASS: Test_DownloadArgoCDAutopilotCli (0.00s)
=== RUN   Test_DownloadNovaCli
=== RUN   Test_DownloadNovaCli/darwin_x86_64_2.3.2
=== RUN   Test_DownloadNovaCli/linux_x86_64_2.3.2
=== RUN   Test_DownloadNovaCli/linux_aarch64_2.3.2
=== RUN   Test_DownloadNovaCli/linux_armv7l_2.3.2
--- PASS: Test_DownloadNovaCli (0.00s)
    --- PASS: Test_DownloadNovaCli/darwin_x86_64_2.3.2 (0.00s)
    --- PASS: Test_DownloadNovaCli/linux_x86_64_2.3.2 (0.00s)
    --- PASS: Test_DownloadNovaCli/linux_aarch64_2.3.2 (0.00s)
    --- PASS: Test_DownloadNovaCli/linux_armv7l_2.3.2 (0.00s)
=== RUN   Test_DownloadKubetailCli
=== RUN   Test_DownloadKubetailCli/darwin_x86_64_1.6.13
=== RUN   Test_DownloadKubetailCli/linux_x86_64_1.6.13
=== RUN   Test_DownloadKubetailCli/linux_aarch64_1.6.13
=== RUN   Test_DownloadKubetailCli/linux_armv7l_1.6.13
--- PASS: Test_DownloadKubetailCli (0.00s)
    --- PASS: Test_DownloadKubetailCli/darwin_x86_64_1.6.13 (0.00s)
    --- PASS: Test_DownloadKubetailCli/linux_x86_64_1.6.13 (0.00s)
    --- PASS: Test_DownloadKubetailCli/linux_aarch64_1.6.13 (0.00s)
    --- PASS: Test_DownloadKubetailCli/linux_armv7l_1.6.13 (0.00s)
=== RUN   Test_DownloadKgctl
=== RUN   Test_DownloadKgctl/darwin_x86_64_0.3.0
=== RUN   Test_DownloadKgctl/darwin_aarch64_0.3.0
=== RUN   Test_DownloadKgctl/linux_x86_64_0.3.0
=== RUN   Test_DownloadKgctl/linux_armv7l_0.3.0
=== RUN   Test_DownloadKgctl/linux_aarch64_0.3.0
=== RUN   Test_DownloadKgctl/mingw64_nt-10.0-18362_x86_64_0.3.0
--- PASS: Test_DownloadKgctl (0.00s)
    --- PASS: Test_DownloadKgctl/darwin_x86_64_0.3.0 (0.00s)
    --- PASS: Test_DownloadKgctl/darwin_aarch64_0.3.0 (0.00s)
    --- PASS: Test_DownloadKgctl/linux_x86_64_0.3.0 (0.00s)
    --- PASS: Test_DownloadKgctl/linux_armv7l_0.3.0 (0.00s)
    --- PASS: Test_DownloadKgctl/linux_aarch64_0.3.0 (0.00s)
    --- PASS: Test_DownloadKgctl/mingw64_nt-10.0-18362_x86_64_0.3.0 (0.00s)
=== RUN   Test_DownloadEquinixMetalCli
=== RUN   Test_DownloadEquinixMetalCli/darwin_x86_64_0.6.0-alpha2
=== RUN   Test_DownloadEquinixMetalCli/linux_x86_64_0.6.0-alpha2
=== RUN   Test_DownloadEquinixMetalCli/linux_aarch64_0.6.0-alpha2
=== RUN   Test_DownloadEquinixMetalCli/linux_armv7l_0.6.0-alpha2
=== RUN   Test_DownloadEquinixMetalCli/linux_armv6l_0.6.0-alpha2
=== RUN   Test_DownloadEquinixMetalCli/ming_x86_64_0.6.0-alpha2
--- PASS: Test_DownloadEquinixMetalCli (0.00s)
    --- PASS: Test_DownloadEquinixMetalCli/darwin_x86_64_0.6.0-alpha2 (0.00s)
    --- PASS: Test_DownloadEquinixMetalCli/linux_x86_64_0.6.0-alpha2 (0.00s)
    --- PASS: Test_DownloadEquinixMetalCli/linux_aarch64_0.6.0-alpha2 (0.00s)
    --- PASS: Test_DownloadEquinixMetalCli/linux_armv7l_0.6.0-alpha2 (0.00s)
    --- PASS: Test_DownloadEquinixMetalCli/linux_armv6l_0.6.0-alpha2 (0.00s)
    --- PASS: Test_DownloadEquinixMetalCli/ming_x86_64_0.6.0-alpha2 (0.00s)
=== RUN   Test_DownloadPorterCli
=== RUN   Test_DownloadPorterCli/darwin_x86_64_v0.38.4
=== RUN   Test_DownloadPorterCli/linux_x86_64_v0.38.4
=== RUN   Test_DownloadPorterCli/ming_x86_64_v0.38.4
--- PASS: Test_DownloadPorterCli (0.00s)
    --- PASS: Test_DownloadPorterCli/darwin_x86_64_v0.38.4 (0.00s)
    --- PASS: Test_DownloadPorterCli/linux_x86_64_v0.38.4 (0.00s)
    --- PASS: Test_DownloadPorterCli/ming_x86_64_v0.38.4 (0.00s)
=== RUN   Test_DownloadJq
=== RUN   Test_DownloadJq/darwin_x86_64
=== RUN   Test_DownloadJq/darwin_arm64
=== RUN   Test_DownloadJq/linux_x86_64
=== RUN   Test_DownloadJq/linux_i686
=== RUN   Test_DownloadJq/ming_x86_64
=== RUN   Test_DownloadJq/ming_i686
--- PASS: Test_DownloadJq (0.00s)
    --- PASS: Test_DownloadJq/darwin_x86_64 (0.00s)
    --- PASS: Test_DownloadJq/darwin_arm64 (0.00s)
    --- PASS: Test_DownloadJq/linux_x86_64 (0.00s)
    --- PASS: Test_DownloadJq/linux_i686 (0.00s)
    --- PASS: Test_DownloadJq/ming_x86_64 (0.00s)
    --- PASS: Test_DownloadJq/ming_i686 (0.00s)
=== RUN   Test_DownloadCosignCli
=== RUN   Test_DownloadCosignCli/darwin_x86_64_v1.0.0
=== RUN   Test_DownloadCosignCli/darwin_aarch64_v1.0.0
=== RUN   Test_DownloadCosignCli/linux_x86_64_v1.0.0
=== RUN   Test_DownloadCosignCli/ming_x86_64_v1.0.0
--- PASS: Test_DownloadCosignCli (0.00s)
    --- PASS: Test_DownloadCosignCli/darwin_x86_64_v1.0.0 (0.00s)
    --- PASS: Test_DownloadCosignCli/darwin_aarch64_v1.0.0 (0.00s)
    --- PASS: Test_DownloadCosignCli/linux_x86_64_v1.0.0 (0.00s)
    --- PASS: Test_DownloadCosignCli/ming_x86_64_v1.0.0 (0.00s)
=== RUN   Test_DownloadKanister
=== RUN   Test_DownloadKanister/darwin_x86_64_0.63.0
=== RUN   Test_DownloadKanister/linux_x86_64_0.63.0
--- PASS: Test_DownloadKanister (0.00s)
    --- PASS: Test_DownloadKanister/darwin_x86_64_0.63.0 (0.00s)
    --- PASS: Test_DownloadKanister/linux_x86_64_0.63.0 (0.00s)
=== RUN   Test_DownloadKubestr
=== RUN   Test_DownloadKubestr/darwin_x86_64_v0.4.31
=== RUN   Test_DownloadKubestr/darwin_arm64_v0.4.31
=== RUN   Test_DownloadKubestr/linux_x86_64_v0.4.31
=== RUN   Test_DownloadKubestr/linux_aarch64_v0.4.31
=== RUN   Test_DownloadKubestr/ming_x86_64_v0.4.31
--- PASS: Test_DownloadKubestr (0.00s)
    --- PASS: Test_DownloadKubestr/darwin_x86_64_v0.4.31 (0.00s)
    --- PASS: Test_DownloadKubestr/darwin_arm64_v0.4.31 (0.00s)
    --- PASS: Test_DownloadKubestr/linux_x86_64_v0.4.31 (0.00s)
    --- PASS: Test_DownloadKubestr/linux_aarch64_v0.4.31 (0.00s)
    --- PASS: Test_DownloadKubestr/ming_x86_64_v0.4.31 (0.00s)
=== RUN   Test_DownloadK10multicluster
=== RUN   Test_DownloadK10multicluster/darwin_x86_64_4.0.6
=== RUN   Test_DownloadK10multicluster/linux_x86_64_4.0.6
--- PASS: Test_DownloadK10multicluster (0.00s)
    --- PASS: Test_DownloadK10multicluster/darwin_x86_64_4.0.6 (0.00s)
    --- PASS: Test_DownloadK10multicluster/linux_x86_64_4.0.6 (0.00s)
=== RUN   Test_DownloadK10tools
=== RUN   Test_DownloadK10tools/darwin_x86_64_4.5.9
=== RUN   Test_DownloadK10tools/darwin_arm64_4.5.9
=== RUN   Test_DownloadK10tools/linux_x86_64_4.5.9
=== RUN   Test_DownloadK10tools/linux_aarch64_4.5.9
--- PASS: Test_DownloadK10tools (0.00s)
    --- PASS: Test_DownloadK10tools/darwin_x86_64_4.5.9 (0.00s)
    --- PASS: Test_DownloadK10tools/darwin_arm64_4.5.9 (0.00s)
    --- PASS: Test_DownloadK10tools/linux_x86_64_4.5.9 (0.00s)
    --- PASS: Test_DownloadK10tools/linux_aarch64_4.5.9 (0.00s)
=== RUN   Test_DownloadRekorCli
=== RUN   Test_DownloadRekorCli/darwin_x86_64_v0.3.0
=== RUN   Test_DownloadRekorCli/darwin_aarch64_v0.3.0
=== RUN   Test_DownloadRekorCli/linux_x86_64_v0.3.0
=== RUN   Test_DownloadRekorCli/ming_x86_64_v0.3.0
--- PASS: Test_DownloadRekorCli (0.00s)
    --- PASS: Test_DownloadRekorCli/darwin_x86_64_v0.3.0 (0.00s)
    --- PASS: Test_DownloadRekorCli/darwin_aarch64_v0.3.0 (0.00s)
    --- PASS: Test_DownloadRekorCli/linux_x86_64_v0.3.0 (0.00s)
    --- PASS: Test_DownloadRekorCli/ming_x86_64_v0.3.0 (0.00s)
=== RUN   Test_DownloadTFSecCli
=== RUN   Test_DownloadTFSecCli/darwin_x86_64_v0.57.1
=== RUN   Test_DownloadTFSecCli/darwin_aarch64_v0.57.1
=== RUN   Test_DownloadTFSecCli/linux_x86_64_v0.57.1
=== RUN   Test_DownloadTFSecCli/linux_aarch64_v0.57.1
=== RUN   Test_DownloadTFSecCli/ming_x86_64_v0.57.1
--- PASS: Test_DownloadTFSecCli (0.00s)
    --- PASS: Test_DownloadTFSecCli/darwin_x86_64_v0.57.1 (0.00s)
    --- PASS: Test_DownloadTFSecCli/darwin_aarch64_v0.57.1 (0.00s)
    --- PASS: Test_DownloadTFSecCli/linux_x86_64_v0.57.1 (0.00s)
    --- PASS: Test_DownloadTFSecCli/linux_aarch64_v0.57.1 (0.00s)
    --- PASS: Test_DownloadTFSecCli/ming_x86_64_v0.57.1 (0.00s)
=== RUN   Test_DownloadDive
=== RUN   Test_DownloadDive/darwin_x86_64_0.10.0
=== RUN   Test_DownloadDive/darwin_aarch64_0.10.0
=== RUN   Test_DownloadDive/linux_x86_64_0.10.0
=== RUN   Test_DownloadDive/linux_aarch64_0.10.0
=== RUN   Test_DownloadDive/ming_x86_64_0.10.0
--- PASS: Test_DownloadDive (0.00s)
    --- PASS: Test_DownloadDive/darwin_x86_64_0.10.0 (0.00s)
    --- PASS: Test_DownloadDive/darwin_aarch64_0.10.0 (0.00s)
    --- PASS: Test_DownloadDive/linux_x86_64_0.10.0 (0.00s)
    --- PASS: Test_DownloadDive/linux_aarch64_0.10.0 (0.00s)
    --- PASS: Test_DownloadDive/ming_x86_64_0.10.0 (0.00s)
=== RUN   Test_DownloadGoReleaserCli
=== RUN   Test_DownloadGoReleaserCli/darwin_x86_64_v0.177.0
=== RUN   Test_DownloadGoReleaserCli/darwin_aarch64_v0.177.0
=== RUN   Test_DownloadGoReleaserCli/linux_x86_64_v0.177.0
=== RUN   Test_DownloadGoReleaserCli/linux_aarch64_v0.177.0
=== RUN   Test_DownloadGoReleaserCli/ming_x86_64_v0.177.0
--- PASS: Test_DownloadGoReleaserCli (0.00s)
    --- PASS: Test_DownloadGoReleaserCli/darwin_x86_64_v0.177.0 (0.00s)
    --- PASS: Test_DownloadGoReleaserCli/darwin_aarch64_v0.177.0 (0.00s)
    --- PASS: Test_DownloadGoReleaserCli/linux_x86_64_v0.177.0 (0.00s)
    --- PASS: Test_DownloadGoReleaserCli/linux_aarch64_v0.177.0 (0.00s)
    --- PASS: Test_DownloadGoReleaserCli/ming_x86_64_v0.177.0 (0.00s)
=== RUN   Test_DownloadKubescape
=== RUN   Test_DownloadKubescape/darwin__v1.0.69
=== RUN   Test_DownloadKubescape/linux__v1.0.69
=== RUN   Test_DownloadKubescape/ming__v1.0.69
--- PASS: Test_DownloadKubescape (0.00s)
    --- PASS: Test_DownloadKubescape/darwin__v1.0.69 (0.00s)
    --- PASS: Test_DownloadKubescape/linux__v1.0.69 (0.00s)
    --- PASS: Test_DownloadKubescape/ming__v1.0.69 (0.00s)
=== RUN   Test_DownloadKrew
=== RUN   Test_DownloadKrew/darwin_x86_64_v0.4.2
=== RUN   Test_DownloadKrew/darwin_aarch64_v0.4.2
=== RUN   Test_DownloadKrew/linux_aarch64_v0.4.2
=== RUN   Test_DownloadKrew/linux_x86_64_v0.4.2
=== RUN   Test_DownloadKrew/linux_armv7l_v0.4.2
=== RUN   Test_DownloadKrew/ming_x86_64_v0.4.2
--- PASS: Test_DownloadKrew (0.00s)
    --- PASS: Test_DownloadKrew/darwin_x86_64_v0.4.2 (0.00s)
    --- PASS: Test_DownloadKrew/darwin_aarch64_v0.4.2 (0.00s)
    --- PASS: Test_DownloadKrew/linux_aarch64_v0.4.2 (0.00s)
    --- PASS: Test_DownloadKrew/linux_x86_64_v0.4.2 (0.00s)
    --- PASS: Test_DownloadKrew/linux_armv7l_v0.4.2 (0.00s)
    --- PASS: Test_DownloadKrew/ming_x86_64_v0.4.2 (0.00s)
=== RUN   Test_DownloadKubeBench
--- PASS: Test_DownloadKubeBench (0.00s)
=== RUN   Test_DownloadClusterctl
--- PASS: Test_DownloadClusterctl (0.00s)
=== RUN   Test_DownloadvCluster
--- PASS: Test_DownloadvCluster (0.00s)
=== RUN   Test_DownloadHostcl
--- PASS: Test_DownloadHostcl (0.00s)
=== RUN   Test_DownloadKubecm
=== RUN   Test_DownloadKubecm/darwin_x86_64_v0.16.2
=== RUN   Test_DownloadKubecm/linux_x86_64_v0.16.2
=== RUN   Test_DownloadKubecm/linux_aarch64_v0.16.2
=== RUN   Test_DownloadKubecm/ming_x86_64_v0.16.2
--- PASS: Test_DownloadKubecm (0.00s)
    --- PASS: Test_DownloadKubecm/darwin_x86_64_v0.16.2 (0.00s)
    --- PASS: Test_DownloadKubecm/linux_x86_64_v0.16.2 (0.00s)
    --- PASS: Test_DownloadKubecm/linux_aarch64_v0.16.2 (0.00s)
    --- PASS: Test_DownloadKubecm/ming_x86_64_v0.16.2 (0.00s)
=== RUN   Test_DownloadMkcert
=== RUN   Test_DownloadMkcert/darwin_x86_64_v1.4.2
=== RUN   Test_DownloadMkcert/linux_x86_64_v1.4.2
=== RUN   Test_DownloadMkcert/linux_aarch64_v1.4.2
=== RUN   Test_DownloadMkcert/linux_armv7l_v1.4.2
=== RUN   Test_DownloadMkcert/ming_x86_64_v1.4.2
--- PASS: Test_DownloadMkcert (0.00s)
    --- PASS: Test_DownloadMkcert/darwin_x86_64_v1.4.2 (0.00s)
    --- PASS: Test_DownloadMkcert/linux_x86_64_v1.4.2 (0.00s)
    --- PASS: Test_DownloadMkcert/linux_aarch64_v1.4.2 (0.00s)
    --- PASS: Test_DownloadMkcert/linux_armv7l_v1.4.2 (0.00s)
    --- PASS: Test_DownloadMkcert/ming_x86_64_v1.4.2 (0.00s)
=== RUN   Test_DownloadSOPS
--- PASS: Test_DownloadSOPS (0.00s)
=== RUN   Test_DownloadDagger
--- PASS: Test_DownloadDagger (0.00s)
=== RUN   Test_DownloadOhMyPosh
=== RUN   Test_DownloadOhMyPosh/mingw64_nt-10.0-18362_x86_64_v7.55.2
=== RUN   Test_DownloadOhMyPosh/mingw64_nt-10.0-18362_aarch64_v7.55.2
=== RUN   Test_DownloadOhMyPosh/linux_x86_64_v7.55.2
=== RUN   Test_DownloadOhMyPosh/linux_aarch64_v7.55.2
=== RUN   Test_DownloadOhMyPosh/darwin_x86_64_v7.55.2
=== RUN   Test_DownloadOhMyPosh/darwin_aarch64_v7.55.2
--- PASS: Test_DownloadOhMyPosh (0.00s)
    --- PASS: Test_DownloadOhMyPosh/mingw64_nt-10.0-18362_x86_64_v7.55.2 (0.00s)
    --- PASS: Test_DownloadOhMyPosh/mingw64_nt-10.0-18362_aarch64_v7.55.2 (0.00s)
    --- PASS: Test_DownloadOhMyPosh/linux_x86_64_v7.55.2 (0.00s)
    --- PASS: Test_DownloadOhMyPosh/linux_aarch64_v7.55.2 (0.00s)
    --- PASS: Test_DownloadOhMyPosh/darwin_x86_64_v7.55.2 (0.00s)
    --- PASS: Test_DownloadOhMyPosh/darwin_aarch64_v7.55.2 (0.00s)
=== RUN   Test_DownloadKumactl
=== RUN   Test_DownloadKumactl/darwin_x86_64_1.4.1
=== RUN   Test_DownloadKumactl/darwin_x86_64_1.4.1#01
=== RUN   Test_DownloadKumactl/linux_x86_64_1.4.1
=== RUN   Test_DownloadKumactl/linux_x86_64_1.4.1#01
--- PASS: Test_DownloadKumactl (0.00s)
    --- PASS: Test_DownloadKumactl/darwin_x86_64_1.4.1 (0.00s)
    --- PASS: Test_DownloadKumactl/darwin_x86_64_1.4.1#01 (0.00s)
    --- PASS: Test_DownloadKumactl/linux_x86_64_1.4.1 (0.00s)
    --- PASS: Test_DownloadKumactl/linux_x86_64_1.4.1#01 (0.00s)
=== RUN   Test_DownloadHey
=== RUN   Test_DownloadHey/darwin_x86_64_v0.0.1-rc1
=== RUN   Test_DownloadHey/darwin_arm64_v0.0.1-rc1
=== RUN   Test_DownloadHey/linux_x86_64_v0.0.1-rc1
=== RUN   Test_DownloadHey/linux_aarch64_v0.0.1-rc1
=== RUN   Test_DownloadHey/linux_armv7l_v0.0.1-rc1
=== RUN   Test_DownloadHey/ming_x86_64_v0.0.1-rc1
--- PASS: Test_DownloadHey (0.00s)
    --- PASS: Test_DownloadHey/darwin_x86_64_v0.0.1-rc1 (0.00s)
    --- PASS: Test_DownloadHey/darwin_arm64_v0.0.1-rc1 (0.00s)
    --- PASS: Test_DownloadHey/linux_x86_64_v0.0.1-rc1 (0.00s)
    --- PASS: Test_DownloadHey/linux_aarch64_v0.0.1-rc1 (0.00s)
    --- PASS: Test_DownloadHey/linux_armv7l_v0.0.1-rc1 (0.00s)
    --- PASS: Test_DownloadHey/ming_x86_64_v0.0.1-rc1 (0.00s)
=== RUN   Test_DownloadCaddy
=== RUN   Test_DownloadCaddy/darwin_x86_64_v2.5.0
=== RUN   Test_DownloadCaddy/darwin_arm64_v2.5.0
=== RUN   Test_DownloadCaddy/linux_x86_64_v2.5.0
=== RUN   Test_DownloadCaddy/linux_aarch64_v2.5.0
=== RUN   Test_DownloadCaddy/linux_armv7l_v2.5.0
=== RUN   Test_DownloadCaddy/ming_x86_64_v2.5.0
=== RUN   Test_DownloadCaddy/ming_aarch64_v2.5.0
--- PASS: Test_DownloadCaddy (0.00s)
    --- PASS: Test_DownloadCaddy/darwin_x86_64_v2.5.0 (0.00s)
    --- PASS: Test_DownloadCaddy/darwin_arm64_v2.5.0 (0.00s)
    --- PASS: Test_DownloadCaddy/linux_x86_64_v2.5.0 (0.00s)
    --- PASS: Test_DownloadCaddy/linux_aarch64_v2.5.0 (0.00s)
    --- PASS: Test_DownloadCaddy/linux_armv7l_v2.5.0 (0.00s)
    --- PASS: Test_DownloadCaddy/ming_x86_64_v2.5.0 (0.00s)
    --- PASS: Test_DownloadCaddy/ming_aarch64_v2.5.0 (0.00s)
=== RUN   Test_DownloadNatsServer
=== RUN   Test_DownloadNatsServer/darwin_x86_64_v2.7.4
=== RUN   Test_DownloadNatsServer/darwin_arm64_v2.7.4
=== RUN   Test_DownloadNatsServer/linux_x86_64_v2.7.4
=== RUN   Test_DownloadNatsServer/linux_aarch64_v2.7.4
=== RUN   Test_DownloadNatsServer/linux_armv7l_v2.7.4
=== RUN   Test_DownloadNatsServer/ming_x86_64_v2.7.4
--- PASS: Test_DownloadNatsServer (0.00s)
    --- PASS: Test_DownloadNatsServer/darwin_x86_64_v2.7.4 (0.00s)
    --- PASS: Test_DownloadNatsServer/darwin_arm64_v2.7.4 (0.00s)
    --- PASS: Test_DownloadNatsServer/linux_x86_64_v2.7.4 (0.00s)
    --- PASS: Test_DownloadNatsServer/linux_aarch64_v2.7.4 (0.00s)
    --- PASS: Test_DownloadNatsServer/linux_armv7l_v2.7.4 (0.00s)
    --- PASS: Test_DownloadNatsServer/ming_x86_64_v2.7.4 (0.00s)
=== RUN   Test_DownloadCilium
=== RUN   Test_DownloadCilium/darwin_x86_64_v0.11.9
=== RUN   Test_DownloadCilium/darwin_arm64_v0.11.9
=== RUN   Test_DownloadCilium/linux_x86_64_v0.11.9
=== RUN   Test_DownloadCilium/linux_aarch64_v0.11.9
=== RUN   Test_DownloadCilium/ming_x86_64_v0.11.9
--- PASS: Test_DownloadCilium (0.00s)
    --- PASS: Test_DownloadCilium/darwin_x86_64_v0.11.9 (0.00s)
    --- PASS: Test_DownloadCilium/darwin_arm64_v0.11.9 (0.00s)
    --- PASS: Test_DownloadCilium/linux_x86_64_v0.11.9 (0.00s)
    --- PASS: Test_DownloadCilium/linux_aarch64_v0.11.9 (0.00s)
    --- PASS: Test_DownloadCilium/ming_x86_64_v0.11.9 (0.00s)
=== RUN   Test_DownloadTerragrunt
=== RUN   Test_DownloadTerragrunt/darwin_x86_64_v0.37.1
=== RUN   Test_DownloadTerragrunt/darwin_arm64_v0.37.1
=== RUN   Test_DownloadTerragrunt/linux_x86_64_v0.37.1
=== RUN   Test_DownloadTerragrunt/linux_aarch64_v0.37.1
=== RUN   Test_DownloadTerragrunt/ming_x86_64_v0.37.1
--- PASS: Test_DownloadTerragrunt (0.00s)
    --- PASS: Test_DownloadTerragrunt/darwin_x86_64_v0.37.1 (0.00s)
    --- PASS: Test_DownloadTerragrunt/darwin_arm64_v0.37.1 (0.00s)
    --- PASS: Test_DownloadTerragrunt/linux_x86_64_v0.37.1 (0.00s)
    --- PASS: Test_DownloadTerragrunt/linux_aarch64_v0.37.1 (0.00s)
    --- PASS: Test_DownloadTerragrunt/ming_x86_64_v0.37.1 (0.00s)
=== RUN   Test_DownloadFzf
=== RUN   Test_DownloadFzf/darwin_x86_64_0.30.0
=== RUN   Test_DownloadFzf/darwin_arm64_0.30.0
=== RUN   Test_DownloadFzf/linux_x86_64_0.30.0
=== RUN   Test_DownloadFzf/linux_aarch64_0.30.0
=== RUN   Test_DownloadFzf/linux_armv7l_0.30.0
=== RUN   Test_DownloadFzf/ming_x86_64_0.30.0
=== RUN   Test_DownloadFzf/ming_aarch64_0.30.0
--- PASS: Test_DownloadFzf (0.00s)
    --- PASS: Test_DownloadFzf/darwin_x86_64_0.30.0 (0.00s)
    --- PASS: Test_DownloadFzf/darwin_arm64_0.30.0 (0.00s)
    --- PASS: Test_DownloadFzf/linux_x86_64_0.30.0 (0.00s)
    --- PASS: Test_DownloadFzf/linux_aarch64_0.30.0 (0.00s)
    --- PASS: Test_DownloadFzf/linux_armv7l_0.30.0 (0.00s)
    --- PASS: Test_DownloadFzf/ming_x86_64_0.30.0 (0.00s)
    --- PASS: Test_DownloadFzf/ming_aarch64_0.30.0 (0.00s)
=== RUN   Test_DownloadHubble
=== RUN   Test_DownloadHubble/darwin_x86_64_v0.10.0
=== RUN   Test_DownloadHubble/darwin_arm64_v0.10.0
=== RUN   Test_DownloadHubble/linux_x86_64_v0.10.0
=== RUN   Test_DownloadHubble/linux_aarch64_v0.10.0
=== RUN   Test_DownloadHubble/ming_x86_64_v0.10.0
--- PASS: Test_DownloadHubble (0.00s)
    --- PASS: Test_DownloadHubble/darwin_x86_64_v0.10.0 (0.00s)
    --- PASS: Test_DownloadHubble/darwin_arm64_v0.10.0 (0.00s)
    --- PASS: Test_DownloadHubble/linux_x86_64_v0.10.0 (0.00s)
    --- PASS: Test_DownloadHubble/linux_aarch64_v0.10.0 (0.00s)
    --- PASS: Test_DownloadHubble/ming_x86_64_v0.10.0 (0.00s)
=== RUN   Test_DownloadGomplate
=== RUN   Test_DownloadGomplate/darwin_x86_64_v3.11.1
=== RUN   Test_DownloadGomplate/darwin_arm64_v3.11.1
=== RUN   Test_DownloadGomplate/linux_x86_64_v3.11.1
=== RUN   Test_DownloadGomplate/linux_aarch64_v3.11.1
=== RUN   Test_DownloadGomplate/linux_armv7l_v3.11.1
=== RUN   Test_DownloadGomplate/ming_x86_64_v3.11.1
--- PASS: Test_DownloadGomplate (0.00s)
    --- PASS: Test_DownloadGomplate/darwin_x86_64_v3.11.1 (0.00s)
    --- PASS: Test_DownloadGomplate/darwin_arm64_v3.11.1 (0.00s)
    --- PASS: Test_DownloadGomplate/linux_x86_64_v3.11.1 (0.00s)
    --- PASS: Test_DownloadGomplate/linux_aarch64_v3.11.1 (0.00s)
    --- PASS: Test_DownloadGomplate/linux_armv7l_v3.11.1 (0.00s)
    --- PASS: Test_DownloadGomplate/ming_x86_64_v3.11.1 (0.00s)
=== RUN   Test_DownloadTalosctl
=== RUN   Test_DownloadTalosctl/darwin_x86_64_v1.1.2
=== RUN   Test_DownloadTalosctl/darwin_arm64_v1.1.2
=== RUN   Test_DownloadTalosctl/linux_x86_64_v1.1.2
=== RUN   Test_DownloadTalosctl/linux_aarch64_v1.1.2
=== RUN   Test_DownloadTalosctl/linux_armv7l_v1.1.2
=== RUN   Test_DownloadTalosctl/ming_x86_64_v1.1.2
--- PASS: Test_DownloadTalosctl (0.00s)
    --- PASS: Test_DownloadTalosctl/darwin_x86_64_v1.1.2 (0.00s)
    --- PASS: Test_DownloadTalosctl/darwin_arm64_v1.1.2 (0.00s)
    --- PASS: Test_DownloadTalosctl/linux_x86_64_v1.1.2 (0.00s)
    --- PASS: Test_DownloadTalosctl/linux_aarch64_v1.1.2 (0.00s)
    --- PASS: Test_DownloadTalosctl/linux_armv7l_v1.1.2 (0.00s)
    --- PASS: Test_DownloadTalosctl/ming_x86_64_v1.1.2 (0.00s)
=== RUN   Test_CheckTools
=== RUN   Test_CheckTools/Download_of_faas-cli
=== PAUSE Test_CheckTools/Download_of_faas-cli
=== RUN   Test_CheckTools/Download_of_helm
=== PAUSE Test_CheckTools/Download_of_helm
=== RUN   Test_CheckTools/Download_of_helmfile
=== PAUSE Test_CheckTools/Download_of_helmfile
=== RUN   Test_CheckTools/Download_of_jq
=== PAUSE Test_CheckTools/Download_of_jq
=== RUN   Test_CheckTools/Download_of_kubectl
=== PAUSE Test_CheckTools/Download_of_kubectl
=== RUN   Test_CheckTools/Download_of_kubectx
=== PAUSE Test_CheckTools/Download_of_kubectx
=== RUN   Test_CheckTools/Download_of_kubens
=== PAUSE Test_CheckTools/Download_of_kubens
=== RUN   Test_CheckTools/Download_of_kind
=== PAUSE Test_CheckTools/Download_of_kind
=== RUN   Test_CheckTools/Download_of_k3s
=== PAUSE Test_CheckTools/Download_of_k3s
=== RUN   Test_CheckTools/Download_of_autok3s
=== PAUSE Test_CheckTools/Download_of_autok3s
=== RUN   Test_CheckTools/Download_of_devspace
=== PAUSE Test_CheckTools/Download_of_devspace
=== RUN   Test_CheckTools/Download_of_tilt
=== PAUSE Test_CheckTools/Download_of_tilt
=== RUN   Test_CheckTools/Download_of_k3d
=== PAUSE Test_CheckTools/Download_of_k3d
=== RUN   Test_CheckTools/Download_of_k3sup
=== PAUSE Test_CheckTools/Download_of_k3sup
=== RUN   Test_CheckTools/Download_of_arkade
=== PAUSE Test_CheckTools/Download_of_arkade
=== RUN   Test_CheckTools/Download_of_kubeseal
=== PAUSE Test_CheckTools/Download_of_kubeseal
=== RUN   Test_CheckTools/Download_of_inletsctl
=== PAUSE Test_CheckTools/Download_of_inletsctl
=== RUN   Test_CheckTools/Download_of_osm
=== PAUSE Test_CheckTools/Download_of_osm
=== RUN   Test_CheckTools/Download_of_linkerd2
=== PAUSE Test_CheckTools/Download_of_linkerd2
=== RUN   Test_CheckTools/Download_of_kubebuilder
=== PAUSE Test_CheckTools/Download_of_kubebuilder
=== RUN   Test_CheckTools/Download_of_kustomize
=== PAUSE Test_CheckTools/Download_of_kustomize
=== RUN   Test_CheckTools/Download_of_doctl
=== PAUSE Test_CheckTools/Download_of_doctl
=== RUN   Test_CheckTools/Download_of_eksctl
=== PAUSE Test_CheckTools/Download_of_eksctl
=== RUN   Test_CheckTools/Download_of_k9s
=== PAUSE Test_CheckTools/Download_of_k9s
=== RUN   Test_CheckTools/Download_of_popeye
=== PAUSE Test_CheckTools/Download_of_popeye
=== RUN   Test_CheckTools/Download_of_civo
=== PAUSE Test_CheckTools/Download_of_civo
=== RUN   Test_CheckTools/Download_of_terraform
=== PAUSE Test_CheckTools/Download_of_terraform
=== RUN   Test_CheckTools/Download_of_terragrunt
=== PAUSE Test_CheckTools/Download_of_terragrunt
=== RUN   Test_CheckTools/Download_of_vagrant
=== PAUSE Test_CheckTools/Download_of_vagrant
=== RUN   Test_CheckTools/Download_of_packer
=== PAUSE Test_CheckTools/Download_of_packer
=== RUN   Test_CheckTools/Download_of_waypoint
=== PAUSE Test_CheckTools/Download_of_waypoint
=== RUN   Test_CheckTools/Download_of_gh
=== PAUSE Test_CheckTools/Download_of_gh
=== RUN   Test_CheckTools/Download_of_pack
=== PAUSE Test_CheckTools/Download_of_pack
=== RUN   Test_CheckTools/Download_of_buildx
=== PAUSE Test_CheckTools/Download_of_buildx
=== RUN   Test_CheckTools/Download_of_hey
=== PAUSE Test_CheckTools/Download_of_hey
=== RUN   Test_CheckTools/Download_of_kops
=== PAUSE Test_CheckTools/Download_of_kops
=== RUN   Test_CheckTools/Download_of_krew
=== PAUSE Test_CheckTools/Download_of_krew
=== RUN   Test_CheckTools/Download_of_minikube
=== PAUSE Test_CheckTools/Download_of_minikube
=== RUN   Test_CheckTools/Download_of_stern
=== PAUSE Test_CheckTools/Download_of_stern
=== RUN   Test_CheckTools/Download_of_kail
=== PAUSE Test_CheckTools/Download_of_kail
=== RUN   Test_CheckTools/Download_of_yq
=== PAUSE Test_CheckTools/Download_of_yq
=== RUN   Test_CheckTools/Download_of_kube-bench
=== PAUSE Test_CheckTools/Download_of_kube-bench
=== RUN   Test_CheckTools/Download_of_hugo
=== PAUSE Test_CheckTools/Download_of_hugo
=== RUN   Test_CheckTools/Download_of_docker-compose
=== PAUSE Test_CheckTools/Download_of_docker-compose
=== RUN   Test_CheckTools/Download_of_opa
=== PAUSE Test_CheckTools/Download_of_opa
=== RUN   Test_CheckTools/Download_of_mc
=== PAUSE Test_CheckTools/Download_of_mc
=== RUN   Test_CheckTools/Download_of_nats
=== PAUSE Test_CheckTools/Download_of_nats
=== RUN   Test_CheckTools/Download_of_argocd
=== PAUSE Test_CheckTools/Download_of_argocd
=== RUN   Test_CheckTools/Download_of_nerdctl
=== PAUSE Test_CheckTools/Download_of_nerdctl
=== RUN   Test_CheckTools/Download_of_istioctl
=== PAUSE Test_CheckTools/Download_of_istioctl
=== RUN   Test_CheckTools/Download_of_tkn
=== PAUSE Test_CheckTools/Download_of_tkn
=== RUN   Test_CheckTools/Download_of_inlets-pro
=== PAUSE Test_CheckTools/Download_of_inlets-pro
=== RUN   Test_CheckTools/Download_of_kim
=== PAUSE Test_CheckTools/Download_of_kim
=== RUN   Test_CheckTools/Download_of_trivy
=== PAUSE Test_CheckTools/Download_of_trivy
=== RUN   Test_CheckTools/Download_of_flux
=== PAUSE Test_CheckTools/Download_of_flux
=== RUN   Test_CheckTools/Download_of_polaris
=== PAUSE Test_CheckTools/Download_of_polaris
=== RUN   Test_CheckTools/Download_of_influx
=== PAUSE Test_CheckTools/Download_of_influx
=== RUN   Test_CheckTools/Download_of_argocd-autopilot
=== PAUSE Test_CheckTools/Download_of_argocd-autopilot
=== RUN   Test_CheckTools/Download_of_nova
=== PAUSE Test_CheckTools/Download_of_nova
=== RUN   Test_CheckTools/Download_of_kubetail
=== PAUSE Test_CheckTools/Download_of_kubetail
=== RUN   Test_CheckTools/Download_of_kgctl
=== PAUSE Test_CheckTools/Download_of_kgctl
=== RUN   Test_CheckTools/Download_of_porter
=== PAUSE Test_CheckTools/Download_of_porter
=== RUN   Test_CheckTools/Download_of_k0s
=== PAUSE Test_CheckTools/Download_of_k0s
=== RUN   Test_CheckTools/Download_of_k0sctl
=== PAUSE Test_CheckTools/Download_of_k0sctl
=== RUN   Test_CheckTools/Download_of_metal
=== PAUSE Test_CheckTools/Download_of_metal
=== RUN   Test_CheckTools/Download_of_kanctl
=== PAUSE Test_CheckTools/Download_of_kanctl
=== RUN   Test_CheckTools/Download_of_kubestr
=== PAUSE Test_CheckTools/Download_of_kubestr
=== RUN   Test_CheckTools/Download_of_k10multicluster
=== PAUSE Test_CheckTools/Download_of_k10multicluster
=== RUN   Test_CheckTools/Download_of_k10tools
=== PAUSE Test_CheckTools/Download_of_k10tools
=== RUN   Test_CheckTools/Download_of_cosign
=== PAUSE Test_CheckTools/Download_of_cosign
=== RUN   Test_CheckTools/Download_of_rekor-cli
=== PAUSE Test_CheckTools/Download_of_rekor-cli
=== RUN   Test_CheckTools/Download_of_tfsec
=== PAUSE Test_CheckTools/Download_of_tfsec
=== RUN   Test_CheckTools/Download_of_dive
=== PAUSE Test_CheckTools/Download_of_dive
=== RUN   Test_CheckTools/Download_of_goreleaser
=== PAUSE Test_CheckTools/Download_of_goreleaser
=== RUN   Test_CheckTools/Download_of_kubescape
=== PAUSE Test_CheckTools/Download_of_kubescape
=== RUN   Test_CheckTools/Download_of_clusterctl
=== PAUSE Test_CheckTools/Download_of_clusterctl
=== RUN   Test_CheckTools/Download_of_vcluster
=== PAUSE Test_CheckTools/Download_of_vcluster
=== RUN   Test_CheckTools/Download_of_hostctl
=== PAUSE Test_CheckTools/Download_of_hostctl
=== RUN   Test_CheckTools/Download_of_kubecm
=== PAUSE Test_CheckTools/Download_of_kubecm
=== RUN   Test_CheckTools/Download_of_mkcert
=== PAUSE Test_CheckTools/Download_of_mkcert
=== RUN   Test_CheckTools/Download_of_sops
=== PAUSE Test_CheckTools/Download_of_sops
=== RUN   Test_CheckTools/Download_of_dagger
=== PAUSE Test_CheckTools/Download_of_dagger
=== RUN   Test_CheckTools/Download_of_oh-my-posh
=== PAUSE Test_CheckTools/Download_of_oh-my-posh
=== RUN   Test_CheckTools/Download_of_caddy
=== PAUSE Test_CheckTools/Download_of_caddy
=== RUN   Test_CheckTools/Download_of_nats-server
=== PAUSE Test_CheckTools/Download_of_nats-server
=== RUN   Test_CheckTools/Download_of_cilium
=== PAUSE Test_CheckTools/Download_of_cilium
=== RUN   Test_CheckTools/Download_of_fzf
=== PAUSE Test_CheckTools/Download_of_fzf
=== RUN   Test_CheckTools/Download_of_hubble
=== PAUSE Test_CheckTools/Download_of_hubble
=== RUN   Test_CheckTools/Download_of_gomplate
=== PAUSE Test_CheckTools/Download_of_gomplate
=== RUN   Test_CheckTools/Download_of_talosctl
=== PAUSE Test_CheckTools/Download_of_talosctl
=== CONT  Test_CheckTools/Download_of_fzf
=== CONT  Test_CheckTools/Download_of_cilium
=== CONT  Test_CheckTools/Download_of_vcluster
=== CONT  Test_CheckTools/Download_of_sops
=== CONT  Test_CheckTools/Download_of_faas-cli
=== CONT  Test_CheckTools/Download_of_mkcert
=== CONT  Test_CheckTools/Download_of_kubecm
=== CONT  Test_CheckTools/Download_of_hostctl
=== CONT  Test_CheckTools/Download_of_gomplate
=== CONT  Test_CheckTools/Download_of_talosctl
=== CONT  Test_CheckTools/Download_of_caddy
=== CONT  Test_CheckTools/Download_of_nats-server
=== CONT  Test_CheckTools/Download_of_stern
=== CONT  Test_CheckTools/Download_of_clusterctl
=== CONT  Test_CheckTools/Download_of_kubescape
=== CONT  Test_CheckTools/Download_of_goreleaser
=== CONT  Test_CheckTools/Download_of_dive
=== CONT  Test_CheckTools/Download_of_tfsec
=== CONT  Test_CheckTools/Download_of_rekor-cli
=== CONT  Test_CheckTools/Download_of_cosign
=== CONT  Test_CheckTools/Download_of_k10tools
=== CONT  Test_CheckTools/Download_of_k10multicluster
=== CONT  Test_CheckTools/Download_of_kubestr
=== CONT  Test_CheckTools/Download_of_kanctl
=== CONT  Test_CheckTools/Download_of_metal
=== CONT  Test_CheckTools/Download_of_k0sctl
=== CONT  Test_CheckTools/Download_of_k0s
=== CONT  Test_CheckTools/Download_of_porter
=== CONT  Test_CheckTools/Download_of_kgctl
=== CONT  Test_CheckTools/Download_of_kubetail
=== CONT  Test_CheckTools/Download_of_nova
=== CONT  Test_CheckTools/Download_of_argocd-autopilot
=== CONT  Test_CheckTools/Download_of_influx
=== CONT  Test_CheckTools/Download_of_polaris
=== CONT  Test_CheckTools/Download_of_flux
=== CONT  Test_CheckTools/Download_of_trivy
=== CONT  Test_CheckTools/Download_of_kim
=== CONT  Test_CheckTools/Download_of_inlets-pro
=== CONT  Test_CheckTools/Download_of_tkn
=== CONT  Test_CheckTools/Download_of_istioctl
=== CONT  Test_CheckTools/Download_of_nerdctl
=== CONT  Test_CheckTools/Download_of_argocd
=== CONT  Test_CheckTools/Download_of_nats
=== CONT  Test_CheckTools/Download_of_mc
=== CONT  Test_CheckTools/Download_of_opa
=== CONT  Test_CheckTools/Download_of_docker-compose
=== CONT  Test_CheckTools/Download_of_hugo
=== CONT  Test_CheckTools/Download_of_kube-bench
=== CONT  Test_CheckTools/Download_of_yq
=== CONT  Test_CheckTools/Download_of_kail
=== CONT  Test_CheckTools/Download_of_kubebuilder
=== CONT  Test_CheckTools/Download_of_minikube
=== CONT  Test_CheckTools/Download_of_krew
=== CONT  Test_CheckTools/Download_of_kops
=== CONT  Test_CheckTools/Download_of_hey
=== CONT  Test_CheckTools/Download_of_buildx
=== CONT  Test_CheckTools/Download_of_pack
=== CONT  Test_CheckTools/Download_of_gh
=== CONT  Test_CheckTools/Download_of_waypoint
=== CONT  Test_CheckTools/Download_of_packer
=== CONT  Test_CheckTools/Download_of_vagrant
=== CONT  Test_CheckTools/Download_of_terragrunt
=== CONT  Test_CheckTools/Download_of_terraform
=== CONT  Test_CheckTools/Download_of_civo
=== CONT  Test_CheckTools/Download_of_popeye
=== CONT  Test_CheckTools/Download_of_k9s
=== CONT  Test_CheckTools/Download_of_eksctl
=== CONT  Test_CheckTools/Download_of_doctl
=== CONT  Test_CheckTools/Download_of_kustomize
=== CONT  Test_CheckTools/Download_of_hubble
=== CONT  Test_CheckTools/Download_of_devspace
=== CONT  Test_CheckTools/Download_of_linkerd2
=== CONT  Test_CheckTools/Download_of_osm
=== CONT  Test_CheckTools/Download_of_kubectx
=== CONT  Test_CheckTools/Download_of_autok3s
=== CONT  Test_CheckTools/Download_of_k3s
=== CONT  Test_CheckTools/Download_of_kind
=== CONT  Test_CheckTools/Download_of_kubens
=== CONT  Test_CheckTools/Download_of_dagger
=== CONT  Test_CheckTools/Download_of_inletsctl
=== CONT  Test_CheckTools/Download_of_jq
=== CONT  Test_CheckTools/Download_of_kubeseal
=== CONT  Test_CheckTools/Download_of_kubectl
=== CONT  Test_CheckTools/Download_of_arkade
=== CONT  Test_CheckTools/Download_of_k3sup
=== CONT  Test_CheckTools/Download_of_k3d
=== CONT  Test_CheckTools/Download_of_oh-my-posh
=== CONT  Test_CheckTools/Download_of_helm
=== CONT  Test_CheckTools/Download_of_helmfile
=== CONT  Test_CheckTools/Download_of_tilt
--- PASS: Test_CheckTools (0.00s)
    --- PASS: Test_CheckTools/Download_of_fzf (0.70s)
    --- PASS: Test_CheckTools/Download_of_faas-cli (0.75s)
    --- PASS: Test_CheckTools/Download_of_kubecm (0.75s)
    --- PASS: Test_CheckTools/Download_of_cilium (0.77s)
    --- PASS: Test_CheckTools/Download_of_hostctl (0.79s)
    --- PASS: Test_CheckTools/Download_of_sops (0.80s)
    --- PASS: Test_CheckTools/Download_of_vcluster (0.81s)
    --- PASS: Test_CheckTools/Download_of_mkcert (0.93s)
    --- PASS: Test_CheckTools/Download_of_stern (0.64s)
    --- PASS: Test_CheckTools/Download_of_gomplate (0.74s)
    --- PASS: Test_CheckTools/Download_of_talosctl (0.80s)
    --- PASS: Test_CheckTools/Download_of_caddy (0.82s)
    --- PASS: Test_CheckTools/Download_of_kubescape (0.78s)
    --- PASS: Test_CheckTools/Download_of_nats-server (0.81s)
    --- PASS: Test_CheckTools/Download_of_clusterctl (1.05s)
    --- PASS: Test_CheckTools/Download_of_dive (0.46s)
    --- PASS: Test_CheckTools/Download_of_tfsec (0.48s)
    --- PASS: Test_CheckTools/Download_of_goreleaser (1.06s)
    --- PASS: Test_CheckTools/Download_of_cosign (0.73s)
    --- PASS: Test_CheckTools/Download_of_k10tools (0.77s)
    --- PASS: Test_CheckTools/Download_of_k10multicluster (0.78s)
    --- PASS: Test_CheckTools/Download_of_metal (0.45s)
    --- PASS: Test_CheckTools/Download_of_rekor-cli (0.83s)
    --- PASS: Test_CheckTools/Download_of_kubetail (0.24s)
    --- PASS: Test_CheckTools/Download_of_kubestr (0.77s)
    --- PASS: Test_CheckTools/Download_of_influx (0.11s)
    --- PASS: Test_CheckTools/Download_of_k0sctl (0.74s)
    --- PASS: Test_CheckTools/Download_of_porter (0.57s)
    --- PASS: Test_CheckTools/Download_of_kanctl (1.06s)
    --- PASS: Test_CheckTools/Download_of_k0s (0.78s)
    --- PASS: Test_CheckTools/Download_of_kgctl (0.76s)
    --- PASS: Test_CheckTools/Download_of_nova (0.85s)
    --- PASS: Test_CheckTools/Download_of_argocd-autopilot (0.71s)
    --- PASS: Test_CheckTools/Download_of_kim (0.47s)
    --- PASS: Test_CheckTools/Download_of_trivy (0.68s)
    --- PASS: Test_CheckTools/Download_of_flux (1.02s)
    --- PASS: Test_CheckTools/Download_of_polaris (1.08s)
    --- PASS: Test_CheckTools/Download_of_argocd (0.66s)
    --- PASS: Test_CheckTools/Download_of_tkn (0.97s)
    --- PASS: Test_CheckTools/Download_of_nerdctl (0.89s)
    --- PASS: Test_CheckTools/Download_of_istioctl (1.02s)
    --- PASS: Test_CheckTools/Download_of_mc (0.52s)
    --- PASS: Test_CheckTools/Download_of_nats (0.77s)
    --- PASS: Test_CheckTools/Download_of_inlets-pro (1.62s)
    --- PASS: Test_CheckTools/Download_of_opa (0.99s)
    --- PASS: Test_CheckTools/Download_of_yq (0.59s)
    --- PASS: Test_CheckTools/Download_of_kail (0.76s)
    --- PASS: Test_CheckTools/Download_of_kubebuilder (0.71s)
    --- PASS: Test_CheckTools/Download_of_docker-compose (1.01s)
    --- PASS: Test_CheckTools/Download_of_hugo (1.06s)
    --- PASS: Test_CheckTools/Download_of_kube-bench (0.99s)
    --- PASS: Test_CheckTools/Download_of_waypoint (0.19s)
    --- PASS: Test_CheckTools/Download_of_packer (0.02s)
    --- PASS: Test_CheckTools/Download_of_vagrant (0.02s)
    --- PASS: Test_CheckTools/Download_of_minikube (0.76s)
    --- PASS: Test_CheckTools/Download_of_terraform (0.03s)
    --- PASS: Test_CheckTools/Download_of_krew (0.76s)
    --- PASS: Test_CheckTools/Download_of_kops (0.80s)
    --- PASS: Test_CheckTools/Download_of_buildx (0.84s)
    --- PASS: Test_CheckTools/Download_of_hey (1.00s)
    --- PASS: Test_CheckTools/Download_of_pack (1.03s)
    --- PASS: Test_CheckTools/Download_of_gh (1.02s)
    --- PASS: Test_CheckTools/Download_of_k9s (0.77s)
    --- PASS: Test_CheckTools/Download_of_civo (0.94s)
    --- PASS: Test_CheckTools/Download_of_terragrunt (1.02s)
    --- PASS: Test_CheckTools/Download_of_popeye (0.97s)
    --- PASS: Test_CheckTools/Download_of_doctl (0.69s)
    --- PASS: Test_CheckTools/Download_of_linkerd2 (0.45s)
    --- PASS: Test_CheckTools/Download_of_hubble (0.74s)
    --- PASS: Test_CheckTools/Download_of_eksctl (1.07s)
    --- PASS: Test_CheckTools/Download_of_kustomize (0.92s)
    --- PASS: Test_CheckTools/Download_of_kubectx (0.67s)
    --- PASS: Test_CheckTools/Download_of_devspace (0.80s)
    --- PASS: Test_CheckTools/Download_of_kubens (0.37s)
    --- PASS: Test_CheckTools/Download_of_k3s (0.58s)
    --- PASS: Test_CheckTools/Download_of_osm (1.02s)
    --- PASS: Test_CheckTools/Download_of_jq (0.43s)
    --- PASS: Test_CheckTools/Download_of_autok3s (0.94s)
    --- PASS: Test_CheckTools/Download_of_kubectl (0.20s)
    --- PASS: Test_CheckTools/Download_of_dagger (0.82s)
    --- PASS: Test_CheckTools/Download_of_kind (0.97s)
    --- PASS: Test_CheckTools/Download_of_inletsctl (0.84s)
    --- PASS: Test_CheckTools/Download_of_kubeseal (0.83s)
    --- PASS: Test_CheckTools/Download_of_oh-my-posh (0.64s)
    --- PASS: Test_CheckTools/Download_of_arkade (0.83s)
    --- PASS: Test_CheckTools/Download_of_k3sup (0.74s)
    --- PASS: Test_CheckTools/Download_of_helm (0.71s)
    --- PASS: Test_CheckTools/Download_of_k3d (1.41s)
    --- PASS: Test_CheckTools/Download_of_tilt (1.21s)
    --- PASS: Test_CheckTools/Download_of_helmfile (1.57s)
PASS
coverage: 52.3% of statements
ok  	github.com/alexellis/arkade/pkg/get	(cached)	coverage: 52.3% of statements
</pre>
</details>


## Are you a GitHub Sponsor yet (Yes/No?)

- [ ] Yes
- [X] No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [X] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
