### PR TITLE
Add generation for compatibility matrix

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -60,6 +60,7 @@ and provides a fast and easy alternative to a package manager.`,
 
 	command.Flags().Bool("progress", true, "Display a progress bar")
 	command.Flags().StringP("output", "o", "", "Output format of the list of tools (table/markdown/list)")
+	command.Flags().Bool("matrix", false, "Output compatibility matrix")
 	command.Flags().Bool("stash", true, "When set to true, stash binary in HOME/.arkade/bin/, otherwise store in /tmp/")
 	command.Flags().StringP("version", "v", "", "Download a specific version")
 	command.Flags().String("arch", clientArch, "CPU architecture for the tool")
@@ -67,6 +68,11 @@ and provides a fast and easy alternative to a package manager.`,
 	command.Flags().Bool("quiet", false, "Suppress most additional output")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
+		matrix, _ := command.Flags().GetBool("matrix")
+		if matrix {
+			get.CreateCompatibilityToolsTable()
+			return nil
+		}
 		if len(args) == 0 {
 			output, _ := command.Flags().GetString("output")
 

--- a/pkg/get/table.go
+++ b/pkg/get/table.go
@@ -3,6 +3,7 @@ package get
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/olekukonko/tablewriter"
 )
@@ -37,5 +38,80 @@ func CreateToolsTable(tools Tools, format TableFormat) {
 		table.Append([]string{t.Name, t.Description})
 	}
 
+	table.Render()
+}
+
+type ArchMatrix struct {
+	OS   string
+	Arch string
+}
+
+func CreateCompatibilityToolsTable() {
+	table := tablewriter.NewWriter(os.Stdout)
+
+	arch := []ArchMatrix{
+		{OS: "darwin", Arch: "x86_64"},
+		{OS: "darwin", Arch: "arm64"},
+		{OS: "linux", Arch: "x86_64"},
+		{OS: "linux", Arch: "aarch64"},
+		{OS: "linux", Arch: "armhf"},
+		{OS: "ming", Arch: "x86_64"},
+	}
+	var header = []string{"Tool"}
+	for _, v := range arch {
+		header = append(header, v.OS+"/"+v.Arch)
+	}
+	table.SetHeader(header)
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetCenterSeparator("|")
+	table.SetAutoWrapText(false)
+
+	var compatible = '✅'
+	var notCompatible = '❌'
+	// var undefined = '🤷'
+
+	tools := MakeTools()
+
+	// check tools in parallel
+	c := make(chan []string)
+	var wg sync.WaitGroup
+	for _, tool := range tools {
+		wg.Add(1)
+		go func(t Tool) {
+			result := []string{t.Name}
+			decision := string(compatible)
+			for _, pair := range arch {
+				quiet := true
+				_, err := t.GetURL(pair.OS, pair.Arch, t.Version, quiet)
+				if err != nil {
+					decision = string(notCompatible)
+				}
+
+				// status, _, headers, err := t.Head(url)
+				// if err != nil {
+				// 	decision = string(undefined)
+				// 	fmt.Println("Head failed for ", t.Name)
+				// }
+
+				// if status != http.StatusOK {
+				// 	decision = string(notCompatible)
+				// 	fmt.Println("StatusNotOK for ", t.Name)
+				// }
+				result = append(result, decision)
+			}
+			c <- result
+			defer wg.Done()
+		}(tool)
+	}
+
+	go func() {
+		wg.Wait()
+		close(c)
+	}()
+
+	// process data
+	for row := range c {
+		table.Append(row)
+	}
 	table.Render()
 }


### PR DESCRIPTION
Signed-off-by: Maria Kotlyarevskaya <mariia.kotliarevskaia@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- adds generation for compatibility matrix
- adds separate arkade command to invoke a function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

fixes #762 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
./arkade get --matrix=true
|       TOOL       | DARWIN/X86 64 | DARWIN/ARM64 | LINUX/X86 64 | LINUX/AARCH64 | LINUX/ARMHF | MING/X86 64 |
|------------------|---------------|--------------|--------------|---------------|-------------|-------------|
| kubens           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kubetail         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| helm             | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| linkerd2         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kubectl          | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| porter           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| tfsec            | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| dive             | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kubebuilder      | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| mc               | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kumactl          | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kustomize        | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| vagrant          | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| waypoint         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| terraform        | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| doctl            | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| packer           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| metal            | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kim              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| vault            | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| influx           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| helmfile         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| civo             | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| goreleaser       | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| k9s              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| autok3s          | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| k0sctl           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| inletsctl        | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| minikube         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| argocd-autopilot | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| argocd           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| bun              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kubescape        | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| istioctl         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| devspace         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| flux             | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| arkade           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| talosctl         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kops             | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| nats             | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| rpk              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kind             | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| hey              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| k3d              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| k3sup            | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| golangci-lint    | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| run-job          | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| k3s              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| osm              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| tkn              | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| gomplate         | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| gh               | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| kanctl           | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| polaris          | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| nerdctl          | ✅            | ✅           | ✅           | ✅            | ✅          | ✅          |
| docker-compose   | ✅            | ✅           | ✅           | ✅            | ✅          | ❌          |
| butane           | ✅            | ✅           | ✅           | ✅            | ✅          | ❌          |
| cilium           | ✅            | ✅           | ✅           | ✅            | ✅          | ❌          |
| nova             | ✅            | ✅           | ✅           | ✅            | ✅          | ❌          |
| lazygit          | ✅            | ✅           | ✅           | ✅            | ✅          | ❌          |
| k0s              | ✅            | ✅           | ✅           | ✅            | ✅          | ❌          |
| rekor-cli        | ✅            | ✅           | ✅           | ✅            | ❌          | ❌          |
| eksctl           | ✅            | ✅           | ✅           | ✅            | ❌          | ❌          |
| krew             | ✅            | ✅           | ✅           | ✅            | ❌          | ❌          |
| kail             | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| stern            | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| kubectx          | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| opa              | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| mkcert           | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| inlets-pro       | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| kubeseal         | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| trivy            | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| popeye           | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| just             | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| buildx           | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| pack             | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| kube-bench       | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| promtool         | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| kgctl            | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| dagger           | ✅            | ✅           | ✅           | ✅            | ❌          | ❌          |
| faas-cli         | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| kubestr          | ✅            | ✅           | ✅           | ❌            | ❌          | ❌          |
| hostctl          | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| oh-my-posh       | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| jq               | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| terragrunt       | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| sops             | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          |
| vcluster         | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| operator-sdk     | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| kubecm           | ✅            | ✅           | ✅           | ✅            | ❌          | ❌          |
| terrascan        | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| hadolint         | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          |
| nats-server      | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| k10multicluster  | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| caddy            | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          |
| k10tools         | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| cosign           | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| tilt             | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| hubble           | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          |
| clusterctl       | ✅            | ✅           | ❌           | ❌            | ❌          | ❌          |
| hugo             | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          |
| yq               | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          |
| fzf              | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          |
| cr               | ✅            | ❌           | ❌           | ❌            | ❌          | ❌          | 
```

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
