### PR TITLE
Add user-agent to all HTTP requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 Version := $(shell git describe --tags --dirty)
 GitCommit := $(shell git rev-parse HEAD)
-LDFLAGS := "-s -w -X github.com/alexellis/arkade/cmd.Version=$(Version) -X github.com/alexellis/arkade/cmd.GitCommit=$(GitCommit)"
+LDFLAGS := "-s -w -X github.com/alexellis/arkade/pkg.Version=$(Version) -X github.com/alexellis/arkade/pkg.GitCommit=$(GitCommit)"
 PLATFORM := $(shell ./hack/platform-tag.sh)
 SOURCE_DIRS = cmd pkg main.go
 export GO111MODULE=on
@@ -27,12 +27,12 @@ e2e:
 .PHONY: dist
 dist:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade
-	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade-darwin
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS)  -o bin/arkade
+	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS)  -o bin/arkade-darwin
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -ldflags $(LDFLAGS) -installsuffix cgo -o bin/arkade-darwin-arm64
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade-armhf
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade-arm64
-	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/arkade.exe
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS)  -o bin/arkade-armhf
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS)  -o bin/arkade-arm64
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags $(LDFLAGS)  -o bin/arkade.exe
 
 .PHONY: hash
 hash:

--- a/cmd/system/go.go
+++ b/cmd/system/go.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/archive"
 	"github.com/alexellis/arkade/pkg/env"
 	"github.com/alexellis/arkade/pkg/get"
@@ -112,6 +113,8 @@ func getGoVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	req.Header.Set("User-Agent", pkg.UserAgent())
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/cmd/system/node.go
+++ b/cmd/system/node.go
@@ -2,23 +2,33 @@ package system
 
 import (
 	"fmt"
-	"github.com/alexellis/arkade/pkg/archive"
-	"github.com/alexellis/arkade/pkg/env"
-	"github.com/alexellis/arkade/pkg/get"
-	cp "github.com/otiai10/copy"
-	"github.com/spf13/cobra"
 	"io"
 	"net/http"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/archive"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/get"
+	cp "github.com/otiai10/copy"
+	"github.com/spf13/cobra"
 )
 
 func getLatestNodeVersion(version, channel string) (*string, error) {
-	res, err := http.Get(fmt.Sprintf("https://nodejs.org/download/%s/%s", channel, version))
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://nodejs.org/download/%s/%s", channel, version), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Set("User-Agent", pkg.UserAgent())
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,11 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	Version   string
-	GitCommit string
-)
-
 func PrintArkadeASCIIArt() {
 	arkadeLogo := aec.BlueF.Apply(arkadeFigletStr)
 	fmt.Print(arkadeLogo)
@@ -31,12 +26,12 @@ func MakeVersion() *cobra.Command {
 	}
 	command.Run = func(cmd *cobra.Command, args []string) {
 		PrintArkadeASCIIArt()
-		if len(Version) == 0 {
+		if len(pkg.Version) == 0 {
 			fmt.Println("Version: dev")
 		} else {
-			fmt.Println("Version:", Version)
+			fmt.Println("Version:", pkg.Version)
 		}
-		fmt.Println("Git Commit:", GitCommit)
+		fmt.Println("Git Commit:", pkg.GitCommit)
 
 		fmt.Println("\n", aec.Bold.Apply(pkg.SupportMessageShort))
 	}

--- a/pkg/get/download.go
+++ b/pkg/get/download.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/archive"
 	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/env"
@@ -24,7 +25,7 @@ const (
 type ErrNotFound struct{}
 
 func (e *ErrNotFound) Error() string {
-	return fmt.Sprintf("incorrect status for downloading tool: 404")
+	return "incorrect status for downloading tool: 404"
 }
 
 func Download(tool *Tool, arch, operatingSystem, version string, downloadMode int, displayProgress, quiet bool) (string, string, error) {
@@ -97,7 +98,15 @@ func DownloadFileP(downloadURL string, displayProgress bool) (string, error) {
 }
 
 func downloadFile(downloadURL string, displayProgress bool) (string, error) {
-	res, err := http.DefaultClient.Get(downloadURL)
+
+	req, err := http.NewRequest(http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", pkg.UserAgent())
+
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -13,6 +13,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/env"
 )
 
@@ -113,6 +114,8 @@ func (tool Tool) Head(uri string) (int, string, http.Header, error) {
 		return http.StatusBadRequest, "", nil, err
 	}
 
+	req.Header.Set("User-Agent", pkg.UserAgent())
+
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return http.StatusBadRequest, "", nil, err
@@ -195,6 +198,8 @@ func FindGitHubRelease(owner, repo string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	req.Header.Set("User-Agent", pkg.UserAgent())
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -1,0 +1,12 @@
+package pkg
+
+import "fmt"
+
+var (
+	Version,
+	GitCommit string
+)
+
+func UserAgent() string {
+	return fmt.Sprintf("arkade/%s", Version)
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add user-agent to all HTTP requests

## Motivation and Context

This is generally required to be a good citizen on the Internet, and may be causing "arkade system install node" to fail in GitHub Actions.

I also moved where the version gets injected into - from cmd to pkg, for re-use within pkg.

After `make dist`, I got:

```
./bin/arkade version
            _             _      
  __ _ _ __| | ____ _  __| | ___ 
 / _` | '__| |/ / _` |/ _` |/ _ \
| (_| | |  |   < (_| | (_| |  __/
 \__,_|_|  |_|\_\__,_|\__,_|\___|

Open Source Marketplace For Developer Tools

Version: 0.8.54-32-gb774bf3
Git Commit: b774bf3510f7b8afac2ad78b810e72180a4a1585
```

## How Has This Been Tested?

```
go run . get k3s --quiet --progress=false; echo $?
0

go run . system i node --path /tmp/n --progress=false ; echo $?
Installing Node.js to /tmp/n
Installing version: v19.6.1 for: x64
Downloading from: https://nodejs.org/download/release/v19.6.1/node-v19.6.1-linux-x64.tar.gz
Downloaded to: /tmp/node-v19.6.1-linux-x64.tar.gz
Unpacking binaries to: /tmp/node395626836
2023/02/21 11:51:37 extracted tarball into /tmp/node395626836: 4348 files, 1023 dirs (842.053343ms)
Copying binaries to: /tmp/n
0
```

I then ran make e2e which passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
