### PR TITLE
Support reading non gzip-compressed tar files

### DIFF
--- a/cmd/system/cni.go
+++ b/cmd/system/cni.go
@@ -100,7 +100,7 @@ func MakeInstallCNI() *cobra.Command {
 		defer os.RemoveAll(tempUnpackPath)
 
 		fmt.Printf("Unpacking CNI Plugins to: %s\n", tempUnpackPath)
-		if err := archive.Untar(f, tempUnpackPath, true); err != nil {
+		if err := archive.Untar(f, tempUnpackPath, true, true); err != nil {
 			return err
 		}
 

--- a/cmd/system/firecracker.go
+++ b/cmd/system/firecracker.go
@@ -89,7 +89,7 @@ func MakeInstallFirecracker() *cobra.Command {
 			return err
 		}
 		fmt.Printf("Unpacking Firecracker to: %s\n", tempUnpackPath)
-		if err := archive.Untar(f, tempUnpackPath, true); err != nil {
+		if err := archive.Untar(f, tempUnpackPath, true, true); err != nil {
 			return err
 		}
 

--- a/cmd/system/prometheus.go
+++ b/cmd/system/prometheus.go
@@ -90,7 +90,7 @@ func MakeInstallPrometheus() *cobra.Command {
 		defer os.RemoveAll(tempUnpackPath)
 
 		fmt.Printf("Unpacking binaries to: %s\n", tempUnpackPath)
-		if err := archive.Untar(f, tempUnpackPath, true); err != nil {
+		if err := archive.Untar(f, tempUnpackPath, true, true); err != nil {
 			return err
 		}
 

--- a/pkg/get/download.go
+++ b/pkg/get/download.go
@@ -205,7 +205,7 @@ func decompress(tool *Tool, downloadURL, outFilePath, operatingSystem, arch, ver
 	forceQuiet := true
 
 	if strings.HasSuffix(downloadURL, "tar.gz") || strings.HasSuffix(downloadURL, "tgz") {
-		if err := archive.Untar(archiveFile, outFilePathDir, forceQuiet); err != nil {
+		if err := archive.Untar(archiveFile, outFilePathDir, true, forceQuiet); err != nil {
 			return "", err
 		}
 	} else if strings.HasSuffix(downloadURL, "zip") {


### PR DESCRIPTION


Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add gzip true/false option in the Untar function to support reading tar files that are not gzip-compressed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to allow us to use the archive package in the faas-cli to untar plugins.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified the arkade get and various system apps that use the `Untar` function are still working.

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
