### PR TITLE
add tests for helm utils

### DIFF
--- a/pkg/helm/io_test.go
+++ b/pkg/helm/io_test.go
@@ -1,0 +1,217 @@
+package helm
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func Test_Load(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    ValuesMap
+		err     bool
+	}{
+		{
+			name: "valid yaml file",
+			content: `
+replicaCount: 1
+image: demo-operator
+nginx:
+  image: nginx
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""`,
+			want: ValuesMap{
+				"replicaCount": 1,
+				"image":        "demo-operator",
+				"nginx": ValuesMap{
+					"image":      "nginx",
+					"pullPolicy": "IfNotPresent",
+				},
+				"imagePullSecrets": []interface{}{},
+				"nameOverride":     "",
+				"fullnameOverride": "",
+			},
+		},
+		{
+			name:    "empty yaml file",
+			content: ``,
+			want:    ValuesMap{},
+		},
+		{
+			name: "invalid yaml file",
+			content: `
+			replicaCount: 1
+			image:
+			repository: nginx`,
+			err: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := os.CreateTemp("", "app-helm-*.yaml")
+			if err != nil {
+				t.Fatalf("failed to create yaml file for load test: %v", err)
+			}
+			// defer os.Remove(file.Name())
+
+			_, err = file.WriteString(tc.content)
+			if err != nil {
+				t.Fatalf("failed to write yaml file for load test: %v", err)
+			}
+
+			err = file.Close()
+			if err != nil {
+				t.Fatalf("failed to close yaml file for load test: %v", err)
+			}
+
+			got, err := Load(file.Name())
+			if !tc.err && err != nil {
+				t.Fatalf("failed to parse yaml file full path for load test: %v", err)
+			}
+
+			if !tc.err && !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("fwant: %q\n but got: %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func Test_ReplaceValuesInHelmValuesFile(t *testing.T) {
+	tests := []struct {
+		name        string
+		fileContent string
+		values      map[string]string
+		want        string
+	}{
+		{
+			name: "replace successfully",
+			fileContent: `
+              replicaCount: "1"
+              nginx:
+                image: NGINX_IMG
+                pullPolicy: IfNotPresent
+              imagePullSecrets: []
+              nameOverride: ""
+              fullnameOverride: ""`,
+			values: map[string]string{
+				"NGINX_IMG": "nginx",
+			},
+			want: `
+              replicaCount: "1"
+              nginx:
+                image: nginx
+                pullPolicy: IfNotPresent
+              imagePullSecrets: []
+              nameOverride: ""
+              fullnameOverride: ""`,
+		},
+		{
+			name: "replace values not found",
+			fileContent: `
+              replicaCount: "1"
+              nginx:
+                image: NGINX_IMG
+                pullPolicy: IfNotPresent
+              imagePullSecrets: []
+              nameOverride: ""
+              fullnameOverride: ""`,
+			values: map[string]string{
+				"TEST_IMG": "test",
+			},
+			want: `
+              replicaCount: "1"
+              nginx:
+                image: NGINX_IMG
+                pullPolicy: IfNotPresent
+              imagePullSecrets: []
+              nameOverride: ""
+              fullnameOverride: ""`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			file, err := os.CreateTemp("", "app-helm-*.yaml")
+			if err != nil {
+				t.Fatalf("failed to create yaml file for load test: %v", err)
+			}
+			defer os.Remove(file.Name())
+
+			_, err = file.WriteString(tc.fileContent)
+			if err != nil {
+				t.Fatalf("failed to write yaml file for load test: %v", err)
+			}
+
+			err = file.Close()
+			if err != nil {
+				t.Fatalf("failed to close yaml file for load test: %v", err)
+			}
+
+			got, err := ReplaceValuesInHelmValuesFile(tc.values, file.Name())
+			if err != nil {
+				t.Fatalf("failed to replace values in yaml file: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("fwant: %q\n but got: %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func Test_FilterImagesUptoDepth(t *testing.T) {
+	tests := []struct {
+		name   string
+		values ValuesMap
+		depth  int
+		want   map[string]string
+	}{
+		{
+			name: "fetch images upto level 1",
+			values: ValuesMap{
+				"nginx": ValuesMap{
+					"image":      "nginx",
+					"pullPolicy": "IfNotPresent",
+				},
+			},
+			depth: 1,
+			want: map[string]string{
+				"nginx": "nginx",
+			},
+		},
+		{
+			name: "fetch images upto level 2",
+			values: ValuesMap{
+				"deployment1": ValuesMap{
+					"container1": ValuesMap{
+						"image":      "nginx",
+						"pullPolicy": "IfNotPresent",
+					},
+					"container2": ValuesMap{
+						"image":      "deamonjob",
+						"pullPolicy": "IfNotPresent",
+					},
+				},
+			},
+			depth: 2,
+			want: map[string]string{
+				"nginx":     "nginx",
+				"deamonjob": "deamonjob",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FilterImagesUptoDepth(tc.values, tc.depth)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("fwant: %q\n but got: %q", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add tests for helm utils
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Closes #986

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh TOOL_NAME
```
NA. As it's logic tests included , so nothing additional tests are needed to be done.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
