### PR TITLE
Add support of cloud-hypervisor and ch-remote binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,8 +735,10 @@ There are 56 apps that you can install on your cluster.
 | [bun](https://github.com/oven-sh/bun)                                        | Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one.                                                             |
 | [butane](https://github.com/coreos/butane)                                   | Translates human readable Butane Configs into machine readable Ignition Configs                                                                                 |
 | [caddy](https://github.com/caddyserver/caddy)                                | Caddy is an extensible server platform that uses TLS by default                                                                                                 |
+| [ch-remote](https://github.com/cloud-hypervisor/cloud-hypervisor)            | The ch-remote binary is used for controlling an running Virtual Machine.                                                                                        |
 | [cilium](https://github.com/cilium/cilium-cli)                               | CLI to install, manage & troubleshoot Kubernetes clusters running Cilium.                                                                                       |
 | [civo](https://github.com/civo/cli)                                          | CLI for interacting with your Civo resources.                                                                                                                   |
+| [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor)     | Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of the KVM hypervisor and the Microsoft Hypervisor (MSHV).                    |
 | [clusterawsadm](https://github.com/kubernetes-sigs/cluster-api-provider-aws) | Kubernetes Cluster API Provider AWS Management Utility                                                                                                          |
 | [clusterctl](https://github.com/kubernetes-sigs/cluster-api)                 | The clusterctl CLI tool handles the lifecycle of a Cluster API management cluster                                                                               |
 | [cmctl](https://github.com/cert-manager/cert-manager)                        | cmctl is a CLI tool that helps you manage cert-manager and its resources inside your cluster.                                                                   |
@@ -868,6 +870,6 @@ There are 56 apps that you can install on your cluster.
 | [waypoint](https://github.com/hashicorp/waypoint)                            | Easy application deployment for Kubernetes and Amazon ECS                                                                                                       |
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                                           |
 | [yt-dlp](https://github.com/yt-dlp/yt-dlp)                                   | Fork of youtube-dl with additional features and fixes                                                                                                           |
-There are 144 tools, use `arkade get NAME` to download one.
+There are 146 tools, use `arkade get NAME` to download one.
 
 > Note to contributors, run `arkade get --format markdown` to generate this list

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -6284,38 +6284,38 @@ func Test_DownloadKubeBurner(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "v1.6"
+	const toolVersion = "v1.8.1"
 
 	tests := []test{
 		{
 			os:      "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.6/kube-burner-V1.6-Linux-x86_64.tar.gz`,
+			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-linux-x86_64.tar.gz`,
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.6/kube-burner-V1.6-Darwin-x86_64.tar.gz`,
+			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-darwin-x86_64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.6/kube-burner-V1.6-Linux-arm64.tar.gz`,
+			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-linux-arm64.tar.gz`,
 		},
 		{
 			os:      "darwin",
 			arch:    archDarwinARM64,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.6/kube-burner-V1.6-Darwin-arm64.tar.gz`,
+			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-darwin-arm64.tar.gz`,
 		},
 		{
 			os:      "ming",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.6/kube-burner-V1.6-Windows-x86_64.zip`,
+			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-windows-x86_64.zip`,
 		},
 	}
 
@@ -6857,6 +6857,70 @@ func Test_DownloadSnowMachine(t *testing.T) {
 			arch:    archDarwinARM64,
 			version: version,
 			url:     `https://github.com/rgee0/snowmachine/releases/download/1.0.1/snowmachine-darwin-arm64`,
+		},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
+func Test_DownloadCloudHypervisor(t *testing.T) {
+	tools := MakeTools()
+	name := "cloud-hypervisor"
+	const version = "v36.1"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: version,
+			url:     `https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v36.1/cloud-hypervisor-static`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: version,
+			url:     `https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v36.1/cloud-hypervisor-static-aarch64`,
+		},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
+func Test_DownloadCloudHypervisorRemote(t *testing.T) {
+	tools := MakeTools()
+	name := "ch-remote"
+	const version = "v36.1"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: version,
+			url:     `https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v36.1/ch-remote-static`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: version,
+			url:     `https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v36.1/ch-remote-static-aarch64`,
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -3626,6 +3626,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			Owner:       "cloud-bulldozer",
 			Repo:        "kube-burner",
 			Name:        "kube-burner",
+			Version:     "v1.8.1",
 			Description: "A tool aimed at stressing Kubernetes clusters by creating or deleting a high quantity of objects.",
 			BinaryTemplate: `
  					{{$os := .OS}}
@@ -3633,11 +3634,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
  					{{$ext := "tar.gz"}}
  	
  					{{- if eq .OS "darwin" -}}
- 						{{$os = "Darwin"}}
+ 						{{$os = "darwin"}}
  					{{- else if eq .OS "linux" -}}
- 						{{ $os = "Linux" }}
+ 						{{ $os = "linux" }}
 					{{- else if HasPrefix .OS "ming" -}}
-						{{$os = "Windows"}}
+						{{$os = "windows"}}
 						{{$ext = "zip"}}
  					{{- end -}}
 
@@ -3957,5 +3958,40 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 	{{- end -}}`,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:       "cloud-hypervisor",
+			Repo:        "cloud-hypervisor",
+			Name:        "cloud-hypervisor",
+			Description: "Cloud Hypervisor is an open source Virtual Machine Monitor (VMM) that runs on top of the KVM hypervisor and the Microsoft Hypervisor (MSHV).",
+			BinaryTemplate: `
+				{{ $os := .OS }}
+				{{ $arch := .Arch }}
+				{{ $ext := "" }}
+	
+				{{- if (eq .Arch "aarch64") -}}
+					{{ $ext = "-aarch64" }}
+				{{- end -}}
+	
+				cloud-hypervisor-static{{$ext}}`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:       "cloud-hypervisor",
+			Repo:        "cloud-hypervisor",
+			Name:        "ch-remote",
+			Description: "The ch-remote binary is used for controlling an running Virtual Machine.",
+			BinaryTemplate: `
+					{{ $os := .OS }}
+					{{ $arch := .Arch }}
+					{{ $ext := "" }}
+		
+					{{- if (eq .Arch "aarch64") -}}
+						{{ $ext = "-aarch64" }}
+					{{- end -}}
+		
+					ch-remote-static{{$ext}}`,
+		})
 	return tools
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Add support for cloud-hypervisor binary and ch-remote client binary to work with VMM
2. Existing `kube-burner` download was broken as per their past few latest releases.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
closes #1011 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh TOOL_NAME
```
1. Run `go build && ./hack/test-tool.sh ch-remote` produces below output
```
+ ./arkade get ch-remote --arch arm64 --os darwin --quiet
+ file /home/nitishkumar/.arkade/bin/ch-remote
/home/nitishkumar/.arkade/bin/ch-remote: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=b9899369fb13f74ea35208d6d4053763f7ec87aa, stripped
+ rm /home/nitishkumar/.arkade/bin/ch-remote
+ echo

+ ./arkade get ch-remote --arch x86_64 --os darwin --quiet
+ file /home/nitishkumar/.arkade/bin/ch-remote
/home/nitishkumar/.arkade/bin/ch-remote: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=b9899369fb13f74ea35208d6d4053763f7ec87aa, stripped
+ rm /home/nitishkumar/.arkade/bin/ch-remote
+ echo

+ ./arkade get ch-remote --arch x86_64 --os linux --quiet
+ file /home/nitishkumar/.arkade/bin/ch-remote
/home/nitishkumar/.arkade/bin/ch-remote: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=b9899369fb13f74ea35208d6d4053763f7ec87aa, stripped
+ rm /home/nitishkumar/.arkade/bin/ch-remote
+ echo

+ ./arkade get ch-remote --arch aarch64 --os linux --quiet
+ file /home/nitishkumar/.arkade/bin/ch-remote
/home/nitishkumar/.arkade/bin/ch-remote: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
+ rm /home/nitishkumar/.arkade/bin/ch-remote
+ echo

+ ./arkade get ch-remote --arch x86_64 --os mingw --quiet
+ file /home/nitishkumar/.arkade/bin/ch-remote.exe
/home/nitishkumar/.arkade/bin/ch-remote.exe: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=b9899369fb13f74ea35208d6d4053763f7ec87aa, stripped
+ rm /home/nitishkumar/.arkade/bin/ch-remote.exe
+ echo
```

2. 1. Run `go build && ./hack/test-tool.sh cloud-hypervisor` produces below output
```
+ ./arkade get cloud-hypervisor --arch arm64 --os darwin --quiet
+ file /home/nitishkumar/.arkade/bin/cloud-hypervisor
/home/nitishkumar/.arkade/bin/cloud-hypervisor: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=ead37764790ed54e3bdc6db0e7ccc1615df4ca08, stripped
+ rm /home/nitishkumar/.arkade/bin/cloud-hypervisor
+ echo

+ ./arkade get cloud-hypervisor --arch x86_64 --os darwin --quiet
+ file /home/nitishkumar/.arkade/bin/cloud-hypervisor
/home/nitishkumar/.arkade/bin/cloud-hypervisor: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=ead37764790ed54e3bdc6db0e7ccc1615df4ca08, stripped
+ rm /home/nitishkumar/.arkade/bin/cloud-hypervisor
+ echo

+ ./arkade get cloud-hypervisor --arch x86_64 --os linux --quiet
+ file /home/nitishkumar/.arkade/bin/cloud-hypervisor
/home/nitishkumar/.arkade/bin/cloud-hypervisor: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=ead37764790ed54e3bdc6db0e7ccc1615df4ca08, stripped
+ rm /home/nitishkumar/.arkade/bin/cloud-hypervisor
+ echo

+ ./arkade get cloud-hypervisor --arch aarch64 --os linux --quiet
+ file /home/nitishkumar/.arkade/bin/cloud-hypervisor
/home/nitishkumar/.arkade/bin/cloud-hypervisor: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
+ rm /home/nitishkumar/.arkade/bin/cloud-hypervisor
+ echo

+ ./arkade get cloud-hypervisor --arch x86_64 --os mingw --quiet
+ file /home/nitishkumar/.arkade/bin/cloud-hypervisor.exe
/home/nitishkumar/.arkade/bin/cloud-hypervisor.exe: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=ead37764790ed54e3bdc6db0e7ccc1615df4ca08, stripped
+ rm /home/nitishkumar/.arkade/bin/cloud-hypervisor.exe
+ echo
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
