### PR TITLE
Add a flag to deploy OpenFaaS Pro with JetStream

### DIFF
--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -157,7 +157,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		overrides["queueWorker.replicas"] = fmt.Sprintf("%d", queueWorkers)
 		overrides["queueWorker.maxInflight"] = fmt.Sprintf("%d", maxInflight)
 		overrides["autoscaler.enabled"] = strconv.FormatBool(autoscaler)
-		overrides["dashboard.enabled"] = strconv.FormatBool(autoscaler)
+		overrides["dashboard.enabled"] = strconv.FormatBool(dashboard)
 		overrides["dashboard.publicURL"] = "http://127.0.0.1:8080"
 
 		// the value in the template is "basic_auth" not the more usual basicAuth

--- a/cmd/apps/openfaas_app.go
+++ b/cmd/apps/openfaas_app.go
@@ -46,6 +46,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 	openfaas.Flags().Bool("clusterrole", false, "Create a ClusterRole for OpenFaaS instead of a limited scope Role")
 	openfaas.Flags().Bool("direct-functions", false, "Invoke functions directly from the gateway, or load-balance via endpoint IPs when set to false")
 	openfaas.Flags().Bool("autoscaler", false, "Deploy OpenFaaS with the autoscaler enabled")
+	openfaas.Flags().Bool("jetstream", false, "Deploy OpenFaaS with jetstream queue mode")
 	openfaas.Flags().Bool("dashboard", false, "Deploy OpenFaaS with the dashboard enabled")
 
 	openfaas.Flags().Int("queue-workers", 1, "Replicas of queue-worker for HA")
@@ -76,6 +77,7 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		clusterRole, _ := command.Flags().GetBool("clusterrole")
 		directFunctions, _ := command.Flags().GetBool("direct-functions")
 		autoscaler, _ := command.Flags().GetBool("autoscaler")
+		jetstream, _ := command.Flags().GetBool("jetstream")
 		dashboard, _ := command.Flags().GetBool("dashboard")
 		gateways, _ := command.Flags().GetInt("gateways")
 		maxInflight, _ := command.Flags().GetInt("max-inflight")
@@ -167,6 +169,10 @@ func MakeInstallOpenFaaS() *cobra.Command {
 			overrides["serviceType"] = "LoadBalancer"
 		}
 
+		if jetstream {
+			overrides["queueMode"] = "jetstream"
+		}
+
 		customFlags, _ := command.Flags().GetStringArray("set")
 		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err
@@ -228,6 +234,11 @@ func MakeInstallOpenFaaS() *cobra.Command {
 		}
 
 		_, err = cmd.Flags().GetBool("autoscaler")
+		if err != nil {
+			return err
+		}
+
+		_, err = cmd.Flags().GetBool("jetstream")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a new flag `--jetstream` to the openfaas app to enable the `jetstream` queue mode. 

Fixes a bug with the `dashboard flag`. The value of the autoscaler flag was used to
enable the dashboard instead of the actual value for the dashboard flag.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

Closes #805 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Deployed OpenFaaS Pro using the new `--jetstream` flag:

```bash
./arkade install openfaas \
  --license-file ~/.openfaas/LICENSE \
  --jetstream
```

Verified the openfaas deployment and checked nats and the queue-worker are using the image:

```bash
kubectl get deploy -n openfaas -o wide

NAME                READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS           IMAGES                                                                   SELECTOR
basic-auth-plugin   1/1     1            1           6s    basic-auth-plugin    ghcr.io/openfaas/basic-auth:0.25.2                                       app=basic-auth-plugin
queue-worker        1/1     1            1           6s    queue-worker         ghcr.io/openfaasltd/jetstream-queue-worker:0.2.3                         app=queue-worker
gateway             1/1     1            1           6s    gateway,faas-netes   ghcr.io/openfaasltd/gateway:0.2.5,ghcr.io/openfaasltd/faas-netes:0.2.1   app=gateway
prometheus          1/1     1            1           6s    prometheus           prom/prometheus:v2.38.0                                                  app=prometheus
alertmanager        1/1     1            1           6s    alertmanager         prom/alertmanager:v0.24.0                                                app=alertmanager
nats                1/1     1            1           6s    nats                 nats:2.9.2                                                               app=nats
```

Deploy OpenFaas Pro using the `--dashboard` flag:

```bash
./arkade install openfaas \
  --clusterrole
  --license-file ~/.openfaas/LICENSE \
  --jetstream
```

Verified the dashboard was deployed:

```bash
kubectl get deploy -n openfaas

NAME                READY   UP-TO-DATE   AVAILABLE   AGE
basic-auth-plugin   1/1     1            1           34s
prometheus          1/1     1            1           34s
nats                1/1     1            1           34s
alertmanager        1/1     1            1           34s
dashboard           1/1     1            1           34s
queue-worker        1/1     1            1           34s
gateway             1/1     1            1           34s
```

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [x] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
