### PR TITLE
Add kubeconform, conftest, kubeval tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ There are 56 apps that you can install on your cluster.
 | cilium           | CLI to install, manage & troubleshoot Kubernetes clusters running Cilium.                                                                 |
 | civo             | CLI for interacting with your Civo resources.                                                                                             |
 | clusterctl       | The clusterctl CLI tool handles the lifecycle of a Cluster API management cluster                                                         |
+| conftest         | Write tests against structured configuration data using the Open Policy Agent Rego query language                                         |
 | cosign           | Container Signing, Verification and Storage in an OCI registry.                                                                           |
 | cr               | Hosting Helm Charts via GitHub Pages and Releases                                                                                         |
 | dagger           | A portable devkit for CI/CD pipelines.                                                                                                    |
@@ -644,6 +645,7 @@ There are 56 apps that you can install on your cluster.
 | kube-bench       | Checks whether Kubernetes is deployed securely by running the checks documented in the CIS Kubernetes Benchmark.                          |
 | kubebuilder      | Framework for building Kubernetes APIs using custom resource definitions (CRDs).                                                          |
 | kubecm           | Easier management of kubeconfig.                                                                                                          |
+| kubeconform      | A FAST Kubernetes manifests validator, with support for Custom Resources                                                                  |
 | kubectl          | Run commands against Kubernetes clusters                                                                                                  |
 | kubectx          | Faster way to switch between clusters.                                                                                                    |
 | kubens           | Switch between Kubernetes namespaces smoothly.                                                                                            |
@@ -651,6 +653,7 @@ There are 56 apps that you can install on your cluster.
 | kubeseal         | A Kubernetes controller and tool for one-way encrypted Secrets                                                                            |
 | kubestr          | Kubestr discovers, validates and evaluates your Kubernetes storage options.                                                               |
 | kubetail         | Bash script to tail Kubernetes logs from multiple pods at the same time.                                                                  |
+| kubeval          | Validate your Kubernetes configuration files, supports multiple Kubernetes versions                                                       |
 | kumactl          | kumactl is a CLI to interact with Kuma and its data                                                                                       |
 | kustomize        | Customization of kubernetes YAML configurations                                                                                           |
 | lazygit          | A simple terminal UI for git commands.                                                                                                    |
@@ -692,7 +695,7 @@ There are 56 apps that you can install on your cluster.
 | vcluster         | Create fully functional virtual Kubernetes clusters - Each vcluster runs inside a namespace of the underlying k8s cluster.                |
 | waypoint         | Easy application deployment for Kubernetes and Amazon ECS                                                                                 |
 | yq               | Portable command-line YAML processor.                                                                                                     |
-There are 106 tools, use `arkade get NAME` to download one.
+There are 109 tools, use `arkade get NAME` to download one.
 
 
 > Note to contributors, run `arkade get --output markdown` to generate this list

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -4985,3 +4985,138 @@ func Test_DownloadFlyctl(t *testing.T) {
 		})
 	}
 }
+
+func Test_DownloadKubeconform(t *testing.T) {
+	tools := MakeTools()
+	name := "kubeconform"
+	version := "v0.4.14"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/yannh/kubeconform/releases/download/v0.4.14/kubeconform-darwin-amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/yannh/kubeconform/releases/download/v0.4.14/kubeconform-linux-amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: version,
+			url:     "https://github.com/yannh/kubeconform/releases/download/v0.4.14/kubeconform-linux-arm64.tar.gz",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/yannh/kubeconform/releases/download/v0.4.14/kubeconform-windows-amd64.zip",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}
+
+func Test_DownloadConftest(t *testing.T) {
+	tools := MakeTools()
+	name := "conftest"
+	version := "v0.34.0"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/open-policy-agent/conftest/releases/download/v0.34.0/conftest_0.34.0_Darwin_x86_64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/open-policy-agent/conftest/releases/download/v0.34.0/conftest_0.34.0_Linux_x86_64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: version,
+			url:     "https://github.com/open-policy-agent/conftest/releases/download/v0.34.0/conftest_0.34.0_Linux_arm64.tar.gz",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/open-policy-agent/conftest/releases/download/v0.34.0/conftest_0.34.0_Windows_x86_64.zip",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}
+
+func Test_DownloadKubeval(t *testing.T) {
+	tools := MakeTools()
+	name := "kubeval"
+	version := "v0.16.1"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/instrumenta/kubeval/releases/download/v0.16.1/kubeval-darwin-amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/instrumenta/kubeval/releases/download/v0.16.1/kubeval-linux-amd64.tar.gz",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: version,
+			url:     "https://github.com/instrumenta/kubeval/releases/download/v0.16.1/kubeval-Windows-amd64.zip",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -2856,5 +2856,87 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				`,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:       "yannh",
+			Repo:        "kubeconform",
+			Name:        "kubeconform",
+			Description: "A FAST Kubernetes manifests validator, with support for Custom Resources",
+			BinaryTemplate: `
+				{{$os := .OS}}
+				{{$arch := .Arch}}
+				{{$ext := ".tar.gz"}}
+				{{- if HasPrefix .OS "ming" -}}
+				{{$os = "windows"}}
+				{{$ext = ".zip"}}
+				{{- end -}}
+	
+				{{$arch := .Arch}}
+				{{- if eq .Arch "x86_64" -}}
+				{{$arch = "amd64"}}
+				{{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+				{{$arch = "arm64"}}
+				{{- end -}}
+
+				kubeconform-{{$os}}-{{$arch}}{{$ext}}
+				`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "open-policy-agent",
+			Repo:        "conftest",
+			Name:        "conftest",
+			Description: "Write tests against structured configuration data using the Open Policy Agent Rego query language",
+			BinaryTemplate: `
+				{{$os := .OS}}
+				{{$arch := .Arch}}
+				{{$ext := "tar.gz"}}
+
+				{{$arch := .Arch}}
+				{{- if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+				{{$arch = "arm64"}}
+				{{- end -}}
+
+				{{ if HasPrefix .OS "ming" -}}
+				{{$os = "Windows"}}
+				{{$ext = "zip"}}
+				{{- else if eq .OS "linux" -}}
+				{{$os = "Linux"}}
+				{{- else if eq .OS "darwin" -}}
+				{{$os = "Darwin"}}
+				{{- end -}}
+
+				conftest_{{.VersionNumber}}_{{$os}}_{{$arch}}.{{$ext}}
+				`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "instrumenta",
+			Repo:        "kubeval",
+			Name:        "kubeval",
+			Description: "Validate your Kubernetes configuration files, supports multiple Kubernetes versions",
+			BinaryTemplate: `
+				{{$os := .OS}}
+				{{$arch := .Arch}}
+				{{$ext := "tar.gz"}}
+
+				{{$arch := .Arch}}
+				{{- if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+				{{$arch = "arm64"}}
+				{{- else if eq .Arch "x86_64" -}}
+				{{ $arch = "amd64" }}
+				{{- end -}}
+
+				{{ if HasPrefix .OS "ming" -}}
+				{{$os = "Windows"}}
+				{{$ext = "zip"}}
+				{{- end -}}
+
+				kubeval-{{$os}}-{{$arch}}.{{$ext}}
+				`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
Signed-off-by: Maria Kotlyarevskaya <mariia.kotliarevskaia@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- adds kubeconform to arkade get
- adds conftest to arkade get
- adds kubeval to arkade get

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
fixes #781 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
# kubeconform
./hack/test-tool.sh kubeconform
+ go build
+ ./arkade get kubeconform --arch arm64 --os darwin --quiet
+ file /Users/mariarti/.arkade/bin/kubeconform
/Users/mariarti/.arkade/bin/kubeconform: Mach-O 64-bit executable arm64
+ rm /Users/mariarti/.arkade/bin/kubeconform
+ ./arkade get kubeconform --arch x86_64 --os darwin --quiet
+ file /Users/mariarti/.arkade/bin/kubeconform
/Users/mariarti/.arkade/bin/kubeconform: Mach-O 64-bit executable x86_64
+ rm /Users/mariarti/.arkade/bin/kubeconform
+ ./arkade get kubeconform --arch x86_64 --os linux --quiet
+ file /Users/mariarti/.arkade/bin/kubeconform
/Users/mariarti/.arkade/bin/kubeconform: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=_LJpjC7DgdJpJRH7_bHJ/sFBwzBsUTw-HwMVYwkS7/TbEfGwlqSkQ5u6JgUJNU/FyrKvBfW3vzWxUNIPvoP, not stripped
+ rm /Users/mariarti/.arkade/bin/kubeconform
+ ./arkade get kubeconform --arch arm64 --os linux --quiet
+ file /Users/mariarti/.arkade/bin/kubeconform
/Users/mariarti/.arkade/bin/kubeconform: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=MqDhbCSfxwMRFzBSlHF_/CPjzxYSlHCmSLBZ3vg1B/zfo8Mr3itfElFFqAYBZa/QOO-MsJStxs8aH_mPH_D, not stripped
+ rm /Users/mariarti/.arkade/bin/kubeconform
+ ./arkade get kubeconform --arch x86_64 --os ming --quiet
+ file /Users/mariarti/.arkade/bin/kubeconform
/Users/mariarti/.arkade/bin/kubeconform: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=MqDhbCSfxwMRFzBSlHF_/CPjzxYSlHCmSLBZ3vg1B/zfo8Mr3itfElFFqAYBZa/QOO-MsJStxs8aH_mPH_D, not stripped
+ rm /Users/mariarti/.arkade/bin/kubeconform

# conftest
./hack/test-tool.sh conftest
+ go build
+ ./arkade get conftest --arch arm64 --os darwin --quiet
+ file /Users/mariarti/.arkade/bin/conftest
/Users/mariarti/.arkade/bin/conftest: Mach-O 64-bit executable arm64
+ rm /Users/mariarti/.arkade/bin/conftest
+ ./arkade get conftest --arch x86_64 --os darwin --quiet
+ file /Users/mariarti/.arkade/bin/conftest
/Users/mariarti/.arkade/bin/conftest: Mach-O 64-bit executable x86_64
+ rm /Users/mariarti/.arkade/bin/conftest
+ ./arkade get conftest --arch x86_64 --os linux --quiet
+ file /Users/mariarti/.arkade/bin/conftest
/Users/mariarti/.arkade/bin/conftest: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=X_x3Hy7KbIfj374BySaN/xKWZyH698XSEEUfbTnyT/jup5biI_ilW3Pj3Uqgl4/T-307JICxX6HCIqrgMeS, stripped
+ rm /Users/mariarti/.arkade/bin/conftest
+ ./arkade get conftest --arch arm64 --os linux --quiet
+ file /Users/mariarti/.arkade/bin/conftest
/Users/mariarti/.arkade/bin/conftest: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=y_RWX_cWtLFfpHVD8sJh/ZP_pYwAAHkuAyhtqTE2f/zThp9cS0d6YyeGu9bQLz/r9D-5eNQryFyvDUQt02O, stripped
+ rm /Users/mariarti/.arkade/bin/conftest
+ ./arkade get conftest --arch x86_64 --os ming --quiet
+ file /Users/mariarti/.arkade/bin/conftest
/Users/mariarti/.arkade/bin/conftest: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=y_RWX_cWtLFfpHVD8sJh/ZP_pYwAAHkuAyhtqTE2f/zThp9cS0d6YyeGu9bQLz/r9D-5eNQryFyvDUQt02O, stripped
+ rm /Users/mariarti/.arkade/bin/conftest

# kubeval
./hack/test-tool.sh kubeval
+ go build
+ ./arkade get kubeval --arch arm64 --os darwin --quiet
Error: incorrect status for downloading tool: 404
+ file /Users/mariarti/.arkade/bin/kubeval
/Users/mariarti/.arkade/bin/kubeval: cannot open `/Users/mariarti/.arkade/bin/kubeval' (No such file or directory)
+ rm /Users/mariarti/.arkade/bin/kubeval
rm: /Users/mariarti/.arkade/bin/kubeval: No such file or directory
+ ./arkade get kubeval --arch x86_64 --os darwin --quiet
+ file /Users/mariarti/.arkade/bin/kubeval
/Users/mariarti/.arkade/bin/kubeval: Mach-O 64-bit executable x86_64
+ rm /Users/mariarti/.arkade/bin/kubeval
+ ./arkade get kubeval --arch x86_64 --os linux --quiet
+ file /Users/mariarti/.arkade/bin/kubeval
/Users/mariarti/.arkade/bin/kubeval: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=Rl5W_TiRK18l1dtiBUH6/d3GcwwTUKwUHW4PXGBM5/oZPR7utCzSrYDojIAAfm/OHfSwh5Rv3PnyvqKz4sg, stripped
+ rm /Users/mariarti/.arkade/bin/kubeval
+ ./arkade get kubeval --arch arm64 --os linux --quiet
Error: incorrect status for downloading tool: 404
+ file /Users/mariarti/.arkade/bin/kubeval
/Users/mariarti/.arkade/bin/kubeval: cannot open `/Users/mariarti/.arkade/bin/kubeval' (No such file or directory)
+ rm /Users/mariarti/.arkade/bin/kubeval
rm: /Users/mariarti/.arkade/bin/kubeval: No such file or directory
+ ./arkade get kubeval --arch x86_64 --os ming --quiet
+ file /Users/mariarti/.arkade/bin/kubeval
/Users/mariarti/.arkade/bin/kubeval: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=Rl5W_TiRK18l1dtiBUH6/d3GcwwTUKwUHW4PXGBM5/oZPR7utCzSrYDojIAAfm/OHfSwh5Rv3PnyvqKz4sg, stripped
+ rm /Users/mariarti/.arkade/bin/kubeval
```

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
`kubeval` is being deprecated, therefore there is no support for arm processors. see [for details](https://github.com/instrumenta/kubeval#kubeval)