### PR TITLE
feat: Upgrade container images within YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,64 @@ There are no special steps required, just install the binary and run the command
 
 See also: [alexellis/setup-arkade@master](https://github.com/alexellis/setup-arkade)
 
+## Upgrade Helm chart images from within a values.yaml file
+
+With the command `arkade chart upgrade` you can upgrade the image tags of a Helm chart from within a values.yaml file to the latest available semantically versioned image.
+
+Original YAML file:
+
+```yaml
+stan:
+  # Image used for nats deployment when using async with NATS-Streaming.
+  image: nats-streaming:0.24.6
+```
+
+Running the command with `--verbose` prints the upgraded tags to stderr, allowing the output to stdout to be piped to a file.
+
+```bash
+arkade chart upgrade -f \
+  ~/go/src/github.com/openfaas/faas-netes/chart/openfaas/values.yaml \
+  --verbose
+
+2023/01/03 10:12:47 Verifying images in: /home/alex/go/src/github.com/openfaas/faas-netes/chart/openfaas/values.yaml
+2023/01/03 10:12:47 Found 18 images
+2023/01/03 10:12:48 [natsio/prometheus-nats-exporter] 0.8.0 => 0.10.1
+2023/01/03 10:12:50 [nats-streaming] 0.24.6 => 0.25.2
+2023/01/03 10:12:52 [prom/prometheus] v2.38.0 => 2.41.0
+2023/01/03 10:12:54 [prom/alertmanager] v0.24.0 => 0.25.0
+2023/01/03 10:12:54 [nats] 2.9.2 => 2.9.10
+```
+
+Updated YAML file printed to console:
+
+```yaml
+stan:
+  # Image used for nats deployment when using async with NATS-Streaming.
+  image: nats-streaming:0.25.2
+```
+
+Write the updated image tags back to the file:
+
+```bash
+arkade chart upgrade -f \
+  ~/go/src/github.com/openfaas/faasd/docker-compose.yaml \
+  --write
+```
+
+Supported:
+
+* `image:` - at the top level
+* `component.image:` i.e. one level of nesting
+* Docker Hub and GitHub Container Registry
+
+Not supported yet:
+* Custom strings that don't match the word "image": `clientImage: `
+* Split fields for the image and tag name i.e. `image.name` and `image.tag`
+* Third-level nesting `openfaas.gateway.image`
+
 ## Validate Helm chart images from within a values.yaml file
 
-The `arkade chart validate` command validates that all images specified are accessible on a remote registry and takes a values.yaml file as its input.
+The `arkade chart verify` command validates that all images specified are accessible on a remote registry and takes a values.yaml file as its input.
 
 Successful checking of a chart with `image: ghcr.io/openfaas/cron-connector:TAG`:
 

--- a/cmd/chart/chart.go
+++ b/cmd/chart/chart.go
@@ -25,6 +25,7 @@ func MakeChart() *cobra.Command {
 	}
 
 	command.AddCommand(MakeVerify())
+	command.AddCommand(MakeUpgrade())
 
 	return command
 }

--- a/cmd/chart/upgrade.go
+++ b/cmd/chart/upgrade.go
@@ -1,0 +1,142 @@
+package chart
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/spf13/cobra"
+)
+
+func MakeUpgrade() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade all images in a values.yaml file to the latest version",
+		Long: `Upgrade all images in a values.yaml file to the latest version.
+Container images must be specified at the top level, or one level down in the 
+"image: " or "component.image: " field in a values.yaml file.
+
+Returns exit code zero if all images were found on the remote registry.
+
+Otherwise, it returns a non-zero exit code and the updated values.yaml file.`,
+		Example: `arkade upgrade -f ./chart/values.yaml
+  arkade upgrade --verbose -f ./chart/values.yaml`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().StringP("file", "f", "", "Path to values.yaml file")
+	command.Flags().BoolP("verbose", "v", false, "Verbose output")
+	command.Flags().BoolP("write", "w", false, "Write the updated values back to the file, or stdout when set to false")
+	command.Flags().IntP("depth", "d", 3, "how many levels deep into the YAML structure to walk looking for image: tags")
+
+	command.PreRunE = func(cmd *cobra.Command, args []string) error {
+		_, err := cmd.Flags().GetInt("depth")
+		if err != nil {
+			return fmt.Errorf("error with --depth usage: %s", err)
+		}
+		return nil
+	}
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		file, err := cmd.Flags().GetString("file")
+		if err != nil {
+			return fmt.Errorf("invalid value for flag --file")
+		}
+
+		writeFile, _ := cmd.Flags().GetBool("write")
+
+		verbose, _ := cmd.Flags().GetBool("verbose")
+		depth, _ := cmd.Flags().GetInt("depth")
+
+		if len(file) == 0 {
+			return fmt.Errorf("flag --file is required")
+		}
+
+		if ext := path.Ext(file); ext != ".yaml" && ext != ".yml" {
+			return fmt.Errorf("--file must be a YAML file")
+		}
+
+		if verbose {
+			log.Printf("Verifying images in: %s\n", file)
+		}
+
+		values, err := helm.Load(file)
+		if err != nil {
+			return err
+		}
+
+		filtered := helm.FilterImagesUptoDepth(values, depth)
+		if len(filtered) == 0 {
+			return fmt.Errorf("no images found in %s", file)
+		}
+
+		if verbose {
+			if len(filtered) > 0 {
+				log.Printf("Found %d images\n", len(filtered))
+			}
+		}
+
+		updated := 0
+		for k := range filtered {
+
+			imageName, tag := splitImageName(k)
+			ref, err := crane.ListTags(imageName)
+			if err != nil {
+				return errors.New("unable to list tags for " + imageName)
+			}
+
+			var vs []*semver.Version
+			for _, r := range ref {
+				v, err := semver.NewVersion(r)
+				if err == nil {
+					vs = append(vs, v)
+				}
+			}
+
+			sort.Sort(sort.Reverse(semver.Collection(vs)))
+
+			latestTag := vs[0].String()
+
+			if latestTag != tag {
+				updated++
+				filtered[k] = fmt.Sprintf("%s:%s", imageName, latestTag)
+				if verbose {
+					log.Printf("[%s] %s => %s", imageName, tag, latestTag)
+				}
+			}
+		}
+
+		rawValues, err := helm.ReplaceValuesInHelmValuesFile(filtered, file)
+		if err != nil {
+			return err
+		}
+
+		if updated > 0 && writeFile {
+			if err := os.WriteFile(file, []byte(rawValues), 0600); err != nil {
+				return err
+			}
+			log.Printf("Wrote %d updates to: %s", updated, file)
+		}
+
+		if !writeFile {
+			// Output updated YAML file to stdout
+			fmt.Print(rawValues)
+		}
+
+		return nil
+	}
+
+	return command
+}
+
+func splitImageName(reposName string) (string, string) {
+	nameParts := strings.SplitN(reposName, ":", 2)
+	return nameParts[0], nameParts[1]
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/crypto v0.4.0
 	golang.org/x/mod v0.7.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

AE: Fix bugs in PR, tested with OpenFaaS chart and saw correct upgrade statements printed.

Signed-off-by: Engin Diri <engin.diri@ediri.de>
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Example with faasd and docker-compose.yaml:

```bash
go build && ./arkade chart upgrade -f ~/go/src/github.com/openfaas/faasd/docker-compose.yaml  -v
2023/01/03 10:11:59 Verifying images in: /home/alex/go/src/github.com/openfaas/faasd/docker-compose.yaml
2023/01/03 10:11:59 Found 5 images
2023/01/03 10:12:00 [ghcr.io/openfaas/queue-worker] 0.13.1 => 0.13.2
2023/01/03 10:12:00 [ghcr.io/openfaas/basic-auth] 0.25.2 => 0.25.5
2023/01/03 10:12:01 [docker.io/library/nats-streaming] 0.24.6 => 0.25.2
2023/01/03 10:12:01 [docker.io/prom/prometheus] v2.38.0 => 2.41.0
2023/01/03 10:12:02 [ghcr.io/openfaas/gateway] 0.25.2 => 0.25.5
version: "3.7"
services:
  basic-auth-plugin:
    image: ghcr.io/openfaas/basic-auth:0.25.5
    environment:
      - port=8080
      - secret_mount_path=/run/secrets
      - user_filename=basic-auth-user
      - pass_filename=basic-auth-password
    volumes:
      # we assume cwd == /var/lib/faasd
```

Example with OpenFaaS CE:

```bash
go build && ./arkade chart upgrade -f ~/go/src/github.com/openfaas/faas-netes/chart/openfaas/values.yaml  -v
2023/01/03 10:12:47 Verifying images in: /home/alex/go/src/github.com/openfaas/faas-netes/chart/openfaas/values.yaml
2023/01/03 10:12:47 Found 18 images
2023/01/03 10:12:48 [natsio/prometheus-nats-exporter] 0.8.0 => 0.10.1
2023/01/03 10:12:50 [nats-streaming] 0.24.6 => 0.25.2
2023/01/03 10:12:52 [prom/prometheus] v2.38.0 => 2.41.0
2023/01/03 10:12:54 [prom/alertmanager] v0.24.0 => 0.25.0
2023/01/03 10:12:54 [nats] 2.9.2 => 2.9.10

# monitoring and auto-scaling components
# both components
prometheus:
  image: prom/prometheus:2.41.0
  create: true
  resources:
    requests:
      memory: "512Mi"
  annotations: {}

alertmanager:
  image: prom/alertmanager:0.25.0
  create: true
  resources:
    requests:
      memory: "25Mi"
    limits:
      memory: "50Mi"

stan:
  # Image used for nats deployment when using async with NATS-Streaming.
  image: nats-streaming:0.25.2

# NATS is required for async
nats:
  channel: "faas-request"
  # Stream replication is set to 1 by default. This is only recommended for development.
  # For production a value of at least 3 is recommended for NATS JetStream to be resilient.
  # See https://github.com/openfaas/openfaas-pro/blob/master/jetstream.md
  streamReplication: 1
  external:
    clusterName: ""
    enabled: false
    host: ""
    port: ""
  image: nats:2.9.10
  enableMonitoring: false
  metrics:
    # Should stay off by default because the exporter is not multi-arch (yet)
    enabled: false
    image: natsio/prometheus-nats-exporter:0.10.1
  resources:
    requests:
      memory: "120Mi"
```

Additionally, writing back to the original file:

```bash
arkade chart upgrade -f \
  ~/go/src/github.com/openfaas/faasd/docker-compose.yaml \
  --write
```