### PR TITLE
Fix issue with new version of go-execute

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -15,7 +15,10 @@ import (
 
 // GetClientArch returns a pair of arch and os
 func GetClientArch() (arch string, os string) {
-	task := execute.ExecTask{Command: "uname", Args: []string{"-m"}, StreamStdio: false}
+	task := execute.ExecTask{
+		Command:     "uname",
+		Args:        []string{"-m"},
+		StreamStdio: false}
 	res, err := task.Execute(context.Background())
 	if err != nil {
 		log.Println(err)
@@ -23,7 +26,9 @@ func GetClientArch() (arch string, os string) {
 
 	archResult := strings.TrimSpace(res.Stdout)
 
-	taskOS := execute.ExecTask{Command: "uname", Args: []string{"-s"}, StreamStdio: false}
+	taskOS := execute.ExecTask{Command: "uname",
+		Args:        []string{"-s"},
+		StreamStdio: false}
 	resOS, errOS := taskOS.Execute(context.Background())
 	if errOS != nil {
 		log.Println(errOS)

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -71,34 +71,12 @@ func DownloadHelm(userPath, clientArch, clientOS, subdir string) error {
 	return nil
 }
 
-func HelmInit() error {
-	fmt.Println("Running \"helm init\".")
-	subdir := ""
-
-	task := execute.ExecTask{
-		Command:     env.LocalBinary("helm", subdir),
-		Env:         os.Environ(),
-		Args:        []string{"init", "--client-only"},
-		StreamStdio: true,
-	}
-
-	res, err := task.Execute(context.Background())
-
-	if err != nil {
-		return err
-	}
-
-	if res.ExitCode != 0 {
-		return fmt.Errorf("exit code %d", res.ExitCode)
-	}
-	return nil
-}
-
 func UpdateHelmRepos(helm3 bool) error {
 	subdir := ""
 
 	task := execute.ExecTask{
-		Command:     fmt.Sprintf("%s repo update", env.LocalBinary("helm", subdir)),
+		Command:     env.LocalBinary("helm", subdir),
+		Args:        []string{"repo", "update"},
 		Env:         os.Environ(),
 		StreamStdio: true,
 	}
@@ -123,7 +101,8 @@ func AddHelmRepo(name, url string, update bool) error {
 	}
 
 	task := execute.ExecTask{
-		Command:     fmt.Sprintf("%s repo add %s %s --force-update", env.LocalBinary("helm", subdir), name, url),
+		Command:     env.LocalBinary("helm", subdir),
+		Args:        []string{"repo", "add", name, url, "--force-update"},
 		Env:         os.Environ(),
 		StreamStdio: true,
 	}
@@ -140,7 +119,8 @@ func AddHelmRepo(name, url string, update bool) error {
 
 	if update {
 		task := execute.ExecTask{
-			Command:     fmt.Sprintf("%s repo update", env.LocalBinary("helm", subdir)),
+			Command:     env.LocalBinary("helm", subdir),
+			Args:        []string{"repo", "update"},
 			Env:         os.Environ(),
 			StreamStdio: true,
 		}
@@ -180,7 +160,8 @@ func FetchChart(chart, version string) error {
 		return mkErr
 	}
 	task := execute.ExecTask{
-		Command:     fmt.Sprintf("%s fetch %s --untar=true --untardir %s%s", env.LocalBinary("helm", subdir), chart, chartsPath, versionStr),
+		Command:     env.LocalBinary("helm", subdir),
+		Args:        []string{"fetch", chart, "--untar=true", "--untardir", chartsPath + versionStr},
 		Env:         os.Environ(),
 		StreamStdio: true,
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix issue with new version of go-execute

## Motivation and Context

Fixes: #978

Due to the way go-execute had to change for Windows users command can only specify a single command or binary, rather than a whole string separated by spaces. This commit makes sure Args is always used to pass in extra arguments.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
go run . install kubernetes-dashboard

alex@ae-m2 arkade % kubectl get pods -A -w
NAMESPACE              NAME                                         READY   STATUS    RESTARTS   AGE
kubernetes-dashboard   kubernetes-dashboard-b887d64f-nw5t4          1/1     Running   0          5s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
