### PR TITLE
Uncommenting kubestr as issue #160 is resolved due to binaries becoming available once more

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -2959,59 +2959,57 @@ func Test_DownloadKanister(t *testing.T) {
 	}
 }
 
-// Commented out due to: https://github.com/kastenhq/kubestr/issues/160
+func Test_DownloadKubestr(t *testing.T) {
+	tools := MakeTools()
+	name := "kubestr"
+	v := "v0.4.31"
+	tool := getTool(name, tools)
 
-// func Test_DownloadKubestr(t *testing.T) {
-// 	tools := MakeTools()
-// 	name := "kubestr"
-// 	v := "v0.4.31"
-// 	tool := getTool(name, tools)
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_amd64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_arm64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_amd64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_arm64.tar.gz`,
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: v,
+			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Windows_amd64.tar.gz`,
+		},
+	}
 
-// 	tests := []test{
-// 		{
-// 			os:      "darwin",
-// 			arch:    arch64bit,
-// 			version: v,
-// 			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_amd64.tar.gz`,
-// 		},
-// 		{
-// 			os:      "darwin",
-// 			arch:    archDarwinARM64,
-// 			version: v,
-// 			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_MacOS_arm64.tar.gz`,
-// 		},
-// 		{
-// 			os:      "linux",
-// 			arch:    arch64bit,
-// 			version: v,
-// 			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_amd64.tar.gz`,
-// 		},
-// 		{
-// 			os:      "linux",
-// 			arch:    archARM64,
-// 			version: v,
-// 			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Linux_arm64.tar.gz`,
-// 		},
-// 		{
-// 			os:      "ming",
-// 			arch:    arch64bit,
-// 			version: v,
-// 			url:     `https://github.com/kastenhq/kubestr/releases/download/v0.4.31/kubestr_0.4.31_Windows_amd64.tar.gz`,
-// 		},
-// 	}
-
-// 	for _, tc := range tests {
-// 		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
-// 			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
-// 			if err != nil {
-// 				t.Fatal(err)
-// 			}
-// 			if got != tc.url {
-// 				t.Errorf("want: %s, got: %s", tc.url, got)
-// 			}
-// 		})
-// 	}
-// }
+	for _, tc := range tests {
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.url {
+				t.Errorf("want: %s, got: %s", tc.url, got)
+			}
+		})
+	}
+}
 
 func Test_DownloadK10multicluster(t *testing.T) {
 	tools := MakeTools()

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -1888,36 +1888,35 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			BinaryTemplate: `{{.Name}}`,
 		})
 
-	// Commented out due to: https://github.com/kastenhq/kubestr/issues/160
-	// 	tools = append(tools,
-	// 		Tool{
-	// 			Owner:       "kastenhq",
-	// 			Repo:        "kubestr",
-	// 			Name:        "kubestr",
-	// 			Description: "Kubestr discovers, validates and evaluates your Kubernetes storage options.",
+	tools = append(tools,
+		Tool{
+			Owner:       "kastenhq",
+			Repo:        "kubestr",
+			Name:        "kubestr",
+			Description: "Kubestr discovers, validates and evaluates your Kubernetes storage options.",
 
-	// 			URLTemplate: `
-	// {{ $ext := "tar.gz" }}
-	// {{ $osStr := "Linux" }}
-	// {{ $arch := .Arch }}
+			URLTemplate: `
+	{{ $ext := "tar.gz" }}
+	{{ $osStr := "Linux" }}
+	{{ $arch := .Arch }}
+	
+	{{- if eq .Arch "x86_64" -}}
+	{{$arch = "amd64"}}
+	{{- end -}}
 
-	// {{- if eq .Arch "x86_64" -}}
-	// {{$arch = "amd64"}}
-	// {{- end -}}
+	{{- if eq .Arch "aarch64" -}}
+	{{$arch = "arm64"}}
+	{{- end -}}
 
-	// {{- if eq .Arch "aarch64" -}}
-	// {{$arch = "arm64"}}
-	// {{- end -}}
+	{{- if eq .OS "darwin" -}}
+	{{ $osStr = "MacOS" }}
+	{{- else if HasPrefix .OS "ming" -}}
+	{{ $osStr = "Windows" }}
+	{{- end -}}
 
-	// {{- if eq .OS "darwin" -}}
-	// {{ $osStr = "MacOS" }}
-	// {{- else if HasPrefix .OS "ming" -}}
-	// {{ $osStr = "Windows" }}
-	// {{- end -}}
-
-	// https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_{{.VersionNumber}}_{{$osStr}}_{{$arch}}.{{$ext}}`,
-	// 			BinaryTemplate: `{{.Name}}`,
-	// 		})
+	https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}_{{.VersionNumber}}_{{$osStr}}_{{$arch}}.{{$ext}}`,
+			BinaryTemplate: `{{.Name}}`,
+		})
 
 	tools = append(tools,
 		Tool{


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

This PR re-enables kubestr by uncommenting the relevant code blocks. Kubestr was disabled due to the kubestr binaries not being available, this is now resolved. 

## Description
- uncomment code blocks in tools.go and go_test.go
- 
## Motivation and Context
- Fixes issue #160


## How Has This Been Tested?
- make e2e

```
make e2e | grep kubestr
fatal: No names found, cannot describe anything.
=== RUN   Test_CheckTools/Download_of_kubestr
=== PAUSE Test_CheckTools/Download_of_kubestr
=== CONT  Test_CheckTools/Download_of_kubestr
    --- PASS: Test_CheckTools/Download_of_kubestr (0.48s)
```

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh TOOL_NAME
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
