### PR TITLE
Grafana agent changed its download URL

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -5369,7 +5369,7 @@ func Test_DownloadFirectl(t *testing.T) {
 func Test_GrafanaAgent(t *testing.T) {
 	tools := MakeTools()
 	name := "grafana-agent"
-	version := "v0.29.0"
+	version := "v0.31.0"
 
 	tool := getTool(name, tools)
 
@@ -5378,31 +5378,31 @@ func Test_GrafanaAgent(t *testing.T) {
 			os:      "linux",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.29.0/agent-linux-amd64.zip",
+			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-linux-amd64.zip",
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.29.0/agent-linux-arm64.zip",
+			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-linux-arm64.zip",
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.29.0/agent-darwin-amd64.zip",
+			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-darwin-amd64.zip",
 		},
 		{
 			os:      "darwin",
 			arch:    archDarwinARM64,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.29.0/agent-darwin-arm64.zip",
+			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-darwin-arm64.zip",
 		},
 		{
 			os:      "ming",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.29.0/agent-windows-amd64.exe.zip",
+			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-windows-amd64.exe.zip",
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -3074,7 +3074,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 						{{$os = "windows"}}
 						{{$ext = ".exe.zip"}}
 						{{- end -}}
-						https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/agent-{{$os}}-{{$arch}}{{$ext}}
+						https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/grafana-agent-{{$os}}-{{$arch}}{{$ext}}
 						`,
 			BinaryTemplate: `
 						{{$os := .OS}}
@@ -3095,7 +3095,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 						{{$os = "windows"}}
 						{{$ext = ".exe"}}
 						{{- end -}}
-						agent-{{$os}}-{{$arch}}{{$ext}}
+						grafana-agent-{{$os}}-{{$arch}}{{$ext}}
 						`,
 		})
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Grafana agent changed its download URL

## Motivation and Context

Fixes broken e2e tests due to the grafana agent being renamed from agent to grafana-agent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<img width="1552" alt="Screenshot 2023-02-01 at 08 26 27" src="https://user-images.githubusercontent.com/6358735/215990456-fb7256de-bd9a-43b4-832e-790e17915462.png">

Tested by running e2e tests and unit tests, the binary downloaded had the new name and worked on my Mac M1.

