### PR TITLE
chore: update helm version to v3.9.3 & fix kubescape repository owner

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -3068,17 +3068,17 @@ func Test_DownloadKubescape(t *testing.T) {
 		{
 			os:      "darwin",
 			version: "v1.0.69",
-			url:     `https://github.com/armosec/kubescape/releases/download/v1.0.69/kubescape-macos-latest`,
+			url:     `https://github.com/kubescape/kubescape/releases/download/v1.0.69/kubescape-macos-latest`,
 		},
 		{
 			os:      "linux",
 			version: "v1.0.69",
-			url:     `https://github.com/armosec/kubescape/releases/download/v1.0.69/kubescape-ubuntu-latest`,
+			url:     `https://github.com/kubescape/kubescape/releases/download/v1.0.69/kubescape-ubuntu-latest`,
 		},
 		{
 			os:      "ming",
 			version: "v1.0.69",
-			url:     `https://github.com/armosec/kubescape/releases/download/v1.0.69/kubescape-windows-latest`,
+			url:     `https://github.com/kubescape/kubescape/releases/download/v1.0.69/kubescape-windows-latest`,
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -50,7 +50,7 @@ func MakeTools() Tools {
 			Owner:       "helm",
 			Repo:        "helm",
 			Name:        "helm",
-			Version:     "v3.5.2",
+			Version:     "v3.9.3",
 			Description: "The Kubernetes Package Manager: Think of it like apt/yum/homebrew for Kubernetes.",
 			URLTemplate: `{{$arch := "amd64"}}
 
@@ -1945,7 +1945,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "armosec",
+			Owner:       "kubescape",
 			Repo:        "kubescape",
 			Name:        "kubescape",
 			Description: "kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA",

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -16,8 +16,6 @@ import (
 	execute "github.com/alexellis/go-execute/pkg/v1"
 )
 
-const helmVersion = "v3.1.2"
-
 func TryDownloadHelm(userPath, clientArch, clientOS string) (string, error) {
 	helmVal := "helm"
 	subdir := ""

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -8,9 +8,10 @@ import "testing"
 func Test_GetHelmURL_GitBash(t *testing.T) {
 	arch := "amd64"
 	os := "mingw64_nt-10.0-18362"
+	helmVersion := "v3.9.3"
 
 	got := GetHelmURL(arch, os, helmVersion)
-	want := "https://get.helm.sh/helm-v3.1.2-windows-amd64.tar.gz"
+	want := "https://get.helm.sh/helm-v3.9.3-windows-amd64.tar.gz"
 	if got != want {
 		t.Fatalf("want: %s, but got: %s", want, got)
 	}


### PR DESCRIPTION
Signed-off-by: Maria Kotlyarevskaya <jasssstkn@yahoo.com>

This PR updates helm to the latest version, also it fixes installation and tests for kubescape

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Update helm version in `pkg/get/tools.go`
- Remove unused const from `pkg/helm/helm.go` and update correspondent tests
- Fix owner for kubescape because it causes installation and tests to fail 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
- It is being asked here https://github.com/alexellis/arkade/issues/745 and discussed in the https://github.com/alexellis/arkade/pull/739#issuecomment-1225586357


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```bash
./hack/test-dagger.sh helm
+ go build
+ ./arkade get helm --arch arm64 --os darwin --quiet
🐳 arkade needs your support, learn more: https://my.arkade.dev
+ file /Users/mariarti/.arkade/bin/helm
/Users/mariarti/.arkade/bin/helm: Mach-O 64-bit executable x86_64
+ /Users/mariarti/.arkade/bin/helm version
version.BuildInfo{Version:"v3.9.3", GitCommit:"414ff28d4029ae8c8b05d62aa06c7fe3dee2bc58", GitTreeState:"clean", GoVersion:"go1.17.13"}
+ rm /Users/mariarti/.arkade/bin/helm
+ ./arkade get helm --arch x86_64 --os darwin --quiet
🐳 arkade needs your support, learn more: https://my.arkade.dev
+ file /Users/mariarti/.arkade/bin/helm
/Users/mariarti/.arkade/bin/helm: Mach-O 64-bit executable x86_64
+ /Users/mariarti/.arkade/bin/helm version
version.BuildInfo{Version:"v3.9.3", GitCommit:"414ff28d4029ae8c8b05d62aa06c7fe3dee2bc58", GitTreeState:"clean", GoVersion:"go1.17.13"}
+ rm /Users/mariarti/.arkade/bin/helm
+ ./arkade get helm --arch x86_64 --os linux --quiet
🐳 arkade needs your support, learn more: https://my.arkade.dev
+ file /Users/mariarti/.arkade/bin/helm
/Users/mariarti/.arkade/bin/helm: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=_XFOKOEK5p5JL4dkh-io/a9lWKzOxi_AWITxbiVyd/1NG_ZLRO29AIbCSltdH0/SERc77nA8eTN_NotZ5aY, stripped
+ /Users/mariarti/.arkade/bin/helm version
./hack/test-dagger.sh: line 19: /Users/mariarti/.arkade/bin/helm: cannot execute binary file
```


## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
