### PR TITLE
helm: add arkade chart bump to bump chart versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ With over 120 CLIs and 55 Kubernetes apps (charts, manifests, installers) availa
   - [Download CLI tools with arkade](#download-cli-tools-with-arkade)
   - [Install System Packages](#install-system-packages)
   - [Install CLIs during CI with GitHub Actions](#install-clis-during-ci-with-github-actions)
+  - [Bump Helm chart versions](#bump-helm-chart-versions)
   - [Verify and upgrade images in Helm charts](#verify-and-upgrade-images-in-helm-charts)
     - [Upgrade images within a Helm chart](#upgrade-images-within-a-helm-chart)
   - [Verify images within a helm chart](#verify-images-within-a-helm-chart)
@@ -282,6 +283,25 @@ If you just need system applications, you could also try "setup-arkade":
         arkade system install containerd
         arkade system install go
 ```
+
+## Bump Helm chart versions
+
+To bump the patch version of your Helm chart, run `arkade chart bump -f ./chart/values.yaml`. This updates the patch component of the version specified in Chart.yaml.
+
+```bash
+arkade chart bump -f ./charts/flagger/values.yaml
+charts/flagger/Chart.yaml 1.36.0 => 1.37.0
+```
+
+By default, the new version is written to stdout. To bump the version in the file, run the above command with the `--write` flag.
+To bump the version in the chart's Chart.yaml only if the chart has any changes, specify the `--check-for-updates` flag:
+
+```bash
+arkade chart bump -f ./charts/flagger/values.yaml --check-for-updates
+no changes detected in charts/flagger/values.yaml; skipping version bump
+```
+
+The directory that contains the Helm chart should be a Git repository. If the flag is specified, the command runs `git diff --exit-code <file>` to figure out if the file has any changes.
 
 ## Verify and upgrade images in Helm charts
 

--- a/cmd/chart/bump.go
+++ b/cmd/chart/bump.go
@@ -1,0 +1,147 @@
+package chart
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/Masterminds/semver"
+	"github.com/alexellis/arkade/pkg/helm"
+	"github.com/alexellis/go-execute/v2"
+	"github.com/spf13/cobra"
+)
+
+const (
+	versionKey        = "version"
+	ChartYamlFileName = "Chart.yaml"
+	ChartYmlFileName  = "Chart.yml"
+)
+
+func MakeBump() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "bump",
+		Short: "Bump the patch version of the Helm chart.",
+		Long: `Bump the version present in the Chart.yaml of a Helm chart
+if there are changes staged in git.
+
+Add --force to bump the version even if there are not changes staged in git.
+`,
+		Example: `  # Bump if there are changes
+  arkade chart bump -f ./chart/values.yaml
+
+  # Force a bump, even if there are no changes 
+  arkade chart bump -f ./charts/values.yaml --check-for-updates`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().StringP("file", "f", "", "Path to values.yaml file")
+	command.Flags().BoolP("verbose", "v", false, "Verbose output")
+	command.Flags().BoolP("write", "w", false, "Write the updated values back to the file, or stdout when set to false")
+	command.Flags().Bool("force", false, "Update the version even if there are no changes staged in the adjacent folder to Chart.yaml")
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		valuesFile, err := cmd.Flags().GetString("file")
+		if err != nil {
+			return fmt.Errorf("invalid value for --file")
+		}
+		if valuesFile == "" {
+			return fmt.Errorf("flag --file is required")
+		}
+		verbose, err := cmd.Flags().GetBool("verbose")
+		if err != nil {
+			return err
+		}
+
+		write, err := cmd.Flags().GetBool("write")
+		if err != nil {
+			return err
+		}
+		force, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			return err
+		}
+
+		chartDir := filepath.Dir(valuesFile)
+		chartYamlPath := filepath.Join(chartDir, ChartYamlFileName)
+
+		// Map with key as the path to Chart.yaml and the value as the parsed contents of Chart.yaml
+		var values helm.ValuesMap
+		// Try to read a Chart.yaml, but if thats unsuccessful then fall back to Chart.yml
+		if values, err = helm.Load(chartYamlPath); err != nil {
+			if verbose {
+				log.Printf("unable to read %s, falling back to Chart.yml\n", chartYamlPath)
+			}
+			chartYamlPath = filepath.Join(chartDir, ChartYmlFileName)
+			if values, err = helm.Load(chartYamlPath); err != nil {
+				return fmt.Errorf("unable to read Chart.yaml or Chart.yml in directory %s", chartDir)
+			}
+		}
+
+		// If the yaml does not contain a `version` key then error out.
+		if val, ok := values[versionKey]; !ok {
+			return fmt.Errorf("unable to find a version in %s", chartYamlPath)
+		} else {
+			version, ok := val.(string)
+			if !ok {
+				log.Printf("unable to find a valid version in %s", chartYamlPath)
+			}
+			if !force {
+				absPath, err := filepath.Abs(chartDir)
+				if err != nil {
+					return err
+				}
+
+				// Run `git diff --exit-code <file>` to check if any files in the chart dir changed.
+				// An exit code of 0 indicates that there are no changes, thus we skip bumping the
+				// version of the chart.
+				cmd := execute.ExecTask{
+					Command: "git",
+					Args:    []string{"diff", "--exit-code", "."},
+					Cwd:     absPath,
+				}
+				res, err := cmd.Execute(context.Background())
+				if err != nil {
+					return fmt.Errorf("could not check updates to chart values: %s", err)
+				}
+
+				if res.ExitCode == 0 {
+					if verbose {
+						fmt.Printf("No changes in: %s, ignoring.\n", chartDir)
+					}
+					os.Exit(0)
+				}
+			}
+
+			ver, err := semver.NewVersion(version)
+			if err != nil {
+				return fmt.Errorf("%s", err)
+			}
+
+			newVer := ver.IncPatch()
+
+			fmt.Printf("%s %s => %s\n", chartYamlPath, ver.String(), newVer.String())
+
+			if write {
+
+				update := map[string]string{
+					fmt.Sprintf("%s: %s", versionKey, ver.String()): fmt.Sprintf("%s: %s", versionKey, newVer.String()),
+				}
+				rawChartYaml, err := helm.ReplaceValuesInHelmValuesFile(update, chartYamlPath)
+				if err != nil {
+					return fmt.Errorf("unable to bump chart version in %s", chartYamlPath)
+				}
+				if err = os.WriteFile(chartYamlPath, []byte(rawChartYaml), 0600); err != nil {
+					return fmt.Errorf("unable to write updated yaml to %s", chartYamlPath)
+				}
+				fmt.Printf("Wrote to: %s. OK.\n", chartYamlPath)
+			} else {
+				fmt.Printf("Not updating: %s (--write=false)\n", chartYamlPath)
+			}
+
+		}
+		return nil
+	}
+	return command
+}

--- a/cmd/chart/chart.go
+++ b/cmd/chart/chart.go
@@ -26,6 +26,7 @@ func MakeChart() *cobra.Command {
 
 	command.AddCommand(MakeVerify())
 	command.AddCommand(MakeUpgrade())
+	command.AddCommand(MakeBump())
 
 	return command
 }

--- a/cmd/chart/upgrade.go
+++ b/cmd/chart/upgrade.go
@@ -104,7 +104,8 @@ Otherwise, it returns a non-zero exit code and the updated values.yaml file.`,
 
 			latestTag := vs[0].String()
 
-			if latestTag != tag {
+			// AE: Don't upgrade to an RC tag, even if it's newer.
+			if latestTag != tag && !strings.Contains(latestTag, "-rc") {
 				updated++
 				// Semver is "eating" the "v" prefix, so we need to add it back, if it was there in first place
 				if strings.HasPrefix(tag, "v") {
@@ -127,11 +128,6 @@ Otherwise, it returns a non-zero exit code and the updated values.yaml file.`,
 				return err
 			}
 			log.Printf("Wrote %d updates to: %s", updated, file)
-		}
-
-		if !writeFile {
-			// Output updated YAML file to stdout
-			fmt.Print(rawValues)
 		}
 
 		return nil

--- a/log.txt
+++ b/log.txt
@@ -1,0 +1,2940 @@
+time="2024-02-16T14:22:21Z" level=info msg="HEAD /v2/openfaasltd/actuated-agent/manifests/7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9 HTTP/1.1"
+time="2024-02-16T14:22:21Z" level=info msg="Host: ghcr.io"
+time="2024-02-16T14:22:21Z" level=info msg="User-Agent: containerd/v1.7.13"
+time="2024-02-16T14:22:21Z" level=info msg="Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="HTTP/1.1 401 Unauthorized"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Length: 73"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Type: application/json"
+time="2024-02-16T14:22:21Z" level=info msg="Date: Fri, 16 Feb 2024 14:22:21 GMT"
+time="2024-02-16T14:22:21Z" level=info msg="Www-Authenticate: Bearer realm=\"https://ghcr.io/token\",service=\"ghcr.io\",scope=\"repository:openfaasltd/actuated-agent:pull\""
+time="2024-02-16T14:22:21Z" level=info msg="X-Github-Request-Id: E30C:CEB3:1E27C:7270B:65CF6F9D"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="GET /token?scope=repository%3Aopenfaasltd%2Factuated-agent%3Apull&service=ghcr.io HTTP/1.1"
+time="2024-02-16T14:22:21Z" level=info msg="Host: ghcr.io"
+time="2024-02-16T14:22:21Z" level=info msg="User-Agent: containerd/v1.7.13"
+time="2024-02-16T14:22:21Z" level=info msg="Accept-Encoding: gzip"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="HTTP/1.1 200 OK"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Length: 81"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Type: application/json"
+time="2024-02-16T14:22:21Z" level=info msg="Date: Fri, 16 Feb 2024 14:22:21 GMT"
+time="2024-02-16T14:22:21Z" level=info msg="Docker-Distribution-Api-Version: registry/2.0"
+time="2024-02-16T14:22:21Z" level=info msg="X-Github-Request-Id: E30C:CEB3:1E27D:7270D:65CF6F9D"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="{\"token\":\"djE6b3BlbmZhYXNsdGQvYWN0dWF0ZWQtYWdlbnQ6MTcwODA5MzM0MTM4MzI1Mzk3Mw==\"}"
+time="2024-02-16T14:22:21Z" level=info msg="HEAD /v2/openfaasltd/actuated-agent/manifests/7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9 HTTP/1.1"
+time="2024-02-16T14:22:21Z" level=info msg="Host: ghcr.io"
+time="2024-02-16T14:22:21Z" level=info msg="User-Agent: containerd/v1.7.13"
+time="2024-02-16T14:22:21Z" level=info msg="Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json, */*"
+time="2024-02-16T14:22:21Z" level=info msg="Authorization: Bearer djE6b3BlbmZhYXNsdGQvYWN0dWF0ZWQtYWdlbnQ6MTcwODA5MzM0MTM4MzI1Mzk3Mw=="
+time="2024-02-16T14:22:21Z" level=info
+ghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9: resolving      |[32m[0m--------------------------------------| 
+elapsed: 0.1 s                                                               total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9: resolving      |[32m[0m--------------------------------------| 
+elapsed: 0.2 s                                                               total:   0.0 B (0.0 B/s)                                         
+time="2024-02-16T14:22:21Z" level=info msg="HTTP/1.1 200 OK"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Length: 528"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Type: application/vnd.docker.distribution.manifest.v2+json"
+time="2024-02-16T14:22:21Z" level=info msg="Date: Fri, 16 Feb 2024 14:22:21 GMT"
+time="2024-02-16T14:22:21Z" level=info msg="Docker-Content-Digest: sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d"
+time="2024-02-16T14:22:21Z" level=info msg="Docker-Distribution-Api-Version: registry/2.0"
+time="2024-02-16T14:22:21Z" level=info msg="Etag: \"sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d\""
+time="2024-02-16T14:22:21Z" level=info msg="X-Github-Request-Id: E30C:CEB3:1E27E:72710:65CF6F9D"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="GET /v2/openfaasltd/actuated-agent/blobs/sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c HTTP/1.1"
+time="2024-02-16T14:22:21Z" level=info msg="Host: ghcr.io"
+time="2024-02-16T14:22:21Z" level=info msg="User-Agent: containerd/v1.7.13"
+time="2024-02-16T14:22:21Z" level=info msg="Accept: application/vnd.docker.image.rootfs.diff.tar.gzip, */*"
+time="2024-02-16T14:22:21Z" level=info msg="Accept-Encoding: gzip"
+time="2024-02-16T14:22:21Z" level=info
+[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9: resolving      |[32m[0m--------------------------------------| 
+elapsed: 0.3 s                                                               total:   0.0 B (0.0 B/s)                                         
+time="2024-02-16T14:22:21Z" level=info msg="HTTP/1.1 401 Unauthorized"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Length: 73"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Type: application/json"
+time="2024-02-16T14:22:21Z" level=info msg="Date: Fri, 16 Feb 2024 14:22:21 GMT"
+time="2024-02-16T14:22:21Z" level=info msg="Www-Authenticate: Bearer realm=\"https://ghcr.io/token\",service=\"ghcr.io\",scope=\"repository:openfaasltd/actuated-agent:pull\""
+time="2024-02-16T14:22:21Z" level=info msg="X-Github-Request-Id: E318:5B67:118F068:1645C7B:65CF6F9D"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"authentication required\"}]}"
+time="2024-02-16T14:22:21Z" level=info msg="GET /token?scope=repository%3Aopenfaasltd%2Factuated-agent%3Apull&service=ghcr.io HTTP/1.1"
+time="2024-02-16T14:22:21Z" level=info msg="Host: ghcr.io"
+time="2024-02-16T14:22:21Z" level=info msg="User-Agent: containerd/v1.7.13"
+time="2024-02-16T14:22:21Z" level=info msg="Accept-Encoding: gzip"
+time="2024-02-16T14:22:21Z" level=info
+[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 0.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+time="2024-02-16T14:22:21Z" level=info msg="HTTP/1.1 200 OK"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Length: 81"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Type: application/json"
+time="2024-02-16T14:22:21Z" level=info msg="Date: Fri, 16 Feb 2024 14:22:21 GMT"
+time="2024-02-16T14:22:21Z" level=info msg="Docker-Distribution-Api-Version: registry/2.0"
+time="2024-02-16T14:22:21Z" level=info msg="X-Github-Request-Id: E318:5B67:118F06C:1645C7F:65CF6F9D"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="{\"token\":\"djE6b3BlbmZhYXNsdGQvYWN0dWF0ZWQtYWdlbnQ6MTcwODA5MzM0MTY5MzM1NjM2OQ==\"}"
+time="2024-02-16T14:22:21Z" level=info msg="GET /v2/openfaasltd/actuated-agent/blobs/sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c HTTP/1.1"
+time="2024-02-16T14:22:21Z" level=info msg="Host: ghcr.io"
+time="2024-02-16T14:22:21Z" level=info msg="User-Agent: containerd/v1.7.13"
+time="2024-02-16T14:22:21Z" level=info msg="Accept: application/vnd.docker.image.rootfs.diff.tar.gzip, */*"
+time="2024-02-16T14:22:21Z" level=info msg="Authorization: Bearer djE6b3BlbmZhYXNsdGQvYWN0dWF0ZWQtYWdlbnQ6MTcwODA5MzM0MTY5MzM1NjM2OQ=="
+time="2024-02-16T14:22:21Z" level=info msg="Accept-Encoding: gzip"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="HTTP/1.1 307 Temporary Redirect"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Type: application/octet-stream"
+time="2024-02-16T14:22:21Z" level=info msg="Date: Fri, 16 Feb 2024 14:22:21 GMT"
+time="2024-02-16T14:22:21Z" level=info msg="Docker-Distribution-Api-Version: registry/2.0"
+time="2024-02-16T14:22:21Z" level=info msg="Location: https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c?se=2024-02-16T14%3A30%3A00Z&sig=Ua443Y7ZMvs6WynvrECjPndhwHJgyBfWKD%2BeT6Q71D4%3D&sp=r&spr=https&sr=b&sv=2019-12-12"
+time="2024-02-16T14:22:21Z" level=info msg="X-Github-Request-Id: E318:5B67:118F073:1645C89:65CF6F9D"
+time="2024-02-16T14:22:21Z" level=info msg="Content-Length: 0"
+time="2024-02-16T14:22:21Z" level=info
+time="2024-02-16T14:22:21Z" level=info msg="GET /ghcr1/blobs/sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c?se=2024-02-16T14%3A30%3A00Z&sig=Ua443Y7ZMvs6WynvrECjPndhwHJgyBfWKD%2BeT6Q71D4%3D&sp=r&spr=https&sr=b&sv=2019-12-12 HTTP/1.1"
+time="2024-02-16T14:22:21Z" level=info msg="Host: pkg-containers.githubusercontent.com"
+time="2024-02-16T14:22:21Z" level=info msg="User-Agent: containerd/v1.7.13"
+time="2024-02-16T14:22:21Z" level=info msg="Accept: application/vnd.docker.image.rootfs.diff.tar.gzip, */*"
+time="2024-02-16T14:22:21Z" level=info msg="Referer: https://ghcr.io/v2/openfaasltd/actuated-agent/blobs/sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c"
+time="2024-02-16T14:22:21Z" level=info msg="Accept-Encoding: gzip"
+time="2024-02-16T14:22:21Z" level=info
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 0.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 0.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 0.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 0.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 0.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 1.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 2.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 3.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 4.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 5.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 6.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 7.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 8.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.0 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.1 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.2 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.3 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.4 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.5 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.6 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.7 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.8 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 9.9 s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 10.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 11.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 12.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 13.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 14.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 15.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 16.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 17.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 18.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 19.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 20.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 21.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 22.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 23.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 24.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 25.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 26.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 27.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 28.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 29.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 30.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 31.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 32.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 33.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 34.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 35.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 36.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 37.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 38.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 39.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 40.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 41.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 42.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 43.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 44.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 45.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 46.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 47.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 48.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 49.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 50.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 51.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 52.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 53.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 54.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 55.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.2s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.3s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.4s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.5s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.6s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.7s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.8s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 56.9s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 57.0s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 57.1s                                                                    total:   0.0 B (0.0 B/s)                                         
+[1A[2K[1A[2K[1A[2K[1A[2K[1A[2Kghcr.io/openfaasltd/actuated-agent:7a2d8d3297a3ee36a7e4fb88c5d2d4eaf63338b9:      resolved       |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+manifest-sha256:152839bc259fde7bf3ab154d2dfd3075b8878a2c6697b60dad46b7f600f81f3d: exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+layer-sha256:86151a7b787b651a52606b2212caa9fe6ecd9983cf3853e60ed448f52b40826c:    downloading    |[32m[0m--------------------------------------|    0.0 B/14.8 MiB 
+config-sha256:223706cfe42c7694c2296c1841e02cc99172774af69a9d2d665a53222d06dc07:   exists         |[32m++++++++++++++++++++++++++++++++++++++[0m| 
+elapsed: 57.2s                                                                    total:   0.0 B (0.0 B/s)                                         


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

helm: add arkade chart bump to bump chart versions

## Motivation and Context

Update patch version of charts automatically, whenever there are adjacent files changed in git for the folder next to Chart.yaml.

Closes #1024 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With a change to values.yaml in chart/openfaas
 
```bash
$ ~/go/bin/arkade chart bump -w -f ./chart/openfaas/Chart.yaml
$ echo $?
0

$ echo >> ./chart/openfaas/values.yaml
$ ~/go/bin/arkade chart bump -w -f ./chart/openfaas/Chart.yaml
chart/openfaas/Chart.yaml 14.2.16 => 14.2.17
Wrote to: chart/openfaas/Chart.yaml. OK.
```

```diff
diff --git a/chart/openfaas/Chart.yaml b/chart/openfaas/Chart.yaml
index feb526bd..6b5abc43 100644
--- a/chart/openfaas/Chart.yaml
+++ b/chart/openfaas/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: OpenFaaS - Serverless Functions Made Simple
 name: openfaas
-version: 14.2.16
+version: 14.2.17
```

Thanks to @aryan9600 for his initial work and collaboration on this.