### PR TITLE
clusterawsadm: rm ming/arm64 test

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -5617,12 +5617,6 @@ func Test_DownloaClusterawsadm(t *testing.T) {
 			version: toolVersion,
 			url:     `https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.0.2/clusterawsadm-windows-amd64.exe`,
 		},
-		{
-			os:      "ming",
-			arch:    archARM64,
-			version: toolVersion,
-			url:     `https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.0.2/clusterawsadm-windows-arm64.exe`,
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Signed-off-by: Maria Kotlyarevskaya <mariia.kotliarevskaia@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Arkade doesn't support the following combination: ming/arm64. Therefore it should be deleted from the test to avoid confusion. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
./hack/test-tool.sh clusterawsadm
+ go build
+ ./arkade get clusterawsadm --arch arm64 --os darwin --quiet
+ file /Users/mariarti/.arkade/bin/clusterawsadm
/Users/mariarti/.arkade/bin/clusterawsadm: Mach-O 64-bit executable arm64
+ rm /Users/mariarti/.arkade/bin/clusterawsadm
+ ./arkade get clusterawsadm --arch x86_64 --os darwin --quiet
+ file /Users/mariarti/.arkade/bin/clusterawsadm
/Users/mariarti/.arkade/bin/clusterawsadm: Mach-O 64-bit executable x86_64
+ rm /Users/mariarti/.arkade/bin/clusterawsadm
+ ./arkade get clusterawsadm --arch x86_64 --os linux --quiet
+ file /Users/mariarti/.arkade/bin/clusterawsadm
/Users/mariarti/.arkade/bin/clusterawsadm: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=gfqa2F9gKJSuKT95pBmO/K8TSQ6j4PPFOifOCgR2H/urUe3YYhPUYNk08fPn41/4I9Ao1qu_qqOAt8Chm8h, not stripped
+ rm /Users/mariarti/.arkade/bin/clusterawsadm
+ ./arkade get clusterawsadm --arch arm64 --os linux --quiet
+ file /Users/mariarti/.arkade/bin/clusterawsadm
/Users/mariarti/.arkade/bin/clusterawsadm: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=QqjhqN784f-FzDJ1MC94/v1OexFXZh218FxNp0YbI/t4m8n1La9o3aUMjW2xRT/rVtGJFIlQGNtO39xwB_K, not stripped
+ rm /Users/mariarti/.arkade/bin/clusterawsadm
+ ./arkade get clusterawsadm --arch x86_64 --os ming --quiet
+ file /Users/mariarti/.arkade/bin/clusterawsadm
/Users/mariarti/.arkade/bin/clusterawsadm: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
+ rm /Users/mariarti/.arkade/bin/clusterawsadm
```

```bash
make e2e
..
PASS
coverage: 55.6% of statements
ok      github.com/alexellis/arkade/pkg/get     16.570s coverage: 55.6% of statements
```

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
