### PR TITLE
bump linkerd default version

### DIFF
--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var linkerdVersion = "stable-2.11.1"
+var linkerdVersion = "stable-2.13.0"
 
 func MakeInstallLinkerd() *cobra.Command {
 	var linkerd = &cobra.Command{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
bumps the linkerd app default version

closes #864

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
https://github.com/alexellis/arkade/issues/864

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
essentially I had v1.25+ k3s cluster and run into arkade problem with linkerd due to default version being old and using batch/v1beta kind instead of batch/v1 (now probably standard in kubernetes as a kind)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [X] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [X] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
