### PR TITLE
Fix jq executable name for release 1.7

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -11,7 +11,6 @@ import (
 
 var faasCLIVersionConstraint, _ = semver.NewConstraint(">= 0.13.2")
 
-const arch32bit = "i686"
 const arch64bit = "x86_64"
 const archARM7 = "armv7l"
 const archARM64 = "aarch64"
@@ -2790,45 +2789,79 @@ func Test_DownloadJq(t *testing.T) {
 	tools := MakeTools()
 	name := "jq"
 	tool := getTool(name, tools)
-	tool.Version = "jq-1.7"
-	prefix := "https://github.com/" + tool.Owner + "/" + tool.Repo + "/releases/download/" + tool.Version + "/"
 
 	tests := []test{
 		{
-			os:   "darwin",
-			arch: arch64bit,
-			url:  prefix + "jq-osx-amd64",
+			os:      "darwin",
+			arch:    arch64bit,
+			version: "jq-1.7",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.7/jq-macos-amd64",
 		},
 		{
-			os:   "darwin",
-			arch: archDarwinARM64,
-			url:  prefix + "jq-osx-amd64",
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: "jq-1.7",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.7/jq-macos-arm64",
 		},
 		{
-			os:   "linux",
-			arch: arch64bit,
-			url:  prefix + "jq-linux64",
+			os:      "linux",
+			arch:    arch64bit,
+			version: "jq-1.7",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-amd64",
 		},
 		{
-			os:   "linux",
-			arch: arch32bit,
-			url:  prefix + "jq-linux32",
+			os:      "linux",
+			arch:    archARM64,
+			version: "jq-1.7",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-arm64",
 		},
 		{
-			os:   "ming",
-			arch: arch64bit,
-			url:  prefix + "jq-win64.exe",
+			os:      "linux",
+			arch:    archARM7,
+			version: "jq-1.7",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.7/jq-linux-armhf",
 		},
 		{
-			os:   "ming",
-			arch: arch32bit,
-			url:  prefix + "jq-win32.exe",
+			os:      "ming",
+			arch:    arch64bit,
+			version: "jq-1.7",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.7/jq-windows-amd64.exe",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: "jq-1.6",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.6/jq-osx-amd64",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: "jq-1.6",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: "jq-1.6",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64",
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: "jq-1.6",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux32",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: "jq-1.6",
+			url:     "https://github.com/jqlang/jq/releases/download/jq-1.6/jq-win64.exe",
 		},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.os+" "+tc.arch, func(r *testing.T) {
-			got, err := tool.GetURL(tc.os, tc.arch, tool.Version, false)
+		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
+			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2837,7 +2870,6 @@ func Test_DownloadJq(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_DownloadOperatorSDK(t *testing.T) {

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -104,27 +104,47 @@ func MakeTools() Tools {
 			Repo:        "jq",
 			Name:        "jq",
 			Description: "jq is a lightweight and flexible command-line JSON processor",
-			BinaryTemplate: `{{$arch := "arm"}}
+			BinaryTemplate: `
+				{{- if or (eq .Version "jq-1.6") (eq .Version "jq-1.5") -}}
+					{{$os := .OS}}
+					{{$ext := ""}}
+					{{- if eq .OS "darwin" -}}
+						{{$os = "osx-amd"}}
+					{{- else if HasPrefix .OS "ming" -}}
+						{{$os = "win"}}
+						{{$ext = ".exe"}}
+					{{- end -}}
 
-{{- if eq .Arch "x86_64" -}}
-{{$arch = "64"}}
-{{- else if eq .Arch "arm64" -}}
-{{$arch = "64"}}
-{{- else -}}
-{{$arch = "32"}}
-{{- end -}}
+					{{$arch := ""}}
+					{{- if or (eq .Arch "x86_64") (eq .Arch "arm64") (eq .Arch "aarch64") -}}
+						{{$arch = "64"}}
+					{{- else -}}
+						{{$arch = "32"}}
+					{{- end -}}
 
-{{$ext := ""}}
-{{$os := .OS}}
+					{{.Version}}/jq-{{$os}}{{$arch}}{{$ext}}
+				{{- else -}}
 
-{{ if HasPrefix .OS "ming" -}}
-{{$ext = ".exe"}}
-{{$os = "win"}}
-{{- else if eq .OS "darwin" -}}
-{{$os = "osx-amd"}}
-{{- end -}}
+					{{$os := .OS}}
+					{{$ext := ""}}
+					{{- if eq .OS "darwin" -}}
+						{{$os = "macos"}}
+					{{- else if HasPrefix .OS "ming" -}}
+						{{$os = "windows"}}
+						{{$ext = ".exe"}}
+					{{- end -}}
 
-{{.Version}}/jq-{{$os}}{{$arch}}{{$ext}}`,
+					{{$arch := .Arch}}
+					{{- if eq .Arch "x86_64" -}}
+						{{$arch = "amd64"}}
+					{{- else if eq .Arch "aarch64" -}}
+						{{$arch = "arm64"}}
+					{{- else if or (eq .Arch "armv6l") (eq .Arch "armv7l") -}}
+						{{$arch = "armhf"}}
+					{{- end -}}
+
+					{{.Version}}/jq-{{$os}}-{{$arch}}{{$ext}}
+				{{- end -}}`,
 		})
 
 	// https://storage.googleapis.com/kubernetes-release/release/v1.22.2/bin/darwin/amd64/kubectl


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
jq 1.7 has been released. This PR fixes the executable name for the new release.

## Motivation and Context
jq maintainers changed the executable names to support various CPU architectures.
Previously something like `jq-linux64` but now `jq-linux-amd64` and `jq-linux-arm64`.
They temporarily added the executable with old names to fix for the latest URLs (https://github.com/jqlang/jq/issues/2877).
But they might not retain the executable with the old names.

## How Has This Been Tested?
Following commands passed.
```
go test ./...
go build && ./hack/test-tool.sh jq
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
