### PR TITLE
add k8s version strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With `arkade get`, you'll have `kubectl`, `kind`, `terraform`, and `jq` on your 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 ![Downloads](https://img.shields.io/github/downloads/alexellis/arkade/total)
 
-With over 120 CLIs and 55 Kubernetes apps (charts, manifests, installers) available for Kubernetes, gone are the days of contending with dozens of README files just to set up a development stack with the usual suspects like ingress-nginx, Postgres and cert-manager.
+With over 120 CLIs and 55 Kubernetes apps (charts, manifests, installers) available for Kubernetes, gone are the days of contending with dozens of README files just to set up a development stack with the usual suspects like ingress-nginx, Postgres, and cert-manager.
 
 - [arkade - Open Source Marketplace For Developer Tools](#arkade---open-source-marketplace-for-developer-tools)
   - [Support arkade 👋](#support-arkade-)
@@ -68,7 +68,7 @@ Arkade is built to save you time so you can focus and get productive quickly.
 
 You can support Alex's work on arkade [via GitHub Sponsors](https://github.com/sponsors/alexellis/).
 
-Or get a copy of his eBook on Go so you can learn how to build tools like k3sup, arkade and OpenFaaS for yourself:
+Or get a copy of his eBook on Go so you can learn how to build tools like k3sup, arkade, and OpenFaaS for yourself:
 
 <a href="https://openfaas.gumroad.com/l/everyday-golang">
 <img src="https://public-files.gumroad.com/7j27fj7c5xqxm3f9lyxj1pg8oa1w" alt="Buy Everyday Go" width="50%"></a>
@@ -108,11 +108,11 @@ Or get a copy of his eBook on Go so you can learn how to build tools like k3sup,
 > 
 > [Michael Cade @ Kasten](https://twitter.com/MichaelCade1/status/1390403831167700995?s=20)
 
-> You've to install latest and greatest tools for your daily @kubernetesio tasks? No problem, check out #arkade the open source #kubernetes marketplace 👍
+> You've to install the latest and greatest tools for your daily @kubernetesio tasks? No problem, check out #arkade the open source #kubernetes marketplace 👍
 >
 > [Thorsten Hans](https://twitter.com/ThorstenHans/status/1457982292597608449?s=20) - Cloud Native consultant
 
-> If you want to install quickly a new tool in your dev env or in your k8s cluster you can use the Arkade (https://github.com/alexellis/arkade) easy and quick you should try out! Ps. I contribute to this project 🥰
+> If you want to install quickly a new tool in your dev env or in your k8s cluster you can use the Arkade (https://github.com/alexellis/arkade) easy and quick you should it try out! Ps. I contribute to this project 🥰
 >
 > [Carlos Panato](https://twitter.com/comedordexis/status/1423339283713347587) - Staff engineer @ Mattermost
 
@@ -150,9 +150,9 @@ Arkade can be used to install Kubernetes apps or to download CLI tools.
 * `arkade get` - download a CLI tool
 * `arkade update` - perform a self-update of arkade on MacOS and Linux
 
-An arkade "app" could represent a helm chart such as `openfaas/faas-netes`, a custom CLI installer such as `istioctl` or a set of static manifests (i.e. MetalLB).
+An arkade "app" could represent a helm chart such as `openfaas/faas-netes`, a custom CLI installer such as `istioctl`, or a set of static manifests (i.e. MetalLB).
 
-An arkade "tool" is a CLI that can be downloaded for your operating system. Arkade downloads statically-linked binaries from their upstream locations on GitHub or a the vendor's chosen URL such as with `kubectl` and `terraform`.
+An arkade "tool" is a CLI that can be downloaded for your operating system. Arkade downloads statically-linked binaries from their upstream locations on GitHub or the vendor's chosen URL such as with `kubectl` and `terraform`.
 
 > Did you know? Arkade users run `arkade get` both on their local workstations, and on their CI runners such as GitHub Actions or Jenkins.
 
@@ -276,7 +276,7 @@ arkade oci install ghcr.io/openfaasltd/vmmeter \
 
 * [alexellis/arkade-get@master](https://github.com/alexellis/arkade-get)
 
-Example downloading faas-cli (specific version) and kubectl (latest), putting them into the PATH automatically, and executing one of them in a subsequent step.
+Example of downloading faas-cli (specific version) and kubectl (latest), putting them into the PATH automatically, and executing one of them in a subsequent step.
 
 ```yaml
     - uses: alexellis/arkade-get@master
@@ -398,7 +398,7 @@ echo $?
 0
 ```
 
-There is an exit code of zero and no output when the check passed.
+There is an exit code of zero and no output when the check passes.
 
 You can pass `--verbose` to see a detailed view of what's happening.
 
@@ -457,7 +457,7 @@ arkade install openfaas \
 
 The post-installation message shows you how to connect. And whenever you want to see those details again, just run `arkade info openfaas`.
 
-There's even more options you can chose with `arkade install openfaas --help` - the various flags you see map to settings from the helm chart README, that you'd usually have to look up and set via a `values.yaml` file.
+There are even more options you can choose with `arkade install openfaas --help` - the various flags you see map to settings from the helm chart README, that you'd usually have to look up and set via a `values.yaml` file.
 
 If there's something missing from the list of flags that you need, arkade also supports `--set` for any arkade app that uses helm. Note that not every app uses helm.
 
@@ -764,11 +764,11 @@ There are 56 apps that you can install on your cluster.
 | [actuated-cli](https://github.com/self-actuated/actuated-cli)                | Official CLI for actuated.dev                                                                                                                                   |
 | [argocd](https://github.com/argoproj/argo-cd)                                | Declarative, GitOps continuous delivery tool for Kubernetes.                                                                                                    |
 | [argocd-autopilot](https://github.com/argoproj-labs/argocd-autopilot)        | An opinionated way of installing Argo-CD and managing GitOps repositories.                                                                                      |
-| [arkade](https://github.com/alexellis/arkade)                                | Portable marketplace for downloading your favourite devops CLIs and installing helm charts, with a single command.                                              |
-| [atuin](https://github.com/atuinsh/atuin)                                    | Sync, search and backup shell history with Atuin.                                                                                                               |
+| [arkade](https://github.com/alexellis/arkade)                                | Portable marketplace for downloading your favourite DevOps CLIs and installing helm charts, with a single command.                                              |
+| [atuin](https://github.com/atuinsh/atuin)                                    | Sync, search, and backup shell history with Atuin.                                                                                                              |
 | [autok3s](https://github.com/cnrancher/autok3s)                              | Run Rancher Lab's lightweight Kubernetes distribution k3s everywhere.                                                                                           |
 | [buildx](https://github.com/docker/buildx)                                   | Docker CLI plugin for extended build capabilities with BuildKit.                                                                                                |
-| [bun](https://github.com/oven-sh/bun)                                        | Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one.                                                             |
+| [bun](https://github.com/oven-sh/bun)                                        | Bun is an incredibly fast JavaScript runtime, bundler, transpiler, and package manager – all in one.                                                            |
 | [butane](https://github.com/coreos/butane)                                   | Translates human readable Butane Configs into machine readable Ignition Configs                                                                                 |
 | [caddy](https://github.com/caddyserver/caddy)                                | Caddy is an extensible server platform that uses TLS by default                                                                                                 |
 | [ch-remote](https://github.com/cloud-hypervisor/cloud-hypervisor)            | The ch-remote binary is used for controlling an running Virtual Machine.                                                                                        |
@@ -844,7 +844,7 @@ There are 56 apps that you can install on your cluster.
 | [kubectl](https://github.com/kubernetes/kubernetes)                          | Run commands against Kubernetes clusters                                                                                                                        |
 | [kubectx](https://github.com/ahmetb/kubectx)                                 | Faster way to switch between clusters.                                                                                                                          |
 | [kubens](https://github.com/ahmetb/kubectx)                                  | Switch between Kubernetes namespaces smoothly.                                                                                                                  |
-| [kubescape](https://github.com/kubescape/kubescape)                          | kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA                       |
+| [kubescape](https://github.com/kubescape/kubescape)                          | kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by NSA and CISA                          |
 | [kubeseal](https://github.com/bitnami-labs/sealed-secrets)                   | A Kubernetes controller and tool for one-way encrypted Secrets                                                                                                  |
 | [kubestr](https://github.com/kastenhq/kubestr)                               | Kubestr discovers, validates and evaluates your Kubernetes storage options.                                                                                     |
 | [kubetail](https://github.com/johanhaleby/kubetail)                          | Bash script to tail Kubernetes logs from multiple pods at the same time.                                                                                        |

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -17,6 +17,9 @@ import (
 	"github.com/alexellis/arkade/pkg/env"
 )
 
+const GitHubVersionStrategy = "github"
+const k8sVersionStrategy = "k8s"
+
 var supportedOS = [...]string{"linux", "darwin", "ming"}
 var supportedArchitectures = [...]string{"x86_64", "arm", "amd64", "armv6l", "armv7l", "arm64", "aarch64"}
 
@@ -132,22 +135,34 @@ func (tool Tool) Head(uri string) (int, string, http.Header, error) {
 
 func (tool Tool) GetURL(os, arch, version string, quiet bool) (string, error) {
 
-	if len(version) == 0 &&
-		(len(tool.URLTemplate) == 0 ||
-			strings.Contains(tool.URLTemplate, "https://github.com/") ||
-			tool.VersionStrategy == "github") {
+	if len(version) == 0 {
+
 		if !quiet {
 			log.Printf("Looking up version for %s", tool.Name)
 		}
 
-		v, err := FindGitHubRelease(tool.Owner, tool.Repo)
-		if err != nil {
-			return "", err
+		if len(tool.URLTemplate) == 0 ||
+			strings.Contains(tool.URLTemplate, "https://github.com/") ||
+			tool.VersionStrategy == GitHubVersionStrategy {
+
+			v, err := FindGitHubRelease(tool.Owner, tool.Repo)
+			if err != nil {
+				return "", err
+			}
+			version = v
 		}
+
+		if tool.VersionStrategy == k8sVersionStrategy {
+			v, err := FindK8sRelease()
+			if err != nil {
+				return "", err
+			}
+			version = v
+		}
+
 		if !quiet {
-			log.Printf("Found: %s", v)
+			log.Printf("Found: %s", version)
 		}
-		version = v
 	}
 
 	if len(tool.URLTemplate) > 0 {
@@ -220,6 +235,41 @@ func FindGitHubRelease(owner, repo string) (string, error) {
 	}
 
 	version := loc[strings.LastIndex(loc, "/")+1:]
+	return version, nil
+}
+
+func FindK8sRelease() (string, error) {
+	url := "https://cdn.dl.k8s.io/release/stable.txt"
+
+	timeout := time.Second * 5
+	client := makeHTTPClient(&timeout, false)
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("User-Agent", pkg.UserAgent())
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	if res.Body == nil {
+		return "", fmt.Errorf("unable to determine release of tool")
+	}
+
+	defer res.Body.Close()
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	version := string(bodyBytes)
 	return version, nil
 }
 

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -36,6 +36,40 @@ func getTool(name string, tools []Tool) *Tool {
 	return tool
 }
 
+func TestGetToolVersion(t *testing.T) {
+
+	testCases := []struct {
+		description string
+		tool        Tool
+		version     string
+		expected    string
+	}{
+		{
+			description: "Version is empty, expect the tool's version to be returned",
+			tool:        Tool{Version: "1.0.0"},
+			version:     "",
+			expected:    "1.0.0",
+		},
+		{
+			description: "Version argument is provided, expect the provided version to be returned",
+			tool:        Tool{Version: "2.0.0"},
+			version:     "1.2.0",
+			expected:    "1.2.0",
+		},
+	}
+
+	// Iterate over test cases
+	for _, tc := range testCases {
+		// Call the function with test inputs
+		result := GetToolVersion(&tc.tool, tc.version)
+
+		// Check if the result matches the expected output
+		if result != tc.expected {
+			t.Errorf("%s: For tool version %s and input version %s, expected %s but got %s", tc.description, tc.tool.Version, tc.version, tc.expected, result)
+		}
+	}
+}
+
 func Test_MakeSureNoDuplicates(t *testing.T) {
 	count := map[string]int{}
 	tools := MakeTools()

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -380,7 +380,7 @@ https://dl.k8s.io/release/{{.Version}}/bin/{{$os}}/{{$arch}}/kubectl{{$ext}}`})
 			Owner:       "alexellis",
 			Repo:        "arkade",
 			Name:        "arkade",
-			Description: "Portable marketplace for downloading your favourite devops CLIs and installing helm charts, with a single command.",
+			Description: "Portable marketplace for downloading your favourite DevOps CLIs and installing helm charts, with a single command.",
 			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
 			{{.Name}}.exe
 			{{- else if eq .OS "darwin" -}}
@@ -2234,7 +2234,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			Owner:       "kubescape",
 			Repo:        "kubescape",
 			Name:        "kubescape",
-			Description: "kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by to NSA and CISA",
+			Description: "kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by NSA and CISA",
 			BinaryTemplate: `
 		{{$osStr := ""}}
 		{{ if HasPrefix .OS "ming" -}}
@@ -2889,7 +2889,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			Owner:       "oven-sh",
 			Repo:        "bun",
 			Name:        "bun",
-			Description: "Bun is an incredibly fast JavaScript runtime, bundler, transpiler and package manager – all in one.",
+			Description: "Bun is an incredibly fast JavaScript runtime, bundler, transpiler, and package manager – all in one.",
 			BinaryTemplate: `
 							{{$arch := .Arch}}
 							{{- if eq .Arch "x86_64" -}}
@@ -3817,7 +3817,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			Owner:       "atuinsh",
 			Repo:        "atuin",
 			Name:        "atuin",
-			Description: "Sync, search and backup shell history with Atuin.",
+			Description: "Sync, search, and backup shell history with Atuin.",
 			URLTemplate: `
 					{{$os := .OS}}
 					{{$arch := .Arch}}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -54,7 +54,7 @@ func MakeTools() Tools {
 			Owner:           "helm",
 			Repo:            "helm",
 			Name:            "helm",
-			VersionStrategy: "github",
+			VersionStrategy: GitHubVersionStrategy,
 			Description:     "The Kubernetes Package Manager: Think of it like apt/yum/homebrew for Kubernetes.",
 			URLTemplate: `
 						{{$os := .OS}}
@@ -150,11 +150,11 @@ func MakeTools() Tools {
 	// https://dl.k8s.io/release/v1.22.2/bin/darwin/amd64/kubectl
 	tools = append(tools,
 		Tool{
-			Owner:       "kubernetes",
-			Repo:        "kubernetes",
-			Name:        "kubectl",
-			Version:     "v1.29.2",
-			Description: "Run commands against Kubernetes clusters",
+			Owner:           "kubernetes",
+			Repo:            "kubernetes",
+			Name:            "kubectl",
+			VersionStrategy: k8sVersionStrategy,
+			Description:     "Run commands against Kubernetes clusters",
 			URLTemplate: `{{$arch := "arm"}}
 
 {{- if eq .Arch "x86_64" -}}


### PR DESCRIPTION
## Description
Although there is a version strategy for github, whereby the latest version is resolved via the gh release pages something similar did not exist for k8s releases.

https://cdn.dl.k8s.io/release/stable.txt is made available to enable resolution of the latest version.  

This change integrates functionality that interrogates this file and uses its contents to assert the version of `kubectl` to retrieve.  This will negate the situation described in #1048 where the version is out of date until the `arkade` code is updated.

Misc updates to README including the table of tools.

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Mentioned in a comment on #1048

## How Has This Been Tested?

### What does kubectl resolve to? Expecting v1.30.0
```
➜  arkade git:(k8sVersionStrategy) go build
➜  arkade git:(k8sVersionStrategy) ./arkade get kubectl
Downloading: kubectl
2024/05/10 15:18:09 Looking up version for kubectl
2024/05/10 15:18:09 Found: v1.30.0
Downloading: https://dl.k8s.io/release/v1.30.0/bin/darwin/amd64/kubectl
50.15 MiB / 50.15 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2175459231/kubectl written.
2024/05/10 15:18:15 Looking up version for kubectl
2024/05/10 15:18:15 Found: v1.30.0
2024/05/10 15:18:15 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2175459231/kubectl to /Users/rgee0/.arkade/bin/kubectl

Wrote: /Users/rgee0/.arkade/bin/kubectl (52.59MB)
...
```

### test-tool for kubectl
```
➜  arkade git:(k8sVersionStrategy) go build && ./hack/test-tool.sh kubectl
+ ./arkade get kubectl --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=Nw07E9mRBf9nBJc5PSDy/6xGMIBOgLhG6lkjc0Xj7/hnMF0PNvcb9-wslPJ5nh/cwX9GQu1ZeSnUp4Y2iB-, stripped
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kubectl
/Users/rgee0/.arkade/bin/kubectl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=VzRAnGXpLlQctbNaLnKl/oZDpJF6tO440o8MZX2jG/RvCjxRr54MHOuPRJSrwS/dYEmNm_CirHEAgYUSdff, stripped
+ rm /Users/rgee0/.arkade/bin/kubectl
+ echo

+ ./arkade get kubectl --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/kubectl.exe
/Users/rgee0/.arkade/bin/kubectl.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/kubectl.exe
+ echo
```

### test-tool for helm since the const has been used on tools.go
```
➜  arkade git:(k8sVersionStrategy) go build && ./hack/test-tool.sh helm   
+ ./arkade get helm --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=PCzOZGnJOztKhLILw2Us/aeyDOEfwbyQa7Q7WnueN/BapdmPxG_MMNvLr4EYZe/wntKr3IhVA_px4Gr699h, stripped
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=Pz8WCshnh-30smNSLpDA/tRTJheJ7pA5IjAu6Qdgx/-YulxpFB4droMM4QofnO/DiFmWPiAP15uBOLCq1iP, stripped
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/helm.exe
/Users/rgee0/.arkade/bin/helm.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/helm.exe
+ echo➜  arkade git:(k8sVersionStrategy) go build && ./hack/test-tool.sh helm   
+ ./arkade get helm --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=PCzOZGnJOztKhLILw2Us/aeyDOEfwbyQa7Q7WnueN/BapdmPxG_MMNvLr4EYZe/wntKr3IhVA_px4Gr699h, stripped
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/helm
/Users/rgee0/.arkade/bin/helm: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=Pz8WCshnh-30smNSLpDA/tRTJheJ7pA5IjAu6Qdgx/-YulxpFB4droMM4QofnO/DiFmWPiAP15uBOLCq1iP, stripped
+ rm /Users/rgee0/.arkade/bin/helm
+ echo

+ ./arkade get helm --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/helm.exe
/Users/rgee0/.arkade/bin/helm.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/helm.exe
+ echo
```

### make e2e
```
➜  arkade git:(k8sVersionStrategy) make e2e
...
PASS
coverage: 60.8% of statements
ok      github.com/alexellis/arkade/pkg/get     14.943s coverage: 60.8% of statements
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
