### PR TITLE
Updating default version for tools

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -173,7 +173,7 @@ func Test_DownloadFaaSCLIDarwin(t *testing.T) {
 
 func Test_GetDownloadURLs(t *testing.T) {
 	tools := MakeTools()
-	kubectlVersion := "v1.24.2"
+	kubectlVersion := "v1.26.2"
 
 	tests := []struct {
 		name    string
@@ -226,7 +226,7 @@ func Test_GetDownloadURLs(t *testing.T) {
 		},
 		{
 			name:    "terraform",
-			url:     "https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_amd64.zip",
+			url:     "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_amd64.zip",
 			version: "1.1.7",
 			os:      "linux",
 			arch:    "x86_64",
@@ -490,7 +490,7 @@ func Test_DownloadKubens(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := "https://github.com/ahmetb/kubectx/releases/download/v0.9.1/kubens"
+	want := "https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens"
 	if got != want {
 		t.Fatalf("want: %s, got: %s", want, got)
 	}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -125,13 +125,13 @@ https://get.helm.sh/helm-{{.Version}}-{{$os}}-{{$arch}}.{{$ext}}`,
 {{.Version}}/jq-{{$os}}{{$arch}}{{$ext}}`,
 		})
 
-	// https://storage.googleapis.com/kubernetes-release/release/v1.22.2/bin/darwin/amd64/kubectl
+	// https://storage.googleapis.com/kubernetes-release/release/v1.26.2/bin/darwin/amd64/kubectl
 	tools = append(tools,
 		Tool{
 			Owner:       "kubernetes",
 			Repo:        "kubernetes",
 			Name:        "kubectl",
-			Version:     "v1.24.2",
+			Version:     "v1.26.2",
 			Description: "Run commands against Kubernetes clusters",
 			URLTemplate: `{{$arch := "arm"}}
 
@@ -172,7 +172,7 @@ https://storage.googleapis.com/kubernetes-release/release/{{.Version}}/bin/{{$os
 			Owner:          "ahmetb",
 			Repo:           "kubectx",
 			Name:           "kubens",
-			Version:        "v0.9.1",
+			Version:        "v0.9.4",
 			Description:    "Switch between Kubernetes namespaces smoothly.",
 			BinaryTemplate: `kubens`,
 			NoExtension:    true,
@@ -760,7 +760,7 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:       "hashicorp",
 			Repo:        "terraform",
 			Name:        "terraform",
-			Version:     "1.1.9",
+			Version:     "1.3.9",
 			Description: "Infrastructure as Code for major cloud providers.",
 			URLTemplate: `
 			{{$arch := ""}}


### PR DESCRIPTION
Updating the default versions of following tools: 

* kubectl to 1.26.2
* terraform to 1.3.9
* kubectx to 0.9.4


## Description

Upgraded the default version for some tools

## Motivation and Context

I've noticed that the default version of downloaded tools are now old (e.g. Terraform 1.3.9 is out - vs. the default 1.1.9 proposed). I think it's easier for someone to work by default with latest tools instead of define explicitly something new:

`arkade get terraform@1.3.9`

Instead, a older release might be retrieved specifying the command with version.


## How Has This Been Tested?
I've tested the download of the given tools with the @VERSION.

## Are you a GitHub Sponsor yet (Yes/No?)

- [ ] Yes
- [x] No

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
