### PR TITLE
Enable image verification upto Max Level

### DIFF
--- a/cmd/chart/verify.go
+++ b/cmd/chart/verify.go
@@ -36,6 +36,15 @@ autoscaler          ghcr.io/openfaasltd/autoscaler:0.2.5
 
 	command.Flags().StringP("file", "f", "", "Path to values.yaml file")
 	command.Flags().BoolP("verbose", "v", false, "Verbose output")
+	command.Flags().IntP("depth", "d", 3, "how many levels deep into the YAML structure to walk looking for image: tags")
+
+	command.PreRunE = func(cmd *cobra.Command, args []string) error {
+		_, err := cmd.Flags().GetInt("depth")
+		if err != nil {
+			return fmt.Errorf("error with --depth usage: %s", err)
+		}
+		return nil
+	}
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		file, err := cmd.Flags().GetString("file")
@@ -44,6 +53,7 @@ autoscaler          ghcr.io/openfaasltd/autoscaler:0.2.5
 		}
 
 		verbose, _ := cmd.Flags().GetBool("verbose")
+		depth, _ := cmd.Flags().GetInt("depth")
 
 		if len(file) == 0 {
 			return fmt.Errorf("flag --file is required")
@@ -62,7 +72,7 @@ autoscaler          ghcr.io/openfaasltd/autoscaler:0.2.5
 			return err
 		}
 
-		filtered := helm.FilterImages(values)
+		filtered := helm.FilterImagesUptoDepth(values, depth)
 		if len(filtered) == 0 {
 			return fmt.Errorf("no images found in %s", file)
 		}


### PR DESCRIPTION
Signed-off-by: Nitishkumar Singh <nitishkumarsingh71@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
The change will allow user to validate container image present in any yaml file up to max level defined by used
## Description
<!--- Describe your changes in detail -->
1. Included a new flag where user can define max nested level to check. Default value is 3
2. Changed the current implementation to look for image key upto max level
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

closes #755 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Build in local using `make build`
2. Download [docker-compose.yaml](https://github.com/openfaas/faasd/blob/master/docker-compose.yaml) file from faasd and[ values.yaml](https://github.com/openfaas/faas-netes/blob/master/chart/cron-connector/values.yaml) file from faas-netes chart 
3. Validate images into `docker-compose.yaml` using command `./arkade chart verify -f ../faasd/docker-compose.yaml -v true`
```
Verifying images in: ../faasd/docker-compose.yaml
Found 5 images
> [ghcr.io/openfaas/queue-worker:0.12.2] ghcr.io/openfaas/queue-worker:0.12.2
< [ghcr.io/openfaas/queue-worker:0.12.2] sha256:dd69cc3d77c2e06df54ed2dddea384b6defc51ec35763a5ed377548fd30c6831
> [ghcr.io/openfaas/basic-auth:0.21.4] ghcr.io/openfaas/basic-auth:0.21.4
< [ghcr.io/openfaas/basic-auth:0.21.4] sha256:e99c385f248ce9a6569bf262e3480ddbf317cd5982243fcc229ee1766d24eb5a
> [docker.io/library/nats-streaming:0.22.0] docker.io/library/nats-streaming:0.22.0
< [docker.io/library/nats-streaming:0.22.0] sha256:448076816470a7198c7d81db17317ea061d5cb129dcbb715a046ddea3b2bf752
> [docker.io/prom/prometheus:v2.14.0] docker.io/prom/prometheus:v2.14.0
< [docker.io/prom/prometheus:v2.14.0] sha256:907e20b3b0f8b0a76a33c088fe9827e8edc180e874bd2173c27089eade63d8b8
> [ghcr.io/openfaas/gateway:0.22.0] ghcr.io/openfaas/gateway:0.22.0
< [ghcr.io/openfaas/gateway:0.22.0] sha256:57fb2e0034e879264e1dc0f8f4b6af0b803eea3a3b2e52037c0284293e473d44
```
4. Validate images into `values.yaml` using `./arkade chart verify -f ../faas-netes/chart/cron-connector/values.yaml -v true`

```
Verifying images in: ../faas-netes/chart/cron-connector/values.yaml
Found 1 images
> [ghcr.io/openfaas/cron-connector:0.6.1] ghcr.io/openfaas/cron-connector:0.6.1
< [ghcr.io/openfaas/cron-connector:0.6.1] sha256:1f33c56f972e1899a2f9abc32d7dafb14665109a82b68554adabe21467eaec9d
```


## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
