### PR TITLE
fix incorrect tag selection in arkade chart upgrade

### DIFF
--- a/cmd/chart/chart.go
+++ b/cmd/chart/chart.go
@@ -25,7 +25,7 @@ func MakeChart() *cobra.Command {
 	}
 
 	command.AddCommand(MakeVerify())
-	command.AddCommand(MakeUpgrade())
+	command.AddCommand(MakeUpgrade(craneLister{}))
 
 	return command
 }

--- a/cmd/chart/upgrade_test.go
+++ b/cmd/chart/upgrade_test.go
@@ -1,0 +1,155 @@
+package chart
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+type test struct {
+	title   string
+	current string
+	tags    []string
+	want    string
+}
+
+type mockLister struct {
+	imageTags map[string][]string
+}
+
+func (ml mockLister) listTags(image string) ([]string, error) {
+	tags, ok := ml.imageTags[image]
+	if !ok {
+		return nil, fmt.Errorf("Image %s not found", image)
+	}
+
+	return tags, nil
+}
+
+func newMockLister(t *testing.T, tests []test) *mockLister {
+	tagsMap := make(map[string][]string)
+	lister := mockLister{imageTags: tagsMap}
+
+	if len(tests) == 0 {
+		t.Fatal("Tests cannot be empty, please provide test cases")
+	}
+
+	for _, tt := range tests {
+		key, _ := splitImageName(tt.current)
+		// Ensuring that a test entry with the same key doesn't already exist to prevent overwriting
+		if _, ok := lister.imageTags[key]; !ok {
+			lister.imageTags[key] = tt.tags
+		} else {
+			t.Fatalf("Duplicate image name found which might break tests: %s", tt.current)
+		}
+	}
+
+	return &lister
+}
+
+func Test_ChartUpgrade(t *testing.T) {
+	tests := []test{
+		{
+			title:   "Promote from a rootless build to the latest rootless build",
+			current: "moby/buildkit:v0.11.5-rootless",
+			want:    "moby/buildkit:v0.11.6-rootless",
+			tags:    []string{"0.10.6-rootless", "v0.11.5", "0.11.6", "0.11.6-rootless", "0.12.0-rc1", "0.12.0-rc1-rootless"},
+		},
+		{
+			title:   "Promote from a rootless build to the latest rootless build",
+			current: "moby1/buildkit:v0.10.0-rootless",
+			want:    "moby1/buildkit:v0.11.6-rootless",
+			tags:    []string{"0.10.0", "0.10.6", "0.10.6-rootless", "0.11.6", "0.11.6-rootless", "0.12.0-rc1", "0.12.0-rc1-rootless"},
+		},
+		{
+			title:   "Promote from non-rootless build to the latest stable build",
+			current: "moby2/buildkit:v0.8.0",
+			want:    "moby2/buildkit:v0.11.6",
+			tags:    []string{"v0.8.0", "0.10.6-rootless", "0.11.6", "0.11.6-rootless", "0.12.0-rc1", "0.12.0-rc1-rootless"},
+		},
+		{
+			title:   "Promote from stable release to the latest stable release",
+			current: "prom/prometheus:v2.42.0",
+			want:    "prom/prometheus:v2.44.0",
+			tags:    []string{"2.41.5", "2.42.0", "2.43.0", "2.44.0", "2.45.0-rc.0", "2.45.0-rc.1"},
+		},
+		{
+			title:   "Promote from stable release to the latest stable release",
+			current: "prom1/prometheus:v2.2.0",
+			want:    "prom1/prometheus:v2.44.0",
+			tags:    []string{"v2.1.0", "v2.2.0", "2.41.5", "2.42.0", "2.43.0", "2.44.0", "2.45.0-rc.0", "2.45.0-rc.1"},
+		},
+		{
+			title:   "Promote from release condidate to the latest stable release",
+			current: "bitnami/postgresql:v2.42.0-rc.2",
+			want:    "bitnami/postgresql:v2.44.0",
+			tags:    []string{"v2.42.0-rc.5", "2.41.5", "2.42.0", "2.43.0", "2.44.0", "2.45.0-rc.0", "2.45.0-rc.1"},
+		},
+		{
+			title:   "Promote from prerelease version to the latest prerelease version",
+			current: "bitnami/rabbitmq:v2.22.0-rc1",
+			want:    "bitnami/rabbitmq:v2.22.0-rc3",
+			tags:    []string{"v2.21.0", "v2.22.0-rc1", "v2.22.0-rc2", "v2.22.0-rc3"},
+		},
+		{
+			title:   "Remain on current version when there isn't a later version",
+			current: "openfaas/openfaas:v2.23.3",
+			want:    "openfaas/openfaas:v2.23.3",
+			tags:    []string{"v2.23.3", "v2.21.0", "v2.15.6"},
+		},
+	}
+
+	testFile, err := os.CreateTemp(os.TempDir(), "arkade_*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.Remove(testFile.Name())
+
+	testData := make(map[string]map[string]string)
+	for i, t := range tests {
+		title := fmt.Sprintf("test%d", i)
+		testData[title] = map[string]string{"image": t.current}
+	}
+
+	yamlBytes, err := yaml.Marshal(testData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := testFile.Write(yamlBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	lister := newMockLister(t, tests)
+
+	cmd := MakeUpgrade(lister)
+	cmd.SetArgs([]string{"--write", "--file", testFile.Name()})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlData, err := os.ReadFile(testFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var final map[string]map[string]string
+	err = yaml.Unmarshal(yamlData, &final)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			title := fmt.Sprintf("test%d", i)
+			got := final[title]["image"]
+			if got != tc.want {
+				t.Fatalf("want: %s, got: %s", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/helm/io_test.go
+++ b/pkg/helm/io_test.go
@@ -1,0 +1,72 @@
+package helm
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func Test_ReplaceValuesInHelmValuesFile(t *testing.T) {
+	tests := []struct {
+		current string
+		update  string
+	}{
+		{current: "ghcr.io/openfaas/faas-netes:0.1.0", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
+		{current: "ghcr.io/openfaas/faas-netes:0.1.0-rc", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
+		{current: "prom/prometheus:v2.43.0", update: "prom/prometheus:v2.45.0"},
+		{current: "prom/prometheus:v2.43.0-rc.0", update: "prom/prometheus:v2.45.0"},
+		{current: "ghcr.io/openfaas/faas-netes:0.1.0-rc.1", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
+		{current: "ghcr.io/openfaas/faas-netes:0.1.0-rc.1-rc.2", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
+	}
+
+	testFile, err := os.CreateTemp(os.TempDir(), "arkade_*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(testFile.Name())
+
+	yamlData := make(map[string]map[string]string)
+	for i, t := range tests {
+		title := fmt.Sprintf("test%d", i)
+		yamlData[title] = map[string]string{"image": t.current}
+	}
+
+	yamlBytes, err := yaml.Marshal(yamlData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := testFile.Write(yamlBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	input := make(map[string]string)
+	for _, t := range tests {
+		input[t.current] = t.update
+	}
+
+	// Test is run multiple times to verify consistent and correct output independent of the
+	// input map's iteration order, addressing potential non-deterministic behaviour
+	count := 10
+	for i := 0; i < count; i++ {
+		out, err := ReplaceValuesInHelmValuesFile(input, testFile.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var results map[string]map[string]string
+		if err := yaml.Unmarshal([]byte(out), &results); err != nil {
+			t.Fatal(err)
+		}
+
+		for i, tc := range tests {
+			title := fmt.Sprintf("test%d", i)
+			got := results[title]["image"]
+			if got != tc.update {
+				t.Fatalf("want: %s, got: %s", tc.update, got)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

Fix incorrect tag selection in arkade chart upgrade

## Motivation and Context
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
- [x] Fixes: #936

This PR addresses an issue in the upgrade command where incorrect transitions occur between stable and RC versions. It resolves the problem encountered when two available tags are present.

For instance, when upgrading `prom/prometheus`, the command mistakenly replaces the stable version `v2.44.0` with the latest unstable version `v2.45.0-rc.0`

Similar issues arise with the `moby/buildkit` image, where the command replaces the specified version `v0.11.6-rootless` with an unintended alternative `v0.11.6`.

Another issue arises when two images share substrings. Specifically, when the values file contains images with names like `prom/prometheus:1.0.0` and `prom/prometheus:1.0.0-rc`, an unintended behavior is observed when the tool attempts to update the non-rc version. The tool mistakenly matches the rc version and erroneously modifies it. The bug seems to manifest randomly, causing inconsistent behavior. 

This PR provides a fix to ensure accurate and expected behavior during upgrades, preventing undesired transitions between stable and RC versions.

### Example

values.yml:
```yaml
builder:
  image: moby/buildkit:v0.11.5-rootless
prom:
  image: prom/prometheus:v2.43.0
prom_rc:
  image: prom/prometheus:v2.43.0-rc.0
```

Command:
```
arcade chart upgrade -f values.yml
```

#### Output
Before:
```yaml
builder:
  image: moby/buildkit:v0.11.6
prom:
  image: prom/prometheus:v2.45.0-rc.0
prom_rc:
# this is happens because the image was inadvertently modified
# when 'prom' was being modified.
  image: prom/prometheus:v2.45.0-rc.0-rc.0
```

After:
```yaml
builder:
  image: moby/buildkit:v0.11.6-rootless
prom:
  image: prom/prometheus:v2.44.0
prom_rc:
# rcs are upgraded to the latest stable release when available
  image: prom/prometheus:v2.44.0
```


## How Has This Been Tested?

I wrote a unit test to verify the modified tag selection logic

Test Cases:
```go
	tests := []test{
		{
			title:   "Promote from a rootless build to the latest rootless build",
			current: "moby/buildkit:v0.11.5-rootless",
			want:    "moby/buildkit:v0.11.6-rootless",
			tags:    []string{"0.10.6-rootless", "v0.11.5", "0.11.6", "0.11.6-rootless", "0.12.0-rc1", "0.12.0-rc1-rootless"},
		},
		{
			title:   "Promote from a rootless build to the latest rootless build",
			current: "moby1/buildkit:v0.10.0-rootless",
			want:    "moby1/buildkit:v0.11.6-rootless",
			tags:    []string{"0.10.0", "0.10.6", "0.10.6-rootless", "0.11.6", "0.11.6-rootless", "0.12.0-rc1", "0.12.0-rc1-rootless"},
		},
		{
			title:   "Promote from non-rootless build to the latest stable build",
			current: "moby2/buildkit:v0.8.0",
			want:    "moby2/buildkit:v0.11.6",
			tags:    []string{"v0.8.0", "0.10.6-rootless", "0.11.6", "0.11.6-rootless", "0.12.0-rc1", "0.12.0-rc1-rootless"},
		},
		{
			title:   "Promote from stable release to the latest stable release",
			current: "prom/prometheus:v2.42.0",
			want:    "prom/prometheus:v2.44.0",
			tags:    []string{"2.41.5", "2.42.0", "2.43.0", "2.44.0", "2.45.0-rc.0", "2.45.0-rc.1"},
		},
		{
			title:   "Promote from stable release to the latest stable release",
			current: "prom1/prometheus:v2.2.0",
			want:    "prom1/prometheus:v2.44.0",
			tags:    []string{"v2.1.0", "v2.2.0", "2.41.5", "2.42.0", "2.43.0", "2.44.0", "2.45.0-rc.0", "2.45.0-rc.1"},
		},
		{
			title:   "Promote from release condidate to the latest stable release",
			current: "bitnami/postgresql:v2.42.0-rc.2",
			want:    "bitnami/postgresql:v2.44.0",
			tags:    []string{"v2.42.0-rc.5", "2.41.5", "2.42.0", "2.43.0", "2.44.0", "2.45.0-rc.0", "2.45.0-rc.1"},
		},
		{
			title:   "Promote from prerelease version to the latest prerelease version",
			current: "bitnami/rabbitmq:v2.22.0-rc1",
			want:    "bitnami/rabbitmq:v2.22.0-rc3",
			tags:    []string{"v2.21.0", "v2.22.0-rc1", "v2.22.0-rc2", "v2.22.0-rc3"},
		},
		{
			title:   "Remain on current version when there isn't a later version",
			current: "openfaas/openfaas:v2.23.3",
			want:    "openfaas/openfaas:v2.23.3",
			tags:    []string{"v2.23.3", "v2.21.0", "v2.15.6"},
		},
	}
```

Output:
```
=== RUN   Test_ChartUpgrade
2023/07/08 20:25:12 Wrote 7 updates to: /tmp/arkade_3569690160.yml
=== RUN   Test_ChartUpgrade/Promote_from_a_rootless_build_to_the_latest_rootless_build
=== RUN   Test_ChartUpgrade/Promote_from_a_rootless_build_to_the_latest_rootless_build#01
=== RUN   Test_ChartUpgrade/Promote_from_non-rootless_build_to_the_latest_stable_build
=== RUN   Test_ChartUpgrade/Promote_from_stable_release_to_the_latest_stable_release
=== RUN   Test_ChartUpgrade/Promote_from_stable_release_to_the_latest_stable_release#01
=== RUN   Test_ChartUpgrade/Promote_from_release_condidate_to_the_latest_stable_release
=== RUN   Test_ChartUpgrade/Promote_from_prerelease_version_to_the_latest_prerelease_version
=== RUN   Test_ChartUpgrade/Remain_on_current_version_when_there_isn't_a_later_version
--- PASS: Test_ChartUpgrade (0.00s)
    --- PASS: Test_ChartUpgrade/Promote_from_a_rootless_build_to_the_latest_rootless_build (0.00s)
    --- PASS: Test_ChartUpgrade/Promote_from_a_rootless_build_to_the_latest_rootless_build#01 (0.00s)
    --- PASS: Test_ChartUpgrade/Promote_from_non-rootless_build_to_the_latest_stable_build (0.00s)
    --- PASS: Test_ChartUpgrade/Promote_from_stable_release_to_the_latest_stable_release (0.00s)
    --- PASS: Test_ChartUpgrade/Promote_from_stable_release_to_the_latest_stable_release#01 (0.00s)
    --- PASS: Test_ChartUpgrade/Promote_from_release_condidate_to_the_latest_stable_release (0.00s)
    --- PASS: Test_ChartUpgrade/Promote_from_prerelease_version_to_the_latest_prerelease_version (0.00s)
    --- PASS: Test_ChartUpgrade/Remain_on_current_version_when_there_isn't_a_later_version (0.00s)
PASS
ok      command-line-arguments  0.007s
```

I have also added a test to ensure the correct behavior of the  `ReplaceValuesInHelmValuesFile` function.

Test Cases:
```Go
		tests := []struct {
			current string
			update  string
		}{
			{current: "ghcr.io/openfaas/faas-netes:0.1.0", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
			{current: "ghcr.io/openfaas/faas-netes:0.1.0-rc", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
			{current: "prom/prometheus:v2.43.0", update: "prom/prometheus:v2.45.0"},
			{current: "prom/prometheus:v2.43.0-rc.0", update: "prom/prometheus:v2.45.0"},
			{current: "ghcr.io/openfaas/faas-netes:0.1.0-rc.1", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
			{current: "ghcr.io/openfaas/faas-netes:0.1.0-rc.1-rc.2", update: "ghcr.io/openfaas/faas-netes:0.2.0"},
		}

```

Output:
```shell
=== RUN   Test_ReplaceValuesInHelmValuesFile
--- PASS: Test_ReplaceValuesInHelmValuesFile (0.01s)
PASS
ok      command-line-arguments  0.010s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
