### PR TITLE
Fix krew on Apple silicon

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -3317,12 +3317,6 @@ func Test_DownloadKrew(t *testing.T) {
 		},
 		{
 			os:      "darwin",
-			arch:    archARM64,
-			version: "v0.4.3",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
-		},
-		{
-			os:      "darwin",
 			arch:    archDarwinARM64,
 			version: "v0.4.3",
 			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
@@ -3350,18 +3344,6 @@ func Test_DownloadKrew(t *testing.T) {
 			arch:    arch64bit,
 			version: "v0.4.3",
 			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-windows_amd64.tar.gz`,
-		},
-		{
-			os:      "ming",
-			arch:    archARM64,
-			version: "v0.4.3",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
-		},
-		{
-			os:      "ming",
-			arch:    archDarwinARM64,
-			version: "v0.4.3",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
 		},
 	}
 

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -3312,38 +3312,56 @@ func Test_DownloadKrew(t *testing.T) {
 		{
 			os:      "darwin",
 			arch:    arch64bit,
-			version: "v0.4.2",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.2/krew-darwin_amd64.tar.gz`,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_amd64.tar.gz`,
 		},
 		{
 			os:      "darwin",
 			arch:    archARM64,
-			version: "v0.4.2",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.2/krew-darwin_arm64.tar.gz`,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
-			version: "v0.4.2",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.2/krew-linux_arm64.tar.gz`,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-linux_arm64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
-			version: "v0.4.2",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.2/krew-linux_amd64.tar.gz`,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-linux_amd64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    archARM7,
-			version: "v0.4.2",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.2/krew-linux_arm.tar.gz`,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-linux_arm.tar.gz`,
 		},
 		{
 			os:      "ming",
 			arch:    arch64bit,
-			version: "v0.4.2",
-			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.2/krew-windows_amd64.tar.gz`,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-windows_amd64.tar.gz`,
+		},
+		{
+			os:      "ming",
+			arch:    archARM64,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
+		},
+		{
+			os:      "ming",
+			arch:    archDarwinARM64,
+			version: "v0.4.3",
+			url:     `https://github.com/kubernetes-sigs/krew/releases/download/v0.4.3/krew-darwin_arm64.tar.gz`,
 		},
 	}
 
@@ -3354,7 +3372,7 @@ func Test_DownloadKrew(t *testing.T) {
 				t.Fatal(err)
 			}
 			if got != tc.url {
-				t.Errorf("want: %s, got: %s", tc.url, got)
+				t.Errorf("want: %s for %s on %s, got: %s", tc.url, tc.os, tc.arch, got)
 			}
 		})
 	}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1028,9 +1028,7 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			{{$osStr = "darwin_amd64"}}
 			{{- end -}}
 			{{ else if HasPrefix .OS "ming" -}}
-			{{-  if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
-			{{$osStr = "darwin_arm64"}}
-			{{- else if eq .Arch "x86_64" -}}
+			{{- if eq .Arch "x86_64" -}}
 			{{$osStr ="windows_amd64"}}
 			{{- end -}}
 			{{- end -}}
@@ -1052,9 +1050,7 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			{{$osStr = "darwin_amd64"}}
 			{{- end -}}
 			{{ else if HasPrefix .OS "ming" -}}
-			{{-  if  or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
-			{{$osStr = "darwin_arm64"}}
-			{{- else if eq .Arch "x86_64" -}}
+			{{-  if eq .Arch "x86_64" -}}
 			{{$osStr ="windows_amd64"}}
 			{{- end -}}
 			{{- end -}}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1139,7 +1139,7 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 	{{$os = "windows"}}
 	{{- end -}}
 
-	{{.Version}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.tar.gz`,
+	{{.Version}}/{{.Name}}_v{{.VersionNumber}}_{{$os}}_{{$arch}}.tar.gz`,
 		})
 
 	tools = append(tools,

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1022,13 +1022,13 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			{{$osStr = "linux_arm64"}}
 			{{- end -}}
 			{{- else if eq .OS "darwin" -}}
-			{{-  if eq .Arch "aarch64" -}}
+			{{-  if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
 			{{$osStr = "darwin_arm64"}}
 			{{- else if eq .Arch "x86_64" -}}
 			{{$osStr = "darwin_amd64"}}
 			{{- end -}}
 			{{ else if HasPrefix .OS "ming" -}}
-			{{-  if eq .Arch "aarch64" -}}
+			{{-  if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
 			{{$osStr = "darwin_arm64"}}
 			{{- else if eq .Arch "x86_64" -}}
 			{{$osStr ="windows_amd64"}}
@@ -1046,13 +1046,13 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			{{$osStr = "linux_arm64"}}
 			{{- end -}}
 			{{- else if eq .OS "darwin" -}}
-			{{-  if eq .Arch "aarch64" -}}
+			{{-  if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
 			{{$osStr = "darwin_arm64"}}
 			{{- else if eq .Arch "x86_64" -}}
 			{{$osStr = "darwin_amd64"}}
 			{{- end -}}
 			{{ else if HasPrefix .OS "ming" -}}
-			{{-  if eq .Arch "aarch64" -}}
+			{{-  if  or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
 			{{$osStr = "darwin_arm64"}}
 			{{- else if eq .Arch "x86_64" -}}
 			{{$osStr ="windows_amd64"}}


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Adds `arm64` for `darwin` into the tool templates as #836 looks like a possible Apple silicon gap.
There was a `darwin_arm64` entry under the `ming` path in the template, so the `or` has been added in there too.

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer

Might fix #836 - would have been more certain had @bayeslearner completed the issue template.

## How Has This Been Tested?
Added unit tests but haven't been able to test as I don't have apple silicon.  Maybe @bayeslearner can help?  [Here's how](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md#test-other-peoples-prs)

## Are you a GitHub Sponsor yet (Yes/No?)

- [ ] Yes
- [x] No

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
