### PR TITLE
update versions of tf / packer / waypoint

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -45,7 +45,7 @@ and provides a fast and easy alternative to a package manager.`,
 
   # Override the version
   arkade get kubectl@v1.19.3
-  arkade get terraform --version=0.12.0
+  arkade get terraform --version=1.7.4
 
   # Override the OS
   arkade get helm --os darwin --arch aarch64

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -210,8 +210,8 @@ func Test_GetDownloadURLs(t *testing.T) {
 		},
 		{
 			name:    "terraform",
-			url:     "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_amd64.zip",
-			version: "1.3.9",
+			url:     "https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_linux_amd64.zip",
+			version: "1.7.4",
 			os:      "linux",
 			arch:    "x86_64",
 		},
@@ -1259,33 +1259,33 @@ func Test_DownloadWaypoint(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "0.6.1"
+	const toolVersion = "0.11.4"
 
 	tests := []test{
 		{os: "ming",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://releases.hashicorp.com/waypoint/0.6.1/waypoint_0.6.1_windows_amd64.zip`,
+			url:     `https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_windows_amd64.zip`,
 		},
 		{os: "darwin",
 			arch:    archARM64,
 			version: toolVersion,
-			url:     `https://releases.hashicorp.com/waypoint/0.6.1/waypoint_0.6.1_darwin_arm64.zip`,
+			url:     `https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_arm64.zip`,
 		},
 		{os: "darwin",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://releases.hashicorp.com/waypoint/0.6.1/waypoint_0.6.1_darwin_amd64.zip`,
+			url:     `https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_amd64.zip`,
 		},
 		{os: "linux",
 			arch:    archARM7,
 			version: toolVersion,
-			url:     `https://releases.hashicorp.com/waypoint/0.6.1/waypoint_0.6.1_linux_arm.zip`,
+			url:     `https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_arm.zip`,
 		},
 		{os: "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://releases.hashicorp.com/waypoint/0.6.1/waypoint_0.6.1_linux_amd64.zip`,
+			url:     `https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_linux_amd64.zip`,
 		},
 	}
 
@@ -1306,41 +1306,41 @@ func Test_DownloadTerraform(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "1.3.9"
+	const toolVersion = "1.7.4"
 
 	tests := []test{
 		{
 			os:      "mingw64_nt-10.0-18362",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_windows_amd64.zip`,
+			url:     `https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_windows_amd64.zip`,
 		},
 		{
-			url:     "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_amd64.zip",
+			url:     "https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_linux_amd64.zip",
 			version: toolVersion,
 			os:      "linux",
 			arch:    arch64bit,
 		},
 		{
-			url:     "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_arm.zip",
+			url:     "https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_linux_arm.zip",
 			version: toolVersion,
 			os:      "linux",
 			arch:    archARM7,
 		},
 		{
-			url:     "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_arm64.zip",
+			url:     "https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_linux_arm64.zip",
 			version: toolVersion,
 			os:      "linux",
 			arch:    archARM64,
 		},
 		{
-			url:     "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_darwin_arm64.zip",
+			url:     "https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_darwin_arm64.zip",
 			version: toolVersion,
 			os:      "darwin",
 			arch:    archDarwinARM64,
 		},
 		{
-			url:     "https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_darwin_amd64.zip",
+			url:     "https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_darwin_amd64.zip",
 			version: toolVersion,
 			os:      "darwin",
 			arch:    arch64bit,
@@ -1364,41 +1364,41 @@ func Test_DownloadPacker(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "1.6.5"
+	const toolVersion = "1.10.1"
 
 	tests := []test{
 		{
 			os:      "mingw64_nt-10.0-18362",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://releases.hashicorp.com/packer/1.6.5/packer_1.6.5_windows_amd64.zip`,
+			url:     `https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_windows_amd64.zip`,
 		},
 		{
-			url:     "https://releases.hashicorp.com/packer/1.6.5/packer_1.6.5_linux_amd64.zip",
+			url:     "https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_linux_amd64.zip",
 			version: toolVersion,
 			os:      "linux",
 			arch:    arch64bit,
 		},
 		{
-			url:     "https://releases.hashicorp.com/packer/1.6.5/packer_1.6.5_linux_arm.zip",
+			url:     "https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_linux_arm.zip",
 			version: toolVersion,
 			os:      "linux",
 			arch:    archARM7,
 		},
 		{
-			url:     "https://releases.hashicorp.com/packer/1.6.5/packer_1.6.5_linux_arm64.zip",
+			url:     "https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_linux_arm64.zip",
 			version: toolVersion,
 			os:      "linux",
 			arch:    archARM64,
 		},
 		{
-			url:     "https://releases.hashicorp.com/packer/1.6.5/packer_1.6.5_darwin_arm64.zip",
+			url:     "https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_darwin_arm64.zip",
 			version: toolVersion,
 			os:      "darwin",
 			arch:    archARM64,
 		},
 		{
-			url:     "https://releases.hashicorp.com/packer/1.6.5/packer_1.6.5_darwin_amd64.zip",
+			url:     "https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_darwin_amd64.zip",
 			version: toolVersion,
 			os:      "darwin",
 			arch:    arch64bit,

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -822,7 +822,7 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Owner:       "hashicorp",
 			Repo:        "terraform",
 			Name:        "terraform",
-			Version:     "1.3.9",
+			Version:     "1.7.4",
 			Description: "Infrastructure as Code for major cloud providers.",
 			URLTemplate: `
 			{{$arch := ""}}
@@ -883,26 +883,26 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Version:     "2.2.19",
 			Description: "Tool for building and distributing development environments.",
 			URLTemplate: `{{$arch := .Arch}}
-
-{{- if eq .Arch "x86_64" -}}
-{{$arch = "amd64"}}
-{{- else if eq .Arch "armv7l" -}}
-{{$arch = "arm"}}
-{{- end -}}
-
-{{$os := .OS}}
-{{ if HasPrefix .OS "ming" -}}
-{{$os = "windows"}}
-{{- end -}}
-
-https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`})
+	
+	{{- if eq .Arch "x86_64" -}}
+	{{$arch = "amd64"}}
+	{{- else if eq .Arch "armv7l" -}}
+	{{$arch = "arm"}}
+	{{- end -}}
+	
+	{{$os := .OS}}
+	{{ if HasPrefix .OS "ming" -}}
+	{{$os = "windows"}}
+	{{- end -}}
+	
+	https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`})
 
 	tools = append(tools,
 		Tool{
 			Owner:       "hashicorp",
 			Repo:        "packer",
 			Name:        "packer",
-			Version:     "1.8.0",
+			Version:     "1.10.1",
 			Description: "Build identical machine images for multiple platforms from a single source configuration.",
 			URLTemplate: `
 			{{$arch := ""}}
@@ -927,10 +927,10 @@ https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$
 			Owner:       "hashicorp",
 			Repo:        "waypoint",
 			Name:        "waypoint",
-			Version:     "0.8.1",
+			Version:     "0.11.4",
 			Description: "Easy application deployment for Kubernetes and Amazon ECS",
 			URLTemplate: `
-			{{$arch := ""}}
+			{{$arch := .Arch}}
 			{{- if eq .Arch "x86_64" -}}
 			{{$arch = "amd64"}}
 			{{- else if eq .Arch "aarch64" -}}


### PR DESCRIPTION
## Description
Updates versions of Terraform ([1.7.4](https://releases.hashicorp.com/terraform/1.7.4/)), Packer ([1.10.1](https://releases.hashicorp.com/packer/1.10.1/)) and waypoint ([0.11.4](https://releases.hashicorp.com/waypoint/0.11.4/))

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Partially fixes #1029

## How Has This Been Tested?

Updated the tests and url check ran green in the pipeline.
Built locally and tested get on darwin x86_64:

```sh
➜  arkade git:(hashicorpVersions) make build
go build
➜  arkade git:(hashicorpVersions) ./arkade version
            _             _      
  __ _ _ __| | ____ _  __| | ___ 
 / _` | '__| |/ / _` |/ _` |/ _ \
| (_| | |  |   < (_| | (_| |  __/
 \__,_|_|  |_|\_\__,_|\__,_|\___|

Open Source Marketplace For Developer Tools

Version: dev
Git Commit: 

 🚀 Speed up GitHub Actions/GitLab CI + reduce costs: https://actuated.dev
➜  arkade git:(hashicorpVersions) ./arkade get terraform
Downloading: terraform
Downloading: https://releases.hashicorp.com/terraform/1.7.4/terraform_1.7.4_darwin_amd64.zip
26.26 MiB / 26.26 MiB [---------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2307178767/terraform_1.7.4_darwin_amd64.zip written.
Name: terraform_1.7.4_darwin_amd64.zip, size: 275391342024/02/24 11:17:00 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2307178767/terraform
2024/02/24 11:17:00 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2307178767/terraform to /Users/rgee0/.arkade/bin/terraform

Wrote: /Users/rgee0/.arkade/bin/terraform (95.21MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/terraform

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/terraform /usr/local/bin/

🚀 Speed up GitHub Actions/GitLab CI + reduce costs: https://actuated.dev
➜  arkade git:(hashicorpVersions) ./arkade get packer   
Downloading: packer
Downloading: https://releases.hashicorp.com/packer/1.10.1/packer_1.10.1_darwin_amd64.zip
16.18 MiB / 16.18 MiB [---------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2542431408/packer_1.10.1_darwin_amd64.zip written.
Name: packer_1.10.1_darwin_amd64.zip, size: 169607522024/02/24 11:17:08 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2542431408/packer
2024/02/24 11:17:08 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2542431408/packer to /Users/rgee0/.arkade/bin/packer

Wrote: /Users/rgee0/.arkade/bin/packer (57.87MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/packer

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/packer /usr/local/bin/

🚀 Speed up GitHub Actions/GitLab CI + reduce costs: https://actuated.dev
➜  arkade git:(hashicorpVersions) ./arkade get waypoint
Downloading: waypoint
Downloading: https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_amd64.zip
83.73 MiB / 83.73 MiB [---------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-602702544/waypoint_0.11.4_darwin_amd64.zip written.
Name: waypoint_0.11.4_darwin_amd64.zip, size: 877930182024/02/24 11:17:23 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-602702544/waypoint
2024/02/24 11:17:23 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-602702544/waypoint to /Users/rgee0/.arkade/bin/waypoint

Wrote: /Users/rgee0/.arkade/bin/waypoint (166.6MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/waypoint

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/waypoint /usr/local/bin/

🚀 Speed up GitHub Actions/GitLab CI + reduce costs: https://actuated.dev
➜  arkade git:(hashicorpVersions) 
```

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh TOOL_NAME
```

### Packer output
```sh
➜  arkade git:(hashicorpVersions) ./hack/test-tool.sh packer
+ ./arkade get packer --arch arm64 --os darwin --quiet

The requested version of packer is not available or configured in arkade for darwin/arm64

* Check if a binary is available from the project for your Operating System
* Feel free to raise an issue at https://github.com/alexellis/arkade/issues for help

Error: server returned status: 404
+ ./arkade get packer --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/packer
/Users/rgee0/.arkade/bin/packer: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/packer
+ echo

+ ./arkade get packer --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/packer
/Users/rgee0/.arkade/bin/packer: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=FcMegUkGwdN2cM3u_s7c/zVPeB9bUAxe4ZWNfoUU_/1HEYgL4yLIJP9-9DkBDN/3QX7cP1FYgar_lFdy6O7, stripped
+ rm /Users/rgee0/.arkade/bin/packer
+ echo

+ ./arkade get packer --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/packer
/Users/rgee0/.arkade/bin/packer: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=pH9dfrUXucBLJIGFwO6u/YUG9I-HXw8i4VwqYesHI/vQy89STSx1IfCw4_CjD9/qCX4rtXfYsgf9OxIcf5E, stripped
+ rm /Users/rgee0/.arkade/bin/packer
+ echo

+ ./arkade get packer --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/packer.exe
/Users/rgee0/.arkade/bin/packer.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
+ rm /Users/rgee0/.arkade/bin/packer.exe
+ echo
```

### Terraform output

```
➜  arkade git:(hashicorpVersions) ./hack/test-tool.sh terraform
+ ./arkade get terraform --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=tGV2awnbj8i3XF_mN518/rjAnEm5HyUZXlwHErq2I/3xZn2D-wput5LTFbcQl4/k5hThcFH0CsmODd6hNDH, stripped
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=EP0J13LdnxxkW0yxQasu/vGYSHfXijyRu2ptsXM75/4fVhKqauYK2jjRCb2ven/-OeNAt1VAjad7FDREGG0, stripped
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/terraform.exe
/Users/rgee0/.arkade/bin/terraform.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/terraform.exe
+ echo
```
### Waypoint output

```
➜  arkade git:(hashicorpVersions) ./hack/test-tool.sh waypoint        
+ ./arkade get waypoint --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=BjDrvGk2_OENbAmfM4_R/CGUUh7-1wMXER25McDxC/1i57FFiXSIruqmWnjvs4/5sdVBfZtWFZJDh6uvhYC, stripped
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=Nsi8i0X2eROpyhD7qSbo/_QSuviOi4kfcoXVBELI9/LgPi6pJBqW3aWC35itaR/lGpvhE6Fy1W3NY5CfZhE, stripped
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/waypoint.exe
/Users/rgee0/.arkade/bin/waypoint.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
+ rm /Users/rgee0/.arkade/bin/waypoint.exe
+ echo
```

## Types of changes
- [x] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
