### PR TITLE
Download binaries to separate temp directory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@
 
 ## Documentation
 
-- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
+- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
 - [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`
 
 ## Checklist:

--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ arkade get faas-cli \
 ```
 > This is a time saver compared to searching for download pages every time you need a tool.
 
+Files are stored at `$HOME/.arkade/bin/`
+
+Want to download tools to a custom path such as into the GitHub Actions cached tool folder?
+
+```bash
+arkade get faas-cli kubectl \
+  --path $HOME/runner/_work/_tools
+
+# Usage:
+/runner/_work/_tools/faas-cli version
+
+PATH=$PATH:$HOME/runner/_work/_tools
+faas-cli version
+```
 
 Think of `arkade get TOOL` as a doing for CLIs, what `arkade install` does for helm.
 
@@ -813,4 +827,4 @@ There are 56 apps that you can install on your cluster.
 There are 126 tools, use `arkade get NAME` to download one.
 
 
-> Note to contributors, run `arkade get --output markdown` to generate this list
+> Note to contributors, run `arkade get --format markdown` to generate this list

--- a/cmd/apps/istio_app.go
+++ b/cmd/apps/istio_app.go
@@ -199,8 +199,9 @@ func downloadIstio(userPath, arch, clientOS, version string) error {
 			progress bool
 			quiet    bool
 		)
+		defaultMovePath := ""
 
-		outPath, finalName, err := get.Download(tool, arch, clientOS, version, get.DownloadArkadeDir, progress, quiet)
+		outPath, finalName, err := get.Download(tool, arch, clientOS, version, defaultMovePath, progress, quiet)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/linkerd_app.go
+++ b/cmd/apps/linkerd_app.go
@@ -151,7 +151,8 @@ func downloadLinkerd(userPath, arch, clientOS, version string) error {
 			quiet    bool
 		)
 
-		outPath, finalName, err := get.Download(tool, arch, clientOS, version, get.DownloadArkadeDir, progress, quiet)
+		defaultMovePath := ""
+		outPath, finalName, err := get.Download(tool, arch, clientOS, version, defaultMovePath, progress, quiet)
 		if err != nil {
 			return err
 		}

--- a/cmd/apps/osm_app.go
+++ b/cmd/apps/osm_app.go
@@ -108,8 +108,9 @@ func downloadOSM(userPath, arch, clientOS string) error {
 			progress bool
 			quiet    bool
 		)
+		defaultMovePath := ""
 
-		outPath, finalName, err := get.Download(tool, arch, clientOS, tool.Version, get.DownloadArkadeDir, progress, quiet)
+		outPath, finalName, err := get.Download(tool, arch, clientOS, tool.Version, defaultMovePath, progress, quiet)
 		if err != nil {
 			return err
 		}

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -379,14 +379,13 @@ func PostToolNotFoundMsg(url string) string {
 }
 
 // PostInstallationMsg generates installation message after tool has been downloaded
-func PostInstallationMsg(dlMode int, localToolsStore []ToolLocal) ([]byte, error) {
+func PostInstallationMsg(movePath string, localToolsStore []ToolLocal) ([]byte, error) {
 
 	t := template.New("Installation Instructions")
 
-	if dlMode == DownloadTempDir {
+	if movePath != "" {
 		t.Parse(`Run the following to copy to install the tool:
 
-chmod +x {{range .}}{{.Path}} {{end}}
 {{- range . }}
 sudo install -m 755 {{.Path}} /usr/local/bin/{{.Name}}
 {{- end}}`)

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -82,12 +82,12 @@ func Test_MakeSureToolsAreSorted(t *testing.T) {
 func Test_PostInstallationMsg(t *testing.T) {
 
 	testCases := []struct {
-		dlMode          int
-		localToolsStore []ToolLocal
-		want            string
+		defaultDownloadDir string
+		localToolsStore    []ToolLocal
+		want               string
 	}{
 		{
-			dlMode: 1,
+			defaultDownloadDir: "",
 			localToolsStore: []ToolLocal{
 				{Name: "yq",
 					Path: "/home/user/.arkade/bin/yq",
@@ -108,31 +108,30 @@ sudo mv /home/user/.arkade/bin/yq /usr/local/bin/
 sudo mv /home/user/.arkade/bin/jq /usr/local/bin/`,
 		},
 		{
-			dlMode: 0,
+			defaultDownloadDir: "/tmp/bin/",
 			localToolsStore: []ToolLocal{
 				{Name: "yq",
-					Path: "/tmp/yq_linux_amd64",
+					Path: "/tmp/bin/yq_linux_amd64",
 				},
 				{
 					Name: "jq",
-					Path: "/tmp/jq-linux64",
+					Path: "/tmp/bin/jq-linux64",
 				}},
 			want: `Run the following to copy to install the tool:
-
-chmod +x /tmp/yq_linux_amd64 /tmp/jq-linux64 
-sudo install -m 755 /tmp/yq_linux_amd64 /usr/local/bin/yq
-sudo install -m 755 /tmp/jq-linux64 /usr/local/bin/jq`,
+sudo install -m 755 /tmp/bin/yq_linux_amd64 /usr/local/bin/yq
+sudo install -m 755 /tmp/bin/jq-linux64 /usr/local/bin/jq`,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.localToolsStore[0].Name, func(t *testing.T) {
-			msg, _ := PostInstallationMsg(tt.dlMode, tt.localToolsStore)
+			defaultDownloadDir := tt.defaultDownloadDir
+			msg, _ := PostInstallationMsg(defaultDownloadDir, tt.localToolsStore)
 
 			got := string(msg)
 
 			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
+				t.Errorf("got\n%s\n\nwant\n%s", got, tt.want)
 			}
 		})
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -66,11 +66,12 @@ func DownloadHelm(userPath, clientArch, clientOS, subdir string) error {
 			quiet    bool
 		)
 
+		defaultMovePath := ""
 		outPath, finalName, err := get.Download(tool,
 			clientArch,
 			clientOS,
 			tool.Version,
-			get.DownloadArkadeDir,
+			defaultMovePath,
 			progress,
 			quiet)
 		if err != nil {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes #911 where files were downloaded to the same directory with permissions that prevented another user from running arkade get.

The changes remove the concept of stash which I don't think was used or useful and replaces it with a default path for the current behaviour or --path to match the way that system installers work today.

## Motivation and Context

Fixes #911 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


Tested with a single download and multiple downloads via arkade get with and without a custom path. The files were executable by the owner as expected.

Default:

```
alex@bq:~/go/src/github.com/alexellis/arkade$ go run . get k9s 
Downloading: k9s
2023/05/23 11:46:10 Looking up version for k9s
2023/05/23 11:46:10 Found: v0.27.4
Downloading: https://github.com/derailed/k9s/releases/download/v0.27.4/k9s_Linux_amd64.tar.gz
17.80 MiB / 17.80 MiB [----------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/arkade-592201071/k9s_Linux_amd64.tar.gz written.
2023/05/23 11:46:10 Looking up version for k9s
2023/05/23 11:46:11 Found: v0.27.4
2023/05/23 11:46:11 Extracted: /tmp/arkade-592201071/k9s
2023/05/23 11:46:11 Copying /tmp/arkade-592201071/k9s to /home/alex/.arkade/bin/k9s

Wrote: /home/alex/.arkade/bin/k9s (60.56MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/home/alex/.arkade/bin/k9s

# Or install with:
sudo mv /home/alex/.arkade/bin/k9s /usr/local/bin/

🐳 arkade needs your support: https://github.com/sponsors/alexellis
alex@bq:~/go/src/github.com/alexellis/arkade$ ls ~/.arkade/bin/
k9s

```

Custom directory:

```
alex@bq:~/go/src/github.com/alexellis/arkade$ go run . get k9s --path /tmp/binaries/
Downloading: k9s
2023/05/23 11:45:41 Looking up version for k9s
2023/05/23 11:45:41 Found: v0.27.4
Downloading: https://github.com/derailed/k9s/releases/download/v0.27.4/k9s_Linux_amd64.tar.gz
17.80 MiB / 17.80 MiB [----------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/arkade-3900916076/k9s_Linux_amd64.tar.gz written.
2023/05/23 11:45:41 Looking up version for k9s
2023/05/23 11:45:41 Found: v0.27.4
2023/05/23 11:45:42 Extracted: /tmp/arkade-3900916076/k9s
2023/05/23 11:45:42 Copying /tmp/arkade-3900916076/k9s to /tmp/binaries/k9s

Wrote: /tmp/binaries/k9s (60.56MB)

Run the following to copy to install the tool:

sudo install -m 755 /tmp/binaries/k9s /usr/local/bin/k9s

🐳 arkade needs your support: https://github.com/sponsors/alexellis
alex@bq:~/go/src/github.com/alexellis/arkade$ ls /tmp/binaries/
k9s
```

Multiple binaries to a custom path:

```
alex@bq:~/go/src/github.com/alexellis/arkade$ go run . get kubectx kubens k9s --path /tmp/binaries/
Downloading: kubectx
2023/05/23 11:46:32 Looking up version for kubectx
2023/05/23 11:46:33 Found: v0.9.4
Downloading: https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubectx
5.96 KiB / 5.96 KiB [------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/arkade-2721537142/kubectx written.
2023/05/23 11:46:33 Looking up version for kubectx
2023/05/23 11:46:33 Found: v0.9.4
2023/05/23 11:46:33 Copying /tmp/arkade-2721537142/kubectx to /tmp/binaries/kubectx

Wrote: /tmp/binaries/kubectx (6.108kB)

Downloading: kubens
2023/05/23 11:46:33 Looking up version for kubens
2023/05/23 11:46:34 Found: v0.9.4
Downloading: https://github.com/ahmetb/kubectx/releases/download/v0.9.4/kubens
5.42 KiB / 5.42 KiB [------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/arkade-3493732447/kubens written.
2023/05/23 11:46:34 Looking up version for kubens
2023/05/23 11:46:34 Found: v0.9.4
2023/05/23 11:46:34 Copying /tmp/arkade-3493732447/kubens to /tmp/binaries/kubens

Wrote: /tmp/binaries/kubens (5.555kB)

Downloading: k9s
2023/05/23 11:46:34 Looking up version for k9s
2023/05/23 11:46:34 Found: v0.27.4
Downloading: https://github.com/derailed/k9s/releases/download/v0.27.4/k9s_Linux_amd64.tar.gz
17.80 MiB / 17.80 MiB [----------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/arkade-2472131393/k9s_Linux_amd64.tar.gz written.
2023/05/23 11:46:35 Looking up version for k9s
2023/05/23 11:46:35 Found: v0.27.4
2023/05/23 11:46:35 Extracted: /tmp/arkade-2472131393/k9s
2023/05/23 11:46:35 Copying /tmp/arkade-2472131393/k9s to /tmp/binaries/k9s

Wrote: /tmp/binaries/k9s (60.56MB)

Run the following to copy to install the tool:

sudo install -m 755 /tmp/binaries/kubectx /usr/local/bin/kubectx
sudo install -m 755 /tmp/binaries/kubens /usr/local/bin/kubens
sudo install -m 755 /tmp/binaries/k9s /usr/local/bin/k9s

🐳 arkade needs your support: https://github.com/sponsors/alexellis
alex@bq:~/go/src/github.com/alexellis/arkade$ ls /tmp/binaries/
k9s  kubectx  kubens
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

`--stash` is removed, but I don't think it was being used.

I also changed `--output/-o` to `--format` for clarity

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get -o markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`
