### PR TITLE
chore: add cnpg plugin for kubectl

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -5687,3 +5687,61 @@ func Test_DownloaCroc(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadKubectlcnpg(t *testing.T) {
+	tools := MakeTools()
+	name := "kubectl-cnpg"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v1.19.0"
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.19.0/kubectl-cnpg_1.19.0_linux_x86_64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.19.0/kubectl-cnpg_1.19.0_darwin_x86_64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     `https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.19.0/kubectl-cnpg_1.19.0_linux_arm64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     `https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.19.0/kubectl-cnpg_1.19.0_darwin_arm64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     `https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.19.0/kubectl-cnpg_1.19.0_linux_armv7.tar.gz`,
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.19.0/kubectl-cnpg_1.19.0_windows_x86_64.tar.gz`,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -3246,5 +3246,31 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 					croc_{{.VersionNumber}}_{{$os}}-{{$arch}}.{{$ext}}
 					`,
 		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "cloudnative-pg",
+			Repo:        "cloudnative-pg",
+			Name:        "kubectl-cnpg",
+			Description: "This plugin provides multiple commands to help you manage your CloudNativePG clusters.",
+			BinaryTemplate: `
+					{{ $os := .OS }}
+					{{ $arch := .Arch }}
+
+					{{- if eq .Arch "aarch64" -}}
+					{{ $arch = "arm64" }}
+					{{- else if eq .Arch "arm64" -}}
+					{{ $arch = "arm64" }}
+					{{- else if eq .Arch "armv7l" -}}
+					{{ $arch = "armv7" }}
+					{{- end -}}
+
+					{{ if HasPrefix .OS "ming" -}}
+					{{$os = "windows"}}
+					{{- end -}}
+
+					kubectl-cnpg_{{ .VersionNumber }}_{{ $os }}_{{ $arch }}.tar.gz
+					`,
+		})
 	return tools
 }


### PR DESCRIPTION
Add the cnpg plugin for kubectl to be used with CloudNativePG operator

<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to add the cnpg pluging for kubectl to be used with CloudNativePG operator, in a future
PR we hope to provide also a way to install this operator using arkade

## Motivation and Context
The cnpg plugin can make use of Arkade to distribute the plugin

Issue  https://github.com/alexellis/arkade/issues/852

## How Has This Been Tested?
Local laptop using amd64 and RaspberryPi B4 both to install the plugin both with Linux
Local laptop using amd64 with macOS

## Are you a GitHub Sponsor yet (Yes/No?)
- [X] Yes
- [ ] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [X] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [x] I have tested this on arm, or have added code to prevent deployment
