### PR TITLE
Remove IntelArch restriction from some app installs

### DIFF
--- a/cmd/apps/argocd_app.go
+++ b/cmd/apps/argocd_app.go
@@ -33,10 +33,6 @@ func MakeInstallArgoCD() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		_, err := k8s.KubectlTask("create", "ns",
 			"argocd")
 		if err != nil {

--- a/cmd/apps/consul_app.go
+++ b/cmd/apps/consul_app.go
@@ -45,10 +45,6 @@ func MakeInstallConsul() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		namespace, _ := consul.Flags().GetString("namespace")
 
 		overrides := map[string]string{}

--- a/cmd/apps/falco.go
+++ b/cmd/apps/falco.go
@@ -65,10 +65,6 @@ func MakeInstallFalco() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		overrides := map[string]string{}
 		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err

--- a/cmd/apps/gitea_app.go
+++ b/cmd/apps/gitea_app.go
@@ -90,10 +90,6 @@ func MakeInstallGitea() *cobra.Command {
 			WithHelmUpdateRepo(updateRepo).
 			WithKubeconfigPath(kubeConfigPath)
 
-		if _, found := overrides["gitea.config.database.HOST"]; !found && arch != IntelArch {
-			return fmt.Errorf("if installing on ARM platform you'll need to use an external database")
-		}
-
 		_, err = apps.MakeInstallChart(giteaAppOptions)
 		if err != nil {
 			return err

--- a/cmd/apps/jenkins_app.go
+++ b/cmd/apps/jenkins_app.go
@@ -85,10 +85,6 @@ func MakeInstallJenkins() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		jenkinsAppOptions := types.DefaultInstallOptions().
 			WithNamespace(ns).
 			WithHelmRepo("jenkins/jenkins").

--- a/cmd/apps/kube_state_metrics.go
+++ b/cmd/apps/kube_state_metrics.go
@@ -41,10 +41,6 @@ func MakeInstallKubeStateMetrics() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		clientArch, clientOS := env.GetClientArch()
 		fmt.Printf("Client: %q, %q\n", clientArch, clientOS)
 

--- a/cmd/apps/kyverno.go
+++ b/cmd/apps/kyverno.go
@@ -57,10 +57,6 @@ func MakeInstallKyverno() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		overrides := map[string]string{}
 		if err := config.MergeFlags(overrides, customFlags); err != nil {
 			return err

--- a/cmd/apps/metallb_app.go
+++ b/cmd/apps/metallb_app.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	MetalLBNamespaceManifest = "https://raw.githubusercontent.com/metallb/metallb/v0.10.2/manifests/namespace.yaml"
-	MetalLBManifest          = "https://raw.githubusercontent.com/metallb/metallb/v0.10.2/manifests/metallb.yaml"
+	MetalLBManifest = "https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml"
 )
 
 func MakeInstallMetalLB() *cobra.Command {
@@ -57,15 +56,7 @@ func MakeInstallMetalLB() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		addressRange, _ := command.Flags().GetString("address-range")
-
-		if err := k8s.Kubectl("apply", "-f", MetalLBNamespaceManifest); err != nil {
-			return err
-		}
 
 		if err := k8s.Kubectl("apply", "-f", MetalLBManifest); err != nil {
 			return err

--- a/cmd/apps/rabbitmq_app.go
+++ b/cmd/apps/rabbitmq_app.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/alexellis/arkade/pkg"
 	"github.com/alexellis/arkade/pkg/apps"
-	"github.com/alexellis/arkade/pkg/k8s"
 	"github.com/alexellis/arkade/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -58,11 +57,6 @@ func MakeInstallRabbitmq() *cobra.Command {
 		_, err = command.Flags().GetStringArray("set")
 		if err != nil {
 			return fmt.Errorf("error with --set usage: %s", err)
-		}
-
-		arch := k8s.GetNodeArchitecture()
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
 		}
 
 		return nil

--- a/cmd/apps/redis_app.go
+++ b/cmd/apps/redis_app.go
@@ -39,10 +39,6 @@ func MakeInstallRedis() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		overrides := map[string]string{
 			"serviceAccount.create": "true",
 			"rbac.create":           "true",

--- a/cmd/apps/tekton_app.go
+++ b/cmd/apps/tekton_app.go
@@ -32,10 +32,6 @@ func MakeInstallTekton() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(`only Intel and AMD (i.e. PC) architecture is supported for this app`)
-		}
-
 		fmt.Println("Installing Tekton pipelines...")
 		_, err := k8s.KubectlTask("apply", "-f",
 			"https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml")

--- a/cmd/apps/waypoint_app.go
+++ b/cmd/apps/waypoint_app.go
@@ -35,10 +35,6 @@ func MakeInstallWaypoint() *cobra.Command {
 		arch := k8s.GetNodeArchitecture()
 		fmt.Printf("Node architecture: %q\n", arch)
 
-		if arch != IntelArch {
-			return fmt.Errorf(OnlyIntelArch)
-		}
-
 		namespace, _ := waypoint.Flags().GetString("namespace")
 
 		overrides := map[string]string{}


### PR DESCRIPTION
Remove IntelArch restriction from the following app installs:
- argocd
- consul-connect
- falco
- gitea
- jenkins
- kube-state-metrics
- kyverno
- metallb-arp
- rabbitmq
- redis
- tekton
- waypoint

## Description
* Remove IntelArch check from apps that now support linux/arm64
* Update metallb manifests to v0.13.10 (latest) for compatibility with current k8s

NOTE: falco ARM support requires linux/arm64/v8

## Motivation and Context
Fixes #944 
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Installed everything (one at a time) in rancher-desktop (k3s) on Apple M1

Everything installed and was healthy, except falco, whose falco-driver-loader container (1 of 4) failed to download a driver. I don't think this is an issue with falco's arm64 support per se, as falco provides linux/arm64/v8 [images](https://hub.docker.com/r/falcosecurity/falco/tags).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [x] I have tested this on arm, or have added code to prevent deployment
