### PR TITLE
convert popeye to github VersionStrategy

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1159,6 +1159,64 @@ func Test_DownloadK9s(t *testing.T) {
 	}
 }
 
+func Test_DownloadPopeye(t *testing.T) {
+	tools := MakeTools()
+	name := "popeye"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v0.21.2"
+
+	tests := []test{
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Windows_amd64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Linux_amd64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Darwin_amd64.tar.gz`,
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     `https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Darwin_arm64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     `https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Linux_arm64.tar.gz`,
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     `https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Linux_armv7.tar.gz`,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("\nwant: %s, \n got: %s", tc.url, got)
+		}
+	}
+}
+
 func Test_DownloadEtcd(t *testing.T) {
 	tools := MakeTools()
 	name := "etcd"

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -759,10 +759,11 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "derailed",
-			Repo:        "popeye",
-			Name:        "popeye",
-			Description: "Scans live Kubernetes cluster and reports potential issues with deployed resources and configurations.",
+			Owner:           "derailed",
+			Repo:            "popeye",
+			Name:            "popeye",
+			VersionStrategy: "github",
+			Description:     "Scans live Kubernetes cluster and reports potential issues with deployed resources and configurations.",
 			BinaryTemplate: `
 			{{ $os := .OS }}
 			{{ $arch := .Arch }}
@@ -779,6 +780,8 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 				{{ $arch = "arm64" }}
 			{{- else if eq .Arch "x86_64" -}}
 				{{ $arch = "amd64" }}
+			{{- else if eq .Arch "armv7l" -}}
+				{{ $arch = "armv7" }}
 			{{- end -}}
 
 			{{.Version}}/{{.Name}}_{{ $os }}_{{ $arch }}.tar.gz`,


### PR DESCRIPTION
## Description

Converts `derailed/popeye` to `VersionStrategy: "github"` as a janitorial test case.
Also adds tests for `derailed/popeye` covering the architectures provided by the project.

## Motivation and Context
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
😬

## How Has This Been Tested?

### make e2e

```
➜  arkade git:(convertPopeye) ✗ go clean -testcache

➜  arkade git:(convertPopeye) ✗ make e2e
…
PASS
coverage: 59.9% of statements
ok      github.com/alexellis/arkade/pkg/get     35.232s coverage: 59.9% of statements
```

### test-tool.sh

```
➜  arkade git:(convertPopeye) ✗ make build && ./hack/test-tool.sh popeye
+ ./arkade get popeye --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=mcvIB1SKQnwjlitRzVX6/6cB1ltvpIUQoAtUyhriZ/0PZ7H2RJJo4NQWkItLPf/OT1BaF-QFwY2s-oEOw1I, stripped
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=7kL4hk19RKruiVgkbr5O/KSVHZD69pPcskfMIW3Q5/FYRl0PrEDRF1Z-bLZIhA/i9vGZtiS30vs0g66Gyrt, stripped
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/popeye.exe
/Users/rgee0/.arkade/bin/popeye.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/popeye.exe
+ echo
```

### test locally - latest release found (v0.21.3)
```
➜  arkade git:(convertPopeye) ./arkade get popeye                                     
Downloading: popeye
2024/05/10 12:39:35 Looking up version for popeye
2024/05/10 12:39:36 Found: v0.21.3
Downloading: https://github.com/derailed/popeye/releases/download/v0.21.3/popeye_Darwin_amd64.tar.gz
17.64 MiB / 17.64 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-3605829447/popeye_Darwin_amd64.tar.gz written.
2024/05/10 12:40:09 Looking up version for popeye
2024/05/10 12:40:09 Found: v0.21.3
2024/05/10 12:40:09 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-3605829447/popeye
2024/05/10 12:40:09 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-3605829447/popeye to /Users/rgee0/.arkade/bin/popeye

Wrote: /Users/rgee0/.arkade/bin/popeye (60.24MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/popeye

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/popeye /usr/local/bin/

🚀 Speed up GitHub Actions/GitLab CI + reduce costs: https://actuated.dev
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
