### PR TITLE
Added cert-manager's CLI tool cmctl to arkade get

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ There are 56 apps that you can install on your cluster.
 | [civo](https://github.com/civo/cli)                                          | CLI for interacting with your Civo resources.                                                                                             |
 | [clusterawsadm](https://github.com/kubernetes-sigs/cluster-api-provider-aws) | Kubernetes Cluster API Provider AWS Management Utility                                                                                    |
 | [clusterctl](https://github.com/kubernetes-sigs/cluster-api)                 | The clusterctl CLI tool handles the lifecycle of a Cluster API management cluster                                                         |
+| [cmctl](https://github.com/cert-manager/cert-manager)                        | cmctl is a CLI tool that helps you manage cert-manager and its resources inside your cluster.                                             |
 | [conftest](https://github.com/open-policy-agent/conftest)                    | Write tests against structured configuration data using the Open Policy Agent Rego query language                                         |
 | [cosign](https://github.com/sigstore/cosign)                                 | Container Signing, Verification and Storage in an OCI registry.                                                                           |
 | [cr](https://github.com/helm/chart-releaser)                                 | Hosting Helm Charts via GitHub Pages and Releases                                                                                         |
@@ -798,7 +799,7 @@ There are 56 apps that you can install on your cluster.
 | [viddy](https://github.com/sachaos/viddy)                                    | A modern watch command. Time machine and pager etc.                                                                                       |
 | [waypoint](https://github.com/hashicorp/waypoint)                            | Easy application deployment for Kubernetes and Amazon ECS                                                                                 |
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                     |
-There are 120 tools, use `arkade get NAME` to download one.
+There are 121 tools, use `arkade get NAME` to download one.
 
 
 

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -5687,3 +5687,61 @@ func Test_DownloaCroc(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadCmctl(t *testing.T) {
+	tools := MakeTools()
+	name := "cmctl"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v1.11.0"
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cmctl-linux-amd64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cmctl-darwin-amd64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     `https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cmctl-linux-arm64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     `https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cmctl-darwin-arm64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     `https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cmctl-linux-arm.tar.gz`,
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cmctl-windows-amd64.zip`,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -3241,5 +3241,32 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 					croc_{{.VersionNumber}}_{{$os}}-{{$arch}}.{{$ext}}
 					`,
 		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "cert-manager",
+			Repo:        "cert-manager",
+			Name:        "cmctl",
+			Description: "cmctl is a CLI tool that helps you manage cert-manager and its resources inside your cluster.",
+			BinaryTemplate: `
+					{{$os := .OS}}
+					{{$arch := "arm"}}
+					{{$ext := "tar.gz"}}
+
+					{{- if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+					{{$arch = "arm64"}}
+					{{- else if eq .Arch "x86_64" -}}
+					{{$arch = "amd64"}}
+					{{- end -}}
+
+					{{ if HasPrefix .OS "ming" -}}
+					{{$os = "windows"}}
+					{{$ext = "zip"}}
+					{{- end -}}
+
+					cmctl-{{$os}}-{{$arch}}.{{$ext}}
+					`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
This commit adds support to include [cert-manager](https://cert-manager.io/)'s [`cmctl`](https://cert-manager.io/docs/reference/cmctl/) CLI tool.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
      fixes https://github.com/alexellis/arkade/issues/860

(Still waiting for approved label, although looking at the comments of the referenced issue, I think that will be a matter of time.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```sh
$ hack/test-tool.sh cmctl
+ go build
+ ./arkade get cmctl --arch arm64 --os darwin --quiet
+ file /home/hvt/.arkade/bin/cmctl
/home/hvt/.arkade/bin/cmctl: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
+ rm /home/hvt/.arkade/bin/cmctl
+ ./arkade get cmctl --arch x86_64 --os darwin --quiet
+ file /home/hvt/.arkade/bin/cmctl
/home/hvt/.arkade/bin/cmctl: Mach-O 64-bit x86_64 executable
+ rm /home/hvt/.arkade/bin/cmctl
+ ./arkade get cmctl --arch x86_64 --os linux --quiet
+ file /home/hvt/.arkade/bin/cmctl
/home/hvt/.arkade/bin/cmctl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=nG-nCP-tObexT5Ez_K1l/9hPO9PUdqlaRQdlwNefg/gP6ekwKzm-6Fq8L5eiEd/NmWYlbNsgrf_PQiT32PR, stripped
+ rm /home/hvt/.arkade/bin/cmctl
+ ./arkade get cmctl --arch arm64 --os linux --quiet
+ file /home/hvt/.arkade/bin/cmctl
/home/hvt/.arkade/bin/cmctl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=bOtx3cLkqkJs-f39L-h_/3x9eGmD4wgmWApO1c86O/IKL0BcEKMkyAW-0AAIel/BC40Adk51B5bJAXUmuTF, stripped
+ rm /home/hvt/.arkade/bin/cmctl
+ ./arkade get cmctl --arch x86_64 --os ming --quiet
+ file /home/hvt/.arkade/bin/cmctl
/home/hvt/.arkade/bin/cmctl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=bOtx3cLkqkJs-f39L-h_/3x9eGmD4wgmWApO1c86O/IKL0BcEKMkyAW-0AAIel/BC40Adk51B5bJAXUmuTF, stripped
+ rm /home/hvt/.arkade/bin/cmctl
```

(The Windows `file` output seems wrong. But this is the case for more recent additions. When I manually download the URL and `unzip` it, running `file` does give the correct output. Not sure what goes wrong here.)

## Are you a GitHub Sponsor yet (Yes/No?)

<!-- Requests from sponsors take priority -->
<!--- Check at https://github.com/sponsors/alexellis         -->

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
