### PR TITLE
Add vault to list of apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,8 +545,9 @@ A CLI or "tool" is a command line tool that you run directly on your own worksta
 | influxdb                | Install influxdb                                                    |
 | nats-connector          | Install OpenFaaS connector for NATS                                 |
 | kyverno                 | Install Kyverno                                                     |
+| vault                   | Install Vault                                                       |
 
-There are 55 apps that you can install on your cluster.
+There are 56 apps that you can install on your cluster.
 
 > Note to contributors, run `arkade install --print-table` to generate this list
 

--- a/cmd/apps/vault_app.go
+++ b/cmd/apps/vault_app.go
@@ -1,0 +1,167 @@
+// Copyright (c) arkade author(s) 2022. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package apps
+
+import (
+	"fmt"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/apps"
+	"github.com/alexellis/arkade/pkg/config"
+	"github.com/alexellis/arkade/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+func MakeInstallVault() *cobra.Command {
+	var vault = &cobra.Command{
+		Use:   "vault",
+		Short: "Install vault",
+		Long:  `Install vault`,
+		Example: `  arkade install vault
+  # with ingress and custom domain
+  arkade install vault --ingress=true --domain=vault.example.com`,
+		SilenceUsage: true,
+	}
+
+	vault.Flags().StringP("namespace", "n", "vault", "The namespace to install the chart")
+	vault.Flags().Bool("update-repo", true, "Update the helm repo")
+	vault.Flags().Bool("ingress", false, "Enable ingress")
+	vault.Flags().String("domain", "", "Set ingress domain")
+	vault.Flags().Bool("injector", false, "Enable sidecar injector")
+	vault.Flags().Bool("persistence", false, "Enable vault server persistence")
+	vault.Flags().StringArray("set", []string{}, "Use custom flags or override existing flags \n(example --set image.tag=1.11.2)")
+
+	vault.PreRunE = func(cmd *cobra.Command, args []string) error {
+		_, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			return err
+		}
+
+		_, err = cmd.Flags().GetStringArray("set")
+		if err != nil {
+			return err
+		}
+
+		_, err = cmd.Flags().GetBool("update-repo")
+		if err != nil {
+			return err
+		}
+
+		ingressEnabled, err := cmd.Flags().GetBool("ingress")
+		if err != nil {
+			return err
+		}
+
+		ingressDomain, err := cmd.Flags().GetString("domain")
+		if err != nil {
+			return err
+		}
+
+		if !ingressEnabled && ingressDomain != "" {
+			return fmt.Errorf("--domain option should be used only with --ingress=true")
+		}
+
+		_, err = cmd.Flags().GetBool("injector")
+		if err != nil {
+			return err
+		}
+
+		_, err = cmd.Flags().GetBool("persistence")
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	vault.RunE = func(cmd *cobra.Command, args []string) error {
+		kubeConfigPath, _ := cmd.Flags().GetString("kubeconfig")
+		if err := config.SetKubeconfig(kubeConfigPath); err != nil {
+			return err
+		}
+
+		namespace, _ := cmd.Flags().GetString("namespace")
+		updateRepo, _ := cmd.Flags().GetBool("update-repo")
+		ingressEnabled, _ := cmd.Flags().GetBool("ingress")
+		ingressDomain, _ := cmd.Flags().GetString("domain")
+		injectorEnabled, _ := cmd.Flags().GetBool("injector")
+		persistence, _ := cmd.Flags().GetBool("persistence")
+		customFlags, _ := cmd.Flags().GetStringArray("set")
+
+		overrides := map[string]string{
+			"injector.enabled":           "false",
+			"server.dataStorage.enabled": "false",
+		}
+
+		if ingressDomain != "" {
+			overrides["server.ingress.hosts[0].host"] = ingressDomain
+		}
+
+		if ingressEnabled {
+			overrides["server.ingress.enabled"] = "true"
+		}
+		if injectorEnabled {
+			overrides["injector.enabled"] = "true"
+		}
+		if persistence {
+			overrides["server.dataStorage.enabled"] = "true"
+		}
+
+		if err := config.MergeFlags(overrides, customFlags); err != nil {
+			return err
+		}
+
+		vaultOptions := types.DefaultInstallOptions().
+			WithNamespace(namespace).
+			WithHelmRepo("hashicorp/vault").
+			WithHelmURL("https://helm.releases.hashicorp.com").
+			WithOverrides(overrides).
+			WithHelmUpdateRepo(updateRepo).
+			WithKubeconfigPath(kubeConfigPath)
+
+		_, err := apps.MakeInstallChart(vaultOptions)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(vaultInstallMsg)
+
+		return nil
+	}
+
+	return vault
+}
+
+const VaultInfoMsg = `# To use Vault, you need to initialize it:
+kubectl exec --stdin=true --tty=true -n vault vault-0 -- vault operator init
+
+# Then save Unseal Keys and root token and execute command below 3 times with each key (e.g. Unseal Key 1, 2, 3)
+kubectl exec --stdin=true --tty=true -n vault vault-0 -- vault operator unseal # ... Unseal Key 1
+
+# Sealed should be false after that
+Key             Value
+---             -----
+Seal Type       shamir
+Initialized     true
+Sealed          false
+Total Shares    5
+Threshold       3
+Version         1.11.2
+Build Date      2022-07-29T09:48:47Z
+Storage Type    file
+Cluster Name    vault-cluster-dad545cc
+Cluster ID      eacce4ce-7954-62a7-78ff-be5e3f4ee2f7
+HA Enabled      false
+
+# Get started with Vault at
+# https://www.vaultproject.io/docs/platform/k8s
+
+# You can install the "vault" CLI via:
+
+arkade get vault`
+
+const vaultInstallMsg = `=======================================================================
+=                     Vault has been installed.                       =
+=======================================================================` +
+	"\n\n" + VaultInfoMsg + "\n\n" + pkg.SupportMessageShort

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -163,6 +163,7 @@ func GetApps() map[string]ArkadeApp {
 	arkadeApps["inlets-tcp-client"] = NewArkadeApp(apps.MakeInstallInletsTcpClient, apps.InletsTcpClientInfoMsg)
 	arkadeApps["kuma"] = NewArkadeApp(apps.MakeInstallKuma, apps.KumaInfoMsg)
 	arkadeApps["qemu-static"] = NewArkadeApp(apps.MakeInstallQemuStatic, apps.QemuStaticInfoMsg)
+	arkadeApps["vault"] = NewArkadeApp(apps.MakeInstallVault, apps.VaultInfoMsg)
 
 	// Special "chart" app - let a user deploy any helm chart
 	arkadeApps["chart"] = NewArkadeApp(apps.MakeInstallChart, "")


### PR DESCRIPTION
Signed-off-by: Maria Kotlyarevskaya <mariia.kotliarevskaia@gmail.com>

Adds Vault to available apps as part of https://github.com/alexellis/arkade/issues/627

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds vault to arkade's apps (fixes #627)
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
./arkade install vault
Using Kubeconfig: /Users/maria.kotlyarevskaya/.kube/config
Using Kubeconfig: /Users/maria.kotlyarevskaya/.kube/config
[Warning] unable to create namespace vault, may already exist: Error from server (AlreadyExists): namespaces "vault" already exists
Client: arm64, Darwin
2022/08/15 16:22:36 User dir established as: /Users/maria.kotlyarevskaya/.arkade/
"hashicorp" already exists with the same configuration, skipping

VALUES values.yaml
Command: /Users/maria.kotlyarevskaya/.arkade/bin/helm [upgrade --install vault hashicorp/vault --namespace vault --values /var/folders/t7/dp293qn57h12csyb_b4zygtw0000gp/T/charts/vault/values.yaml]
Release "vault" has been upgraded. Happy Helming!
NAME: vault
LAST DEPLOYED: Mon Aug 15 16:22:39 2022
NAMESPACE: vault
STATUS: deployed
REVISION: 7
NOTES:
Thank you for installing HashiCorp Vault!

Now that you have deployed Vault, you should look over the docs on using
Vault with Kubernetes available here:

https://www.vaultproject.io/docs/


Your release is named vault. To learn more about the release, try:

  $ helm status vault
  $ helm get manifest vault
=======================================================================
=                     Vault has been installed.                       =
=======================================================================

# To use Vault, you need to initialize it:
kubectl exec --stdin=true --tty=true -n vault vault-0 -- vault operator init

# Then save Unseal Keys and root token and execute command below 3 times with each key (e.g. Unseal Key 1, 2, 3)
kubectl exec --stdin=true --tty=true -n vault vault-0 -- vault operator unseal # ... Unseal Key 1

# Sealed should be false after that
Key             Value
---             -----
Seal Type       shamir
Initialized     true
Sealed          false
Total Shares    5
Threshold       3
Version         1.11.2
Build Date      2022-07-29T09:48:47Z
Storage Type    file
Cluster Name    vault-cluster-dad545cc
Cluster ID      eacce4ce-7954-62a7-78ff-be5e3f4ee2f7
HA Enabled      false

# Find out more on the project homepage:
# https://learn.hashicorp.com/collections/vault/kubernetes

# You can install the "vault" CLI via:

arkade get vault

🐳 arkade needs your support, learn more: https://my.arkade.dev
```

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [x] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
