### PR TITLE
feat: add Bun to System apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,12 @@ Run the following to see what's available `arkade system install`:
 
 ```bash
   actions-runner Install GitHub Actions Runner
+  bun            Install Bun
   cni            Install CNI plugins
   containerd     Install containerd
   firecracker    Install Firecracker
   go             Install Go
+  node           Install Node.js
   prometheus     Install Prometheus
 ```
 

--- a/cmd/system/bun.go
+++ b/cmd/system/bun.go
@@ -1,0 +1,113 @@
+package system
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/archive"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/get"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallBun() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "bun",
+		Short: "Install Bun",
+		Long:  `Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one.`,
+		Example: `arkade system install bun
+  arkade system install bun --version v0.1.8`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().StringP("version", "v", "latest", "The version for Bun to install (default: latest)")
+	command.Flags().StringP("path", "p", "/usr/local/bin", "Installation path")
+	command.Flags().Bool("progress", true, "Show download progress")
+	command.Flags().String("arch", "", "CPU architecture for Bun, eg: amd64")
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		installPath, _ := cmd.Flags().GetString("path")
+		version, _ := cmd.Flags().GetString("version")
+		progress, _ := cmd.Flags().GetBool("progress")
+
+		fmt.Printf("Installing Bun to %s\n", installPath)
+
+		if err := os.MkdirAll(installPath, 0755); err != nil && !os.IsExist(err) {
+			fmt.Printf("Error creating directory %s, error: %s\n", installPath, err.Error())
+		}
+
+		arch, osVer := env.GetClientArch()
+
+		if strings.ToLower(osVer) == "windows" {
+			return fmt.Errorf("bun does not support Windows")
+		}
+
+		if cmd.Flags().Changed("arch") {
+			arch, _ = cmd.Flags().GetString("arch")
+		}
+
+		dlArch := arch
+		if arch == "x86_64" {
+			dlArch = "x64"
+		}
+
+		if version == "latest" {
+			v, err := get.FindGitHubRelease("oven-sh", "bun")
+			if err != nil {
+				return err
+			}
+			version = v
+		} else {
+			if !strings.HasPrefix(version, "v") {
+				version = "v" + version
+			}
+			version = "bun-" + version
+		}
+
+		fmt.Printf("Installing version: %s for: %s\n", version, dlArch)
+
+		filename := fmt.Sprintf("bun-%s-%s.zip", strings.ToLower(osVer), dlArch)
+		dlURL := fmt.Sprintf(githubDownloadTemplate, "oven-sh", "bun", version, filename)
+
+		fmt.Printf("Downloading from: %s\n", dlURL)
+		outPath, err := get.DownloadFileP(dlURL, progress)
+		if err != nil {
+			return err
+		}
+		defer os.Remove(outPath)
+
+		fmt.Printf("Downloaded to: %s\n", outPath)
+
+		f, err := os.OpenFile(outPath, os.O_RDONLY, 0644)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		tempUnpackPath, err := os.MkdirTemp(os.TempDir(), "bun*")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tempUnpackPath)
+
+		fmt.Printf("Unpacking binaries to: %s\n", tempUnpackPath)
+		fInfo, err := f.Stat()
+		if err := archive.Unzip(f, fInfo.Size(), tempUnpackPath, true); err != nil {
+			return err
+		}
+
+		fmt.Printf("Copying binaries to: %s\n", installPath)
+		filesToCopy := map[string]string{
+			fmt.Sprintf("%s/%s", tempUnpackPath, "bun"): fmt.Sprintf("%s/%s", installPath, "bun"),
+		}
+		for src, dst := range filesToCopy {
+			if _, err := get.CopyFileP(src, dst, readWriteExecuteEveryone); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+	return command
+}

--- a/cmd/system/install.go
+++ b/cmd/system/install.go
@@ -28,6 +28,7 @@ func MakeInstall() *cobra.Command {
 	command.AddCommand(MakeInstallContainerd())
 	command.AddCommand(MakeInstallActionsRunner())
 	command.AddCommand(MakeInstallNode())
+	command.AddCommand(MakeInstallBun())
 
 	return command
 }


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding Bun to System Apps as alternative to Node.js

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
docker container run --rm -v $(pwd):/workspace -ti golang:1.17 bash
root@371d64b6de21:/go# cd /workspace/
root@371d64b6de21:/workspace# go mod tidy && go run .
go: downloading github.com/spf13/cobra v1.5.0
go: downloading github.com/alexellis/go-execute v0.5.0
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/docker/go-units v0.4.0
go: downloading github.com/morikuni/aec v1.0.0
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading github.com/cheggaaa/pb/v3 v3.1.0
go: downloading github.com/Masterminds/semver v1.5.0
go: downloading github.com/otiai10/copy v1.7.0
go: downloading github.com/sethvargo/go-password v0.2.0
go: downloading golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
go: downloading golang.org/x/mod v0.5.1
go: downloading github.com/VividCortex/ewma v1.2.0
go: downloading github.com/mattn/go-runewidth v0.0.13
go: downloading github.com/fatih/color v1.13.0
go: downloading github.com/mattn/go-colorable v0.1.12
go: downloading github.com/mattn/go-isatty v0.0.14
go: downloading github.com/inconshreveable/mousetrap v1.0.0
go: downloading github.com/spf13/pflag v1.0.5
go: downloading github.com/rivo/uniseg v0.2.0
go: downloading golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b
go: downloading github.com/otiai10/mint v1.3.3
            _             _      
  __ _ _ __| | ____ _  __| | ___ 
 / _` | '__| |/ / _` |/ _` |/ _ \
| (_| | |  |   < (_| | (_| |  __/
 \__,_|_|  |_|\_\__,_|\__,_|\___|

Open Source Marketplace For Developer Tools

Usage:
  arkade [flags]
  arkade [command]

Available Commands:
  completion  Output shell completion for the given shell (bash or zsh)
  get         The get command downloads a tool
  help        Help about any command
  info        Find info about a Kubernetes app
  install     Install Kubernetes apps from helm charts or YAML files
  kasten      Sponsored Apps for kasten
  system      System apps
  uninstall   Uninstall apps installed with arkade
  update      Print update instructions
  venafi      Sponsored Apps for Venafi
  version     Print the version

Flags:
  -h, --help   help for arkade

Use "arkade [command] --help" for more information about a command.
root@371d64b6de21:/workspace# ./arkade system install bun
Installing Bun to /usr/local/bin
Installing version: bun-v0.1.8 for: x64
Downloading from: https://github.com/oven-sh/bun/releases/download/bun-v0.1.8/bun-linux-x64.zip
31.66 MiB / 31.66 MiB [-------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
Downloaded to: /tmp/bun-linux-x64.zip
Unpacking binaries to: /tmp/bun3489873688
Copying binaries to: /usr/local/bin
root@371d64b6de21:/workspace# bun
bun: a fast bundler, transpiler, JavaScript Runtime and package manager for web software.

  dev       ./a.ts ./b.jsx        Start a bun Dev Server
  bun       ./a.ts ./b.jsx        Bundle dependencies of input files into a .bun

  init                            Start an empty Bun project from a blank template
  create    next ./app            Create a new project from a template (bun c)
  run       test                  Run JavaScript with bun, a package.json script, or a bin
  install                         Install dependencies for a package.json (bun i)
  add       @compiled/react       Add a dependency to package.json (bun a)
  link                            Link an npm package globally
  remove    webpack               Remove a dependency from package.json (bun rm)
  unlink                          Globally unlink an npm package

  upgrade                         Get the latest version of bun
  completions                     Install shell completions for tab-completion
  discord                         Open bun's Discord server
  help                            Print this help menu
```

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [x] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
