### PR TITLE
Permit postgresql install on arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 arkade
+arkade.exe
 bin/**
 kubeconfig
 .DS_Store

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -41,10 +41,6 @@ func MakeInstallPostgresql() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		ns, _ := postgresql.Flags().GetString("namespace")
 
 		if ns != "default" {

--- a/cmd/apps/postgres_app.go
+++ b/cmd/apps/postgres_app.go
@@ -99,7 +99,7 @@ To connect to your database from outside the cluster execute the following comma
     kubectl port-forward --namespace default svc/postgresql 5432:5432 &
 	PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -d postgres -p 5432
 
-# Find out more at: https://github.com/helm/charts/tree/master/stable/postgresql`
+# Find out more at: https://github.com/bitnami/charts/tree/main/bitnami/postgresql`
 
 const postgresqlInstallMsg = `=======================================================================
 = PostgreSQL has been installed.                                      =


### PR DESCRIPTION
Do not prevent `arkade install postgresql` on arm64 nodes.

## Description
Bitnami postgresql images now support linux/arm64

ALSO: Add `arkade.exe` to `.gitignore` (something I noticed when building on windows)

## Motivation and Context
Fixes #942 
- [] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
```bash
go build
./arkade install postgresql
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [x] I have tested this on arm, or have added code to prevent deployment
