### PR TITLE
Enable self-update for arkade

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -4,9 +4,17 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/alexellis/arkade/pkg"
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/alexellis/arkade/pkg/get"
+	"github.com/alexellis/go-execute/v2"
 	"github.com/morikuni/aec"
 	"github.com/spf13/cobra"
 )
@@ -19,25 +27,106 @@ func MakeUpdate() *cobra.Command {
 		Aliases:      []string{"u"},
 		SilenceUsage: false,
 	}
-	command.Run = func(cmd *cobra.Command, args []string) {
-		fmt.Println(arkadeUpdate)
+	command.RunE = func(cmd *cobra.Command, args []string) error {
 
-		fmt.Println("\n", aec.Bold.Apply(pkg.SupportMessageShort))
+		name := "arkade"
+		toolList := get.MakeTools()
+		var tool *get.Tool
+		for _, t := range toolList {
+			if t.Name == name {
+				tool = &t
+				break
+			}
+		}
+
+		release, err := get.FindGitHubRelease("alexellis", name)
+		if err != nil {
+			return err
+		}
+
+		executable, err := os.Executable()
+		if err != nil {
+			return err
+		}
+
+		task := execute.ExecTask{
+			Command: executable,
+			Args:    []string{"version"},
+		}
+
+		res, err := task.Execute(context.TODO())
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Latest release: %s\n", release)
+
+		if strings.Contains(res.Stdout, release) {
+			fmt.Println("You are already using the latest version of arkade.")
+
+			fmt.Println("\n\n", aec.Bold.Apply(pkg.SupportMessageShort))
+
+			return nil
+		}
+
+		arch, operatingSystem := env.GetClientArch()
+		arch = strings.ToLower(arch)
+		operatingSystem = strings.ToLower(operatingSystem)
+
+		if arch == "x86_64" {
+			arch = "amd64"
+		}
+
+		downloadUrl, err := get.GetDownloadURL(tool, operatingSystem, arch, release, false)
+		if err != nil {
+			return err
+		}
+
+		binary, err := get.DownloadFileP(downloadUrl, true)
+		if err != nil {
+			return err
+		}
+
+		if err := replaceExec(executable, binary); err != nil {
+			return err
+		}
+
+		fmt.Printf("Replaced: %s.. OK.", executable)
+
+		fmt.Println("\n\n", aec.Bold.Apply(pkg.SupportMessageShort))
+		return nil
 	}
 	return command
 }
 
-const arkadeUpdate = `You can update arkade with the following:
+// Copy the new binary to the same directory as the current binary before calling os.Rename to prevent an
+// 'invalid cross-device link' error because the source and destination are not on the same file system.
+func replaceExec(currentExec, newBinary string) error {
+	targetDir := filepath.Dir(currentExec)
+	filename := filepath.Base(currentExec)
+	newExec := filepath.Join(targetDir, fmt.Sprintf(".%s.new", filename))
 
-# Remove cached versions of tools
-rm -rf $HOME/.arkade
+	// Copy the contents of newbinary to a new executable file
+	sf, err := os.Open(newBinary)
+	if err != nil {
+		return err
+	}
+	defer sf.Close()
 
-# For Linux/MacOS:
-curl -SLfs https://get.arkade.dev | sudo sh
+	df, err := os.OpenFile(newExec, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	defer df.Close()
 
-# For Windows (using Git Bash)
-curl -SLfs https://get.arkade.dev | sh
+	if _, err := io.Copy(df, sf); err != nil {
+		return err
+	}
 
-# Or download from GitHub: https://github.com/alexellis/arkade/releases
+	// Replace the current executable file with the new executable file
+	if err := os.Rename(newExec, currentExec); err != nil {
+		return err
+	}
 
-Thanks for using arkade!`
+	return nil
+}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -31,7 +31,11 @@ func MakeUpdate() *cobra.Command {
 		SilenceErrors: false,
 	}
 
+	command.Flags().Bool("verify", true, "Verify the checksum of the downloaded binary")
+
 	command.RunE = func(cmd *cobra.Command, args []string) error {
+
+		verifyDigest, _ := cmd.Flags().GetBool("verify")
 
 		name := "arkade"
 		toolList := get.MakeTools()
@@ -91,17 +95,19 @@ func MakeUpdate() *cobra.Command {
 			return err
 		}
 
-		digest, err := downloadDigest(downloadUrl + ".sha256")
-		if err != nil {
-			return err
-		}
+		if verifyDigest {
+			digest, err := downloadDigest(downloadUrl + ".sha256")
+			if err != nil {
+				return err
+			}
 
-		match, err := compareSHA(digest, newBinary)
-		if err != nil {
-			return fmt.Errorf("SHA256 checksum failed for %s, error: %w", newBinary, err)
-		}
-		if !match {
-			return fmt.Errorf("SHA256 checksum failed for %s", newBinary)
+			match, err := compareSHA(digest, newBinary)
+			if err != nil {
+				return fmt.Errorf("SHA256 checksum failed for %s, error: %w", newBinary, err)
+			}
+			if !match {
+				return fmt.Errorf("SHA256 checksum failed for %s", newBinary)
+			}
 		}
 
 		if err := replaceExec(executable, newBinary); err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,7 +24,9 @@ func MakeVersion() *cobra.Command {
 		Aliases:      []string{"v"},
 		SilenceUsage: false,
 	}
+
 	command.Run = func(cmd *cobra.Command, args []string) {
+
 		PrintArkadeASCIIArt()
 		if len(pkg.Version) == 0 {
 			fmt.Println("Version: dev")

--- a/pkg/thanks.go
+++ b/pkg/thanks.go
@@ -4,4 +4,4 @@
 package pkg
 
 // SupportMessageShort shows how to support arkade
-const SupportMessageShort = `🐳 Want to speed up your CI 2-3x, whilst lowering costs? https://actuated.dev`
+const SupportMessageShort = `🚀 Speed up GitHub Actions/GitLab CI + reduce costs: https://actuated.dev`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Rather than printing bash commands to execute, as arkade used to do, this downloads arkade using itself and then replaces its binary.

## Motivation and Context

It's been requested a few times before, and would make keeping up to date a lot easier, by putting `arkade update` into `.bashrc` or similar, it'd update each time a new terminal was opened (if it needed to)

Checksum verification is included which works by downloading a suffix of `.sha256` from the same URL as the binary.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on MacOS Arm64 and Linux AMD64, in both instances the running binary was replaced by the one on GitHub as expected.

Linux:

```
alex@bq:~/go/src/github.com/alexellis/arkade$ uname -p -o
x86_64 GNU/Linux
alex@bq:~/go/src/github.com/alexellis/arkade$ sudo -E /usr/local/go/bin/go build -o /usr/local/bin/arkade
alex@bq:~/go/src/github.com/alexellis/arkade$ sudo arkade update 
Latest release: 0.10.7
9.27 MiB / 9.27 MiB [-------------------------------------------------------------------] 100.00%
Checksum verified..OK.
Replaced: /usr/local/bin/arkade..OK.

 🐳 Want to speed up your CI 2-3x, whilst lowering costs? https://actuated.dev
alex@bq:~/go/src/github.com/alexellis/arkade$ 
```

MacOS Arm64:

```
alex@ae-m2 arkade % uname -p -o
Darwin arm
alex@ae-m2 arkade % go build -o /usr/local/bin/arkade
alex@ae-m2 arkade % arkade update                    
Latest release: 0.10.7
9.72 MiB / 9.72 MiB [-------------------------------------------------------------------------------------------------------] 100.00%
Checksum verified..OK.
Replaced: /usr/local/bin/arkade..OK.

 🐳 Want to speed up your CI 2-3x, whilst lowering costs? https://actuated.dev
alex@ae-m2 arkade % 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

I'll update the documentation after there's been one or two releases to show the version detection works as expected
