### PR TITLE
fix: arkade get inletsctl on linux aarch64 and mingw

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -23,7 +23,7 @@ type test struct {
 	version string
 	url     string
 	// Optional fields
-	binary  string
+	binary string
 }
 
 func getTool(name string, tools []Tool) *Tool {

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -23,7 +23,7 @@ type test struct {
 	version string
 	url     string
 	// Optional fields
-	binaryBase string
+	binary  string
 }
 
 func getTool(name string, tools []Tool) *Tool {
@@ -778,40 +778,40 @@ func Test_DownloadInletsctl(t *testing.T) {
 
 	tests := []test{
 		{os: "mingw64_nt-10.0-18362",
-			arch:       arch64bit,
-			version:    "0.8.16",
-			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.exe.tgz",
-			binaryBase: "inletsctl"},
+			arch:    arch64bit,
+			version: "0.8.16",
+			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.exe.tgz",
+			binary:  "inletsctl"},
 		{os: "darwin",
-			arch:       arch64bit,
-			version:    "0.8.16",
-			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin.tgz",
-			binaryBase: "inletsctl-darwin"},
+			arch:    arch64bit,
+			version: "0.8.16",
+			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin.tgz",
+			binary:  "inletsctl-darwin"},
 		{os: "darwin",
-			arch:       archDarwinARM64,
-			version:    "0.8.16",
-			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin-arm64.tgz",
-			binaryBase: "inletsctl-darwin-arm64"},
+			arch:    archDarwinARM64,
+			version: "0.8.16",
+			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin-arm64.tgz",
+			binary:  "inletsctl-darwin-arm64"},
 		{os: "linux",
-			arch:       arch64bit,
-			version:    "0.8.16",
-			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.tgz",
-			binaryBase: "inletsctl"},
+			arch:    arch64bit,
+			version: "0.8.16",
+			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.tgz",
+			binary:  "inletsctl"},
 		{os: "linux",
-			arch:       "armv6l",
-			version:    "0.8.16",
-			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz",
-			binaryBase: "inletsctl-armhf"},
+			arch:    "armv6l",
+			version: "0.8.16",
+			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz",
+			binary:  "inletsctl-armhf"},
 		{os: "linux",
-			arch:       "armv7l",
-			version:    "0.8.16",
-			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz",
-			binaryBase: "inletsctl-armhf"},
+			arch:    "armv7l",
+			version: "0.8.16",
+			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz",
+			binary:  "inletsctl-armhf"},
 		{os: "linux",
-			arch:       archARM64,
-			version:    "0.8.16",
-			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-arm64.tgz",
-			binaryBase: "inletsctl-arm64"},
+			arch:    archARM64,
+			version: "0.8.16",
+			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-arm64.tgz",
+			binary:  "inletsctl-arm64"},
 	}
 	for _, tc := range tests {
 		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
@@ -821,12 +821,12 @@ func Test_DownloadInletsctl(t *testing.T) {
 		if got != tc.url {
 			t.Errorf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, tc.url, got)
 		}
-		name, err := GetBinaryName(tool, tc.os, tc.arch, tc.version)
+		binary, err := GetBinaryName(tool, tc.os, tc.arch, tc.version)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if name != tc.binaryBase {
-			t.Errorf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, tc.binaryBase, name)
+		if binary != tc.binary {
+			t.Errorf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, tc.binary, binary)
 		}
 	}
 }

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -2,8 +2,10 @@ package get
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/Masterminds/semver"
@@ -810,7 +812,18 @@ func Test_DownloadInletsctl(t *testing.T) {
 			t.Fatal(err)
 		}
 		if got != tc.url {
-			t.Fatalf("want: %s, got: %s", tc.url, got)
+			t.Errorf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, tc.url, got)
+		}
+		name, err := GetBinaryName(tool, tc.os, tc.arch, tc.version)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Remove the tgz and possible exe extensions from the url base name
+		// and verify that it matches the name from the binary template.
+		// Note: decompress adds the exe extension to the binary name if needed.
+		nameFromUrl := strings.Split(filepath.Base(tc.url), ".")[0]
+		if name != nameFromUrl {
+			t.Errorf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, nameFromUrl, name)
 		}
 	}
 }

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -2,10 +2,8 @@ package get
 
 import (
 	"fmt"
-	"path/filepath"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/Masterminds/semver"
@@ -24,6 +22,8 @@ type test struct {
 	arch    string
 	version string
 	url     string
+	// Optional fields
+	binaryBase string
 }
 
 func getTool(name string, tools []Tool) *Tool {
@@ -778,33 +778,40 @@ func Test_DownloadInletsctl(t *testing.T) {
 
 	tests := []test{
 		{os: "mingw64_nt-10.0-18362",
-			arch:    arch64bit,
-			version: "0.8.16",
-			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.exe.tgz"},
+			arch:       arch64bit,
+			version:    "0.8.16",
+			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.exe.tgz",
+			binaryBase: "inletsctl"},
 		{os: "darwin",
-			arch:    arch64bit,
-			version: "0.8.16",
-			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin.tgz"},
+			arch:       arch64bit,
+			version:    "0.8.16",
+			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin.tgz",
+			binaryBase: "inletsctl-darwin"},
 		{os: "darwin",
-			arch:    archDarwinARM64,
-			version: "0.8.16",
-			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin-arm64.tgz"},
+			arch:       archDarwinARM64,
+			version:    "0.8.16",
+			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-darwin-arm64.tgz",
+			binaryBase: "inletsctl-darwin-arm64"},
 		{os: "linux",
-			arch:    arch64bit,
-			version: "0.8.16",
-			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.tgz"},
+			arch:       arch64bit,
+			version:    "0.8.16",
+			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl.tgz",
+			binaryBase: "inletsctl"},
 		{os: "linux",
-			arch:    "armv6l",
-			version: "0.8.16",
-			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz"},
+			arch:       "armv6l",
+			version:    "0.8.16",
+			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz",
+			binaryBase: "inletsctl-armhf"},
 		{os: "linux",
-			arch:    "armv7l",
-			version: "0.8.16",
-			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz"},
+			arch:       "armv7l",
+			version:    "0.8.16",
+			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-armhf.tgz",
+			binaryBase: "inletsctl-armhf"},
 		{os: "linux",
-			arch:    archARM64,
-			version: "0.8.16",
-			url:     "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-arm64.tgz"},
+			arch:       archARM64,
+			version:    "0.8.16",
+			url:        "https://github.com/inlets/inletsctl/releases/download/0.8.16/inletsctl-arm64.tgz",
+			binaryBase: "inletsctl-arm64"},
 	}
 	for _, tc := range tests {
 		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
@@ -818,12 +825,8 @@ func Test_DownloadInletsctl(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Remove the tgz and possible exe extensions from the url base name
-		// and verify that it matches the name from the binary template.
-		// Note: decompress adds the exe extension to the binary name if needed.
-		nameFromUrl := strings.Split(filepath.Base(tc.url), ".")[0]
-		if name != nameFromUrl {
-			t.Errorf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, nameFromUrl, name)
+		if name != tc.binaryBase {
+			t.Errorf("for %s/%s, want: %q, but got: %q", tc.os, tc.arch, tc.binaryBase, name)
 		}
 	}
 }

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -471,13 +471,15 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 	{{.Name}}-darwin
 	{{- end -}}
 {{- else if eq .OS "linux" -}}
-{{.Name}}
-{{- else if eq .Arch "armv6l" -}}
-{{.Name}}-armhf
-{{- else if eq .Arch "armv7l" -}}
-{{.Name}}-armhf
-{{- else if eq .Arch "aarch64" -}}
-{{.Name}}-arm64
+	{{- if eq .Arch "armv6l" -}}
+	{{.Name}}-armhf
+	{{- else if eq .Arch "armv7l" -}}
+	{{.Name}}-armhf
+	{{- else if eq .Arch "aarch64" -}}
+	{{.Name}}-arm64
+	{{- else -}}
+	{{.Name}}
+	{{- end -}}
 {{- end -}}`,
 		},
 		Tool{

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -463,7 +463,7 @@ https://storage.googleapis.com/kubernetes-release/release/{{.Version}}/bin/{{$os
 {{- end -}}
 https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}`,
 			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
-{{.Name}}.exe
+{{.Name}}
 {{- else if eq .OS "darwin" -}}
 	{{- if eq .Arch "arm64" -}}
 	{{.Name}}-darwin-arm64


### PR DESCRIPTION
## Description
Fix `arkade get inletsctl` on linux aarch64 and mingw

## Motivation and Context
Fixes #922 

## How Has This Been Tested?
make e2e
```
    --- PASS: Test_CheckTools/Download_of_inletsctl (0.62s)
PASS
        github.com/alexellis/arkade/pkg/get     coverage: 54.9% of statements
ok      github.com/alexellis/arkade/pkg/get     7.964s  coverage: 54.9% of statements
```

./hack/test-tool.sh inletsctl
```
+ ./arkade get inletsctl --arch arm64 --os darwin --quiet
+ file /c/Users/joebo/.arkade/bin/inletsctl
/c/Users/joebo/.arkade/bin/inletsctl: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
+ rm /c/Users/joebo/.arkade/bin/inletsctl
+ echo

+ ./arkade get inletsctl --arch x86_64 --os darwin --quiet
+ file /c/Users/joebo/.arkade/bin/inletsctl
/c/Users/joebo/.arkade/bin/inletsctl: Mach-O 64-bit x86_64 executable
+ rm /c/Users/joebo/.arkade/bin/inletsctl
+ echo

+ ./arkade get inletsctl --arch x86_64 --os linux --quiet
+ file /c/Users/joebo/.arkade/bin/inletsctl
/c/Users/joebo/.arkade/bin/inletsctl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=6M_Wagl7j2oAMAhNLegz/ElId8XoAfS4FFgo3RTUH/vdJIc5Q5GK5NVWWpn_rm/YKO4s5vPb3kc4txX14QC, stripped
+ rm /c/Users/joebo/.arkade/bin/inletsctl
+ echo

+ ./arkade get inletsctl --arch aarch64 --os linux --quiet
+ file /c/Users/joebo/.arkade/bin/inletsctl
/c/Users/joebo/.arkade/bin/inletsctl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=3NsRKwpuEEkZC61LBu96/PL2wjtAOPiHovxsxmsJD/cK_e0dZ-RARc9Cap2aQl/KECauLt3s1gFJHPXkfUo, stripped
+ rm /c/Users/joebo/.arkade/bin/inletsctl
+ echo

+ ./arkade get inletsctl --arch x86_64 --os mingw --quiet
+ file /c/Users/joebo/.arkade/bin/inletsctl.exe
/c/Users/joebo/.arkade/bin/inletsctl.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
+ rm /c/Users/joebo/.arkade/bin/inletsctl.exe
+ echo
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
