### PR TITLE
Fix installation of cni system app on armv7

### DIFF
--- a/cmd/system/cni.go
+++ b/cmd/system/cni.go
@@ -50,16 +50,17 @@ func MakeInstallCNI() *cobra.Command {
 			return fmt.Errorf("this app only supports Linux")
 		}
 
-		if arch != "x86_64" && arch != "aarch64" {
-			return fmt.Errorf("this app only supports x86_64 and aarch64 and not %s", arch)
+		if strings.ToLower(osVer) != "linux" {
+			return fmt.Errorf("this app only supports Linux")
 		}
+
 		dlArch := arch
 		if arch == "x86_64" {
 			dlArch = "amd64"
 		} else if arch == "aarch64" {
 			dlArch = "arm64"
 		} else if arch == "armv7" || arch == "armv7l" {
-			dlArch = "armv6l"
+			dlArch = "arm"
 		}
 		if version == githubLatest {
 			v, err := get.FindGitHubRelease(owner, repo)


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updates the cni system app to support armv7.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

Closes #742 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `arkade system install cni --version v0.9.1 --path result`

Output:
```
Installing CNI to result
Installing version: v0.9.1 for: arm
Downloading from: https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-arm-v0.9.1.tgz
35.32 MiB / 35.32 MiB [--------------------------------------------------------------------------] 100.00%
Downloaded to: /tmp/cni-plugins-linux-arm-v0.9.1.tgz
Unpacking CNI Plugins to: /tmp/cni-plugins1363824332
Copying /tmp/cni-plugins1363824332/bandwidth to: result/bandwidth
Copying /tmp/cni-plugins1363824332/bridge to: result/bridge
Copying /tmp/cni-plugins1363824332/dhcp to: result/dhcp
Copying /tmp/cni-plugins1363824332/firewall to: result/firewall
Copying /tmp/cni-plugins1363824332/flannel to: result/flannel
Copying /tmp/cni-plugins1363824332/host-device to: result/host-device
Copying /tmp/cni-plugins1363824332/host-local to: result/host-local
Copying /tmp/cni-plugins1363824332/ipvlan to: result/ipvlan
Copying /tmp/cni-plugins1363824332/loopback to: result/loopback
Copying /tmp/cni-plugins1363824332/macvlan to: result/macvlan
Copying /tmp/cni-plugins1363824332/portmap to: result/portmap
Copying /tmp/cni-plugins1363824332/ptp to: result/ptp
Copying /tmp/cni-plugins1363824332/sbr to: result/sbr
Copying /tmp/cni-plugins1363824332/static to: result/static
Copying /tmp/cni-plugins1363824332/tuning to: result/tuning
Copying /tmp/cni-plugins1363824332/vlan to: result/vlan
Copying /tmp/cni-plugins1363824332/vrf to: result/vrf
```

Verified downloaded binaries:
```
file result/bridge
                                              
result/bridge: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=cwTU4drkR0vm7Juaznfm/_Z0HUmabhyg3Zwi_ciu9/nX7xauhO5cmUufBnPmWt/Dkh23XSFramN4gXevKgL, not stripped
```
## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
