### PR TITLE
fix: kustomize to use version directly from kustomize repo

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -853,7 +853,7 @@ func Test_DownloadKustomize(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	ver := "4.4.1"
+	ver := "v4.4.1"
 
 	tests := []test{
 		{os: "linux",

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -556,7 +556,7 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 	{{- else if eq .OS "darwin" -}}
 	{{$osStr = "darwin_amd64"}}
 	{{- end -}}
-	kustomize%2Fv{{.Version}}/{{.Name}}_v{{.Version}}_{{$osStr}}.tar.gz`,
+	kustomize%2F{{.Version}}/{{.Name}}_{{.Version}}_{{$osStr}}.tar.gz`,
 		})
 
 	tools = append(tools,


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Kustomize releases versions with a `v` prefix and a number, similar to kubeconform, kubectl, and other Kubernetes tools. This commit updates the kustomize version to use the version directly from the kustomize repo instead of assuming it will include a `v` prefix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
- [x] I have raised an issue in a [previous pull request](https://github.com/alexellis/arkade/pull/598#issuecomment-1583243907).


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the `make` and `make test` commands.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- In case it is a new application -->
- [ ] I have tested this on arm, or have added code to prevent deployment
