### PR TITLE
Update kubectl to v1.29.3

### DIFF
--- a/pkg/get/download_test.go
+++ b/pkg/get/download_test.go
@@ -1,0 +1,47 @@
+package get
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCopyFileP(t *testing.T) {
+	// Create a temporary source file
+	srcFile, err := os.CreateTemp("", "src")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(srcFile.Name())
+
+	// Write some data to the source file
+	data := []byte("Hello, World!")
+	if _, err := srcFile.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := srcFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a temporary destination file
+	dstFile, err := os.CreateTemp("", "dst")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dstFile.Name())
+
+	// Use the function to copy the file
+	if _, err := CopyFileP(srcFile.Name(), dstFile.Name(), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the destination file
+	gotData, err := os.ReadFile(dstFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check if the data matches
+	if string(gotData) != string(data) {
+		t.Fatalf("got %q, want %q", string(gotData), string(data))
+	}
+}

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -157,7 +157,7 @@ sudo install -m 755 /tmp/bin/jq-linux64 /usr/local/bin/jq`,
 
 func Test_GetDownloadURLs(t *testing.T) {
 	tools := MakeTools()
-	kubectlVersion := "v1.26.2"
+	kubectlVersion := "v1.29.3"
 
 	tests := []struct {
 		name    string
@@ -422,20 +422,20 @@ func Test_DownloadKubectl(t *testing.T) {
 	tests := []test{
 		{os: "darwin",
 			arch:    arch64bit,
-			version: "v1.20.0",
-			url:     "https://dl.k8s.io/release/v1.20.0/bin/darwin/amd64/kubectl"},
+			version: "v1.29.3",
+			url:     "https://dl.k8s.io/release/v1.29.3/bin/darwin/amd64/kubectl"},
 		{os: "darwin",
 			arch:    archDarwinARM64,
-			version: "v1.20.0",
-			url:     "https://dl.k8s.io/release/v1.20.0/bin/darwin/arm64/kubectl"},
+			version: "v1.29.3",
+			url:     "https://dl.k8s.io/release/v1.29.3/bin/darwin/arm64/kubectl"},
 		{os: "linux",
 			arch:    arch64bit,
-			version: "v1.20.0",
-			url:     "https://dl.k8s.io/release/v1.20.0/bin/linux/amd64/kubectl"},
+			version: "v1.29.3",
+			url:     "https://dl.k8s.io/release/v1.29.3/bin/linux/amd64/kubectl"},
 		{os: "linux",
 			arch:    archARM64,
-			version: "v1.20.0",
-			url:     "https://dl.k8s.io/release/v1.20.0/bin/linux/arm64/kubectl"},
+			version: "v1.29.3",
+			url:     "https://dl.k8s.io/release/v1.29.3/bin/linux/arm64/kubectl"},
 	}
 
 	for _, tc := range tests {

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -153,7 +153,7 @@ func MakeTools() Tools {
 			Owner:       "kubernetes",
 			Repo:        "kubernetes",
 			Name:        "kubectl",
-			Version:     "v1.24.2",
+			Version:     "v1.29.3",
 			Description: "Run commands against Kubernetes clusters",
 			URLTemplate: `{{$arch := "arm"}}
 


### PR DESCRIPTION

## Description
Maintenance change to bump the version of kubectl from v1.24.2 to v1.29.3.  
Updates the kubectl test cases to use the same version
Adds a test for `CopyFileP`

## Motivation and Context

- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
fixes #1048 


## How Has This Been Tested?

Verified using:
```
gofmt -w -s ./pkg
gofmt -w -s ./cmd

# Run all the unit tests
make test

# Use e2e tests ot check that URLs can be downloaded for all tools
make e2e
```

Output:
```
CGO_ENABLED=0 go test github.com/alexellis/arkade github.com/alexellis/arkade/cmd github.com/alexellis/arkade/cmd/apps github.com/alexellis/arkade/cmd/chart github.com/alexellis/arkade/cmd/oci github.com/alexellis/arkade/cmd/system github.com/alexellis/arkade/pkg github.com/alexellis/arkade/pkg/apps github.com/alexellis/arkade/pkg/archive github.com/alexellis/arkade/pkg/config github.com/alexellis/arkade/pkg/env github.com/alexellis/arkade/pkg/get github.com/alexellis/arkade/pkg/helm github.com/alexellis/arkade/pkg/k8s github.com/alexellis/arkade/pkg/types github.com/alexellis/arkade/pkg/update -cover
?   	...	[no test files]
ok  	github.com/alexellis/arkade/cmd	0.412s	coverage: 14.4% of statements
ok  	github.com/alexellis/arkade/cmd/apps	0.644s	coverage: 1.8% of statements
ok  	github.com/alexellis/arkade/pkg/config	0.629s	coverage: 22.9% of statements
ok  	github.com/alexellis/arkade/pkg/get	1.314s	coverage: 59.9% of statements
ok  	github.com/alexellis/arkade/pkg/helm	0.660s	coverage: 2.0% of statements

CGO_ENABLED=0 go test github.com/alexellis/arkade/pkg/get -cover --tags e2e -v
=== RUN   TestCopyFileP
--- PASS: TestCopyFileP (0.00s)
--- PASS: Test_CheckTools (0.00s)
    --- PASS: Test_CheckTools/Download_of_skupper (0.67s)
    --- PASS: Test_CheckTools/Download_of_kwok (0.68s)
    --- PASS: Test_CheckTools/Download_of_snowmachine (0.68s)
    --- PASS: Test_CheckTools/Download_of_cloud-hypervisor (0.69s)
    --- PASS: Test_CheckTools/Download_of_gptscript (0.69s)
    --- PASS: Test_CheckTools/Download_of_faas-cli (0.70s)
    --- PASS: Test_CheckTools/Download_of_kubetail (0.06s)
    --- PASS: Test_CheckTools/Download_of_ch-remote (0.79s)
    --- PASS: Test_CheckTools/Download_of_influx (0.07s)
    --- PASS: Test_CheckTools/Download_of_kwokctl (1.01s)
    --- PASS: Test_CheckTools/Download_of_porter (0.40s)
    --- PASS: Test_CheckTools/Download_of_k0s (0.52s)
    --- PASS: Test_CheckTools/Download_of_vhs (0.54s)
    --- PASS: Test_CheckTools/Download_of_nova (0.52s)
    --- PASS: Test_CheckTools/Download_of_kgctl (0.54s)
    --- PASS: Test_CheckTools/Download_of_argocd-autopilot (0.53s)
    --- PASS: Test_CheckTools/Download_of_polaris (0.53s)
    --- PASS: Test_CheckTools/Download_of_timoni (0.56s)
    --- PASS: Test_CheckTools/Download_of_flux (0.53s)
    --- PASS: Test_CheckTools/Download_of_kim (0.40s)
    --- PASS: Test_CheckTools/Download_of_trivy (0.52s)
    --- PASS: Test_CheckTools/Download_of_op (0.10s)
    --- PASS: Test_CheckTools/Download_of_inlets-pro (0.53s)
    --- PASS: Test_CheckTools/Download_of_tkn (0.53s)
    --- PASS: Test_CheckTools/Download_of_istioctl (0.56s)
    --- PASS: Test_CheckTools/Download_of_nerdctl (0.53s)
    --- PASS: Test_CheckTools/Download_of_k0sctl (0.53s)
    --- PASS: Test_CheckTools/Download_of_argocd (0.55s)
    --- PASS: Test_CheckTools/Download_of_nats (0.52s)
    --- PASS: Test_CheckTools/Download_of_copa (0.52s)
    --- PASS: Test_CheckTools/Download_of_mc (0.53s)
    --- PASS: Test_CheckTools/Download_of_oc (0.14s)
    --- PASS: Test_CheckTools/Download_of_openshift-install (0.05s)
    --- PASS: Test_CheckTools/Download_of_task (0.61s)
    --- PASS: Test_CheckTools/Download_of_opa (0.55s)
    --- PASS: Test_CheckTools/Download_of_atuin (0.53s)
    --- PASS: Test_CheckTools/Download_of_docker-compose (0.52s)
    --- PASS: Test_CheckTools/Download_of_hugo (0.52s)
    --- PASS: Test_CheckTools/Download_of_kube-bench (0.53s)
    --- PASS: Test_CheckTools/Download_of_ktop (0.52s)
    --- PASS: Test_CheckTools/Download_of_kube-burner (0.57s)
    --- PASS: Test_CheckTools/Download_of_kail (0.53s)
    --- PASS: Test_CheckTools/Download_of_replicated (0.55s)
    --- PASS: Test_CheckTools/Download_of_yq (0.76s)
    --- PASS: Test_CheckTools/Download_of_stern (0.52s)
    --- PASS: Test_CheckTools/Download_of_kyverno (0.52s)
    --- PASS: Test_CheckTools/Download_of_minikube (0.54s)
    --- PASS: Test_CheckTools/Download_of_seaweedfs (0.55s)
    --- PASS: Test_CheckTools/Download_of_yt-dlp (0.53s)
    --- PASS: Test_CheckTools/Download_of_kops (0.53s)
    --- PASS: Test_CheckTools/Download_of_krew (0.67s)
    --- PASS: Test_CheckTools/Download_of_hey (0.56s)
    --- PASS: Test_CheckTools/Download_of_waypoint (0.07s)
    --- PASS: Test_CheckTools/Download_of_cmctl (0.71s)
    --- PASS: Test_CheckTools/Download_of_packer (0.02s)
    --- PASS: Test_CheckTools/Download_of_buildx (0.53s)
    --- PASS: Test_CheckTools/Download_of_vagrant (0.02s)
    --- PASS: Test_CheckTools/Download_of_actuated-cli (0.54s)
    --- PASS: Test_CheckTools/Download_of_pack (0.52s)
    --- PASS: Test_CheckTools/Download_of_actions-usage (0.52s)
    --- PASS: Test_CheckTools/Download_of_gomplate (0.52s)
    --- PASS: Test_CheckTools/Download_of_gh (0.56s)
    --- PASS: Test_CheckTools/Download_of_tofu (0.42s)
    --- PASS: Test_CheckTools/Download_of_terraform (0.02s)
    --- PASS: Test_CheckTools/Download_of_hubble (0.53s)
    --- PASS: Test_CheckTools/Download_of_fzf (0.53s)
    --- PASS: Test_CheckTools/Download_of_cilium (0.50s)
    --- PASS: Test_CheckTools/Download_of_terragrunt (0.53s)
    --- PASS: Test_CheckTools/Download_of_terraform-docs (0.51s)
    --- PASS: Test_CheckTools/Download_of_nats-server (0.60s)
    --- PASS: Test_CheckTools/Download_of_civo (0.54s)
    --- PASS: Test_CheckTools/Download_of_popeye (0.54s)
    --- PASS: Test_CheckTools/Download_of_caddy (0.77s)
    --- PASS: Test_CheckTools/Download_of_k9s (0.56s)
    --- PASS: Test_CheckTools/Download_of_eksctl-anywhere (0.53s)
    --- PASS: Test_CheckTools/Download_of_doctl (0.40s)
    --- PASS: Test_CheckTools/Download_of_eksctl (0.53s)
    --- PASS: Test_CheckTools/Download_of_crane (0.52s)
    --- PASS: Test_CheckTools/Download_of_kustomize (0.40s)
    --- PASS: Test_CheckTools/Download_of_kubebuilder (0.41s)
    --- PASS: Test_CheckTools/Download_of_linkerd2 (0.40s)
    --- PASS: Test_CheckTools/Download_of_inletsctl (0.51s)
    --- PASS: Test_CheckTools/Download_of_osm (0.53s)
    --- PASS: Test_CheckTools/Download_of_mixctl (0.58s)
    --- PASS: Test_CheckTools/Download_of_run-job (0.51s)
    --- PASS: Test_CheckTools/Download_of_arkade (0.50s)
    --- PASS: Test_CheckTools/Download_of_k3sup (0.54s)
    --- PASS: Test_CheckTools/Download_of_k3d (0.53s)
    --- PASS: Test_CheckTools/Download_of_devspace (0.52s)
    --- PASS: Test_CheckTools/Download_of_tilt (0.55s)
    --- PASS: Test_CheckTools/Download_of_kubeseal (1.00s)
    --- PASS: Test_CheckTools/Download_of_autok3s (0.55s)
    --- PASS: Test_CheckTools/Download_of_etcd (0.52s)
    --- PASS: Test_CheckTools/Download_of_kubectl (0.27s)
    --- PASS: Test_CheckTools/Download_of_kubens (0.53s)
    --- PASS: Test_CheckTools/Download_of_kind (0.56s)
    --- PASS: Test_CheckTools/Download_of_helm (0.23s)
    --- PASS: Test_CheckTools/Download_of_kubectx (0.57s)
    --- PASS: Test_CheckTools/Download_of_jq (0.57s)
    --- PASS: Test_CheckTools/Download_of_goreleaser (0.54s)
    --- PASS: Test_CheckTools/Download_of_sops (0.52s)
    --- PASS: Test_CheckTools/Download_of_oh-my-posh (0.57s)
    --- PASS: Test_CheckTools/Download_of_k3s (1.19s)
    --- PASS: Test_CheckTools/Download_of_helmfile (0.83s)
    --- PASS: Test_CheckTools/Download_of_mkcert (0.52s)
    --- PASS: Test_CheckTools/Download_of_kubecm (0.71s)
    --- PASS: Test_CheckTools/Download_of_hostctl (0.56s)
    --- PASS: Test_CheckTools/Download_of_vcluster (0.52s)
    --- PASS: Test_CheckTools/Download_of_operator-sdk (0.53s)
    --- PASS: Test_CheckTools/Download_of_clusterctl (0.53s)
    --- PASS: Test_CheckTools/Download_of_kubescape (0.53s)
    --- PASS: Test_CheckTools/Download_of_dagger (1.15s)
    --- PASS: Test_CheckTools/Download_of_tfsec (0.40s)
    --- PASS: Test_CheckTools/Download_of_dive (0.74s)
    --- PASS: Test_CheckTools/Download_of_kube-linter (0.55s)
    --- PASS: Test_CheckTools/Download_of_k10tools (0.53s)
    --- PASS: Test_CheckTools/Download_of_tflint (0.52s)
    --- PASS: Test_CheckTools/Download_of_fstail (0.52s)
    --- PASS: Test_CheckTools/Download_of_croc (0.54s)
    --- PASS: Test_CheckTools/Download_of_rekor-cli (0.54s)
    --- PASS: Test_CheckTools/Download_of_clusterawsadm (0.59s)
    --- PASS: Test_CheckTools/Download_of_cosign (0.54s)
    --- PASS: Test_CheckTools/Download_of_grype (0.51s)
    --- PASS: Test_CheckTools/Download_of_firectl (0.51s)
    --- PASS: Test_CheckTools/Download_of_tctl (0.56s)
    --- PASS: Test_CheckTools/Download_of_syft (0.51s)
    --- PASS: Test_CheckTools/Download_of_kubeval (0.53s)
    --- PASS: Test_CheckTools/Download_of_scaleway-cli (0.51s)
    --- PASS: Test_CheckTools/Download_of_conftest (0.56s)
    --- PASS: Test_CheckTools/Download_of_viddy (0.92s)
    --- PASS: Test_CheckTools/Download_of_k10multicluster (0.52s)
    --- PASS: Test_CheckTools/Download_of_butane (0.52s)
    --- PASS: Test_CheckTools/Download_of_grafana-agent (0.62s)
    --- PASS: Test_CheckTools/Download_of_rpk (0.52s)
    --- PASS: Test_CheckTools/Download_of_vault (0.02s)
    --- PASS: Test_CheckTools/Download_of_kubestr (0.54s)
    --- PASS: Test_CheckTools/Download_of_hadolint (0.54s)
    --- PASS: Test_CheckTools/Download_of_kubeconform (0.51s)
    --- PASS: Test_CheckTools/Download_of_kanctl (0.55s)
    --- PASS: Test_CheckTools/Download_of_flyctl (0.52s)
    --- PASS: Test_CheckTools/Download_of_cr (0.52s)
    --- PASS: Test_CheckTools/Download_of_metal (0.53s)
    --- PASS: Test_CheckTools/Download_of_lazygit (0.53s)
    --- PASS: Test_CheckTools/Download_of_golangci-lint (0.58s)
    --- PASS: Test_CheckTools/Download_of_bun (0.54s)
    --- PASS: Test_CheckTools/Download_of_terrascan (0.50s)
    --- PASS: Test_CheckTools/Download_of_promtool (0.56s)
    --- PASS: Test_CheckTools/Download_of_just (0.53s)
    --- PASS: Test_CheckTools/Download_of_talosctl (0.77s)
PASS
coverage: 62.1% of statements
ok  	github.com/alexellis/arkade/pkg/get	10.691s	coverage: 62.1% of statements

```

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh TOOL_NAME
```
Output:
```
$ go build && ./hack/test-tool.sh kubectl
+ ./arkade get kubectl --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=rL7CPHD2Jai7yZuFrU8W/STQgfOud5Tbj0DwYseVA/bTi2GA9vkdyvTV6SmtxI/3ywglcjR5_lLhUj7pXTr, stripped
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=tUgWJtFaYIaleHbIIjsy/GBkDik474zgkzj6Sy29-/DYOWQSU_4lQxDCPrZ8ok/5MblO1RPHHihWRknLjuf, stripped
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/kubectl.exe
/Users/rgee0/.arkade/bin/kubectl.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/kubectl.exe
+ echo
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
