### PR TITLE
Add 1password and task CLIs to arkage get

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,6 +800,7 @@ There are 56 apps that you can install on your cluster.
 | [nova](https://github.com/FairwindsOps/nova)                                 | Find outdated or deprecated Helm charts running in your cluster.                                                                          |
 | [oc](https://github.com/openshift/oc)                                        | Client to use an OpenShift 4.x cluster.                                                                                                   |
 | [oh-my-posh](https://github.com/jandedobbeleer/oh-my-posh)                   | A prompt theme engine for any shell that can display kubernetes information.                                                              |
+| [op](https://github.com/1password/)                                          | 1Password CLI enables you to automate administrative tasks and securely provision secrets across development environments.                |
 | [opa](https://github.com/open-policy-agent/opa)                              | General-purpose policy engine that enables unified, context-aware policy enforcement across the entire stack.                             |
 | [openshift-install](https://github.com/openshift/installer)                  | CLI to install an OpenShift 4.x cluster.                                                                                                  |
 | [operator-sdk](https://github.com/operator-framework/operator-sdk)           | Operator SDK is a tool for scaffolding and generating code for building Kubernetes operators                                              |
@@ -820,6 +821,7 @@ There are 56 apps that you can install on your cluster.
 | [stern](https://github.com/stern/stern)                                      | Multi pod and container log tailing for Kubernetes.                                                                                       |
 | [syft](https://github.com/anchore/syft)                                      | CLI tool and library for generating a Software Bill of Materials from container images and filesystems                                    |
 | [talosctl](https://github.com/siderolabs/talos)                              | The command-line tool for managing Talos Linux OS.                                                                                        |
+| [task](https://github.com/go-task/task)                                      | A simple task runner and build tool                                                                                                       |
 | [tctl](https://github.com/temporalio/tctl)                                   | Temporal CLI.                                                                                                                             |
 | [terraform](https://github.com/hashicorp/terraform)                          | Infrastructure as Code for major cloud providers.                                                                                         |
 | [terragrunt](https://github.com/gruntwork-io/terragrunt)                     | Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules                          |
@@ -836,6 +838,6 @@ There are 56 apps that you can install on your cluster.
 | [waypoint](https://github.com/hashicorp/waypoint)                            | Easy application deployment for Kubernetes and Amazon ECS                                                                                 |
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                     |
 | [yt-dlp](https://github.com/yt-dlp/yt-dlp)                                   | Fork of youtube-dl with additional features and fixes                                                                                     |
-There are 136 tools, use `arkade get NAME` to download one.
+There are 137 tools, use `arkade get NAME` to download one.
 
 > Note to contributors, run `arkade get --format markdown` to generate this list

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -6332,3 +6332,107 @@ func Test_Copacetic(t *testing.T) {
 	})
 
 }
+
+func Test_DownloadTask(t *testing.T) {
+	tools := MakeTools()
+	name := "task"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v3.26.0"
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/go-task/task/releases/download/v3.26.0/task_linux_amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     "https://github.com/go-task/task/releases/download/v3.26.0/task_linux_arm.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/go-task/task/releases/download/v3.26.0/task_linux_arm64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://github.com/go-task/task/releases/download/v3.26.0/task_darwin_arm64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/go-task/task/releases/download/v3.26.0/task_darwin_amd64.tar.gz",
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
+func Test_Download1Password(t *testing.T) {
+	tools := MakeTools()
+	name := "op"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v2.17.0"
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://cache.agilebits.com/dist/1P/op2/pkg/v2.17.0/op_linux_amd64_v2.17.0.zip",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: "",
+			url:     "https://cache.agilebits.com/dist/1P/op2/pkg/v2.17.0/op_linux_amd64_v2.17.0.zip",
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     "https://cache.agilebits.com/dist/1P/op2/pkg/v2.17.0/op_linux_arm_v2.17.0.zip",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://cache.agilebits.com/dist/1P/op2/pkg/v2.17.0/op_linux_arm64_v2.17.0.zip",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://cache.agilebits.com/dist/1P/op2/pkg/v2.17.0/op_windows_amd64_v2.17.0.zip",
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -3689,5 +3689,61 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_{{.VersionNumber}}_{{$osStr}}_{{$arch}}.{{$extStr}}`,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:       "go-task",
+			Repo:        "task",
+			Name:        "task",
+			Description: "A simple task runner and build tool",
+			BinaryTemplate: `
+					{{$os := .OS}}
+					{{$arch := .Arch}}
+					{{$ext := "tar.gz"}}
+
+					{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
+						{{$arch = "arm64"}}
+					{{- else if eq .Arch "x86_64" -}}
+						{{ $arch = "amd64" }}
+					{{- else if eq .Arch "armv7l" -}}
+						{{ $arch = "arm" }}
+					{{- end -}}
+
+					{{ if HasPrefix .OS "ming" -}}
+					{{$os = "windows"}}
+					{{$ext = "zip"}}
+					{{- end -}}
+
+					{{.Name}}_{{$os}}_{{$arch}}.{{$ext}}`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "1password",
+			Name:        "op",
+			Description: "1Password CLI enables you to automate administrative tasks and securely provision secrets across development environments.",
+			URLTemplate: `
+				{{$os := .OS}}
+				{{$arch := .Arch}}
+				{{$version := .Version}}
+
+				{{- if eq .Version "" -}}
+					{{ $version = "v2.17.0" }}
+				{{- end -}}
+
+				{{- if eq .Arch "aarch64" -}}
+					{{ $arch = "arm64" }}
+				{{- else if eq .Arch "x86_64" -}}
+					{{ $arch = "amd64" }}
+				{{- else if eq .Arch "armv7l" -}}
+					{{ $arch = "arm" }}
+				{{- end -}}
+
+				{{ if HasPrefix .OS "ming" -}}
+				{{$os = "windows"}}
+				{{- end -}}
+
+				https://cache.agilebits.com/dist/1P/op2/pkg/{{$version}}/op_{{$os}}_{{$arch}}_{{$version}}.zip`,
+		})
+
 	return tools
 }


### PR DESCRIPTION

## Description

Add 1password and task CLIs to arkade get

## Motivation and Context

- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
fixes: #909


## How Has This Been Tested?
Unit tests, plus test tool output

### Test tool output for task CLI

```
+ ./arkade get task --arch arm64 --os darwin --quiet
+ file /home/bxffour/.arkade/bin/task
/home/bxffour/.arkade/bin/task: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
+ rm /home/bxffour/.arkade/bin/task
+ echo

+ ./arkade get task --arch x86_64 --os darwin --quiet
+ file /home/bxffour/.arkade/bin/task
/home/bxffour/.arkade/bin/task: Mach-O 64-bit x86_64 executable
+ rm /home/bxffour/.arkade/bin/task
+ echo

+ ./arkade get task --arch x86_64 --os linux --quiet
+ file /home/bxffour/.arkade/bin/task
/home/bxffour/.arkade/bin/task: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=PwnSGD9bn5MncgAbZgX4/aP32reofxPRUA_ZEUbQV/YnA4qqIfxJTViNfu2IpM/88pd3_evUfC0Tnyng9fL, stripped
+ rm /home/bxffour/.arkade/bin/task
+ echo

+ ./arkade get task --arch aarch64 --os linux --quiet
+ file /home/bxffour/.arkade/bin/task
/home/bxffour/.arkade/bin/task: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=rMMirTs83k5BI4yENR7b/-hhTvxNDfm42VAW1-cEG/xiYBoEzAMy3DQOtTvmte/25HORW0WRhlqwGySTkIV, stripped
+ rm /home/bxffour/.arkade/bin/task
+ echo

+ ./arkade get task --arch x86_64 --os mingw --quiet
+ file /home/bxffour/.arkade/bin/task.exe
/home/bxffour/.arkade/bin/task.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 6 sections
+ rm /home/bxffour/.arkade/bin/task.exe
+ echo
```

### Test tool output for 1Password CLI
```
+ ./arkade get op --arch arm64 --os darwin --quiet

The requested version of op is not available or configured in arkade for darwin/arm64

* Check if a binary is available from the project for your Operating System
* Feel free to raise an issue at https://github.com/alexellis/arkade/issues for help

Error: server returned status: 404
+ ./arkade get op --arch x86_64 --os darwin --quiet

The requested version of op is not available or configured in arkade for darwin/x86_64

* Check if a binary is available from the project for your Operating System
* Feel free to raise an issue at https://github.com/alexellis/arkade/issues for help

Error: server returned status: 404
+ ./arkade get op --arch x86_64 --os linux --quiet
+ file /home/bxffour/.arkade/bin/op
/home/bxffour/.arkade/bin/op: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=OyJkJRUAkzPLKHtdGNyx/2AoYaN9Nw3FMsui-xJ6K/LqHJCUixKdVijJ2yE4UA/ei8ed5BguIwW31R4BzY5, stripped
+ rm /home/bxffour/.arkade/bin/op
+ echo

+ ./arkade get op --arch aarch64 --os linux --quiet
+ file /home/bxffour/.arkade/bin/op
/home/bxffour/.arkade/bin/op: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=0WpxgEp-m5SrQbpPSou_/vkpInt7yNx4N5oPSGgxh/GiY6tX-2L7tFxvA_rAxg/kXLAPYUXdE2X41Yp6V6z, stripped
+ rm /home/bxffour/.arkade/bin/op
+ echo

+ ./arkade get op --arch x86_64 --os mingw --quiet
+ file /home/bxffour/.arkade/bin/op.exe
/home/bxffour/.arkade/bin/op.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows, 6 sections
+ rm /home/bxffour/.arkade/bin/op.exe
+ echo
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
