### PR TITLE
Fix issue which saw versions resolved twice

### DIFF
--- a/pkg/get/download.go
+++ b/pkg/get/download.go
@@ -52,10 +52,7 @@ func Download(tool *Tool, arch, operatingSystem, version string, movePath string
 		fmt.Printf("%s written.\n", outFilePath)
 	}
 
-	if isArchive, err := tool.IsArchive(quiet); isArchive {
-		if err != nil {
-			return "", "", err
-		}
+	if isArchiveStr(downloadURL) {
 
 		outPath, err := decompress(tool, downloadURL, outFilePath, operatingSystem, arch, version, quiet)
 		if err != nil {

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -86,6 +86,13 @@ func (tool Tool) IsArchive(quiet bool) (bool, error) {
 		strings.HasSuffix(downloadURL, "tgz"), nil
 }
 
+func isArchiveStr(downloadURL string) bool {
+
+	return strings.HasSuffix(downloadURL, "tar.gz") ||
+		strings.HasSuffix(downloadURL, "zip") ||
+		strings.HasSuffix(downloadURL, "tgz")
+}
+
 // GetDownloadURL fetches the download URL for a release of a tool
 // for a given os, architecture and version
 func GetDownloadURL(tool *Tool, os, arch, version string, quiet bool) (string, error) {

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -155,6 +155,50 @@ sudo install -m 755 /tmp/bin/jq-linux64 /usr/local/bin/jq`,
 	}
 }
 
+func TestIsArchiveStr(t *testing.T) {
+
+	testCases := []struct {
+		description string // Description of the test case
+		downloadURL string // Input download URL
+		expected    bool   // Expected output
+	}{
+		{
+			description: "URL ends with '.tar.gz'",
+			downloadURL: "https://example.com/download.tar.gz",
+			expected:    true,
+		},
+		{
+			description: "URL ends with '.zip'",
+			downloadURL: "https://example.com/download.zip",
+			expected:    true,
+		},
+		{
+			description: "URL ends with '.tgz'",
+			downloadURL: "https://example.com/download.tgz",
+			expected:    true,
+		},
+		{
+			description: "URL does not end with any known archive extension",
+			downloadURL: "https://example.com/download.txt",
+			expected:    false,
+		},
+		{
+			description: "URL ends with '.tgz' but has extra characters",
+			downloadURL: "https://example.com/download.tgz123",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+
+		result := isArchiveStr(tc.downloadURL)
+
+		if result != tc.expected {
+			t.Errorf("%s: For URL %s, expected %v but got %v", tc.description, tc.downloadURL, tc.expected, result)
+		}
+	}
+}
+
 func Test_GetDownloadURLs(t *testing.T) {
 	tools := MakeTools()
 	kubectlVersion := "v1.29.1"


### PR DESCRIPTION
## Description
The version of a tool was being looked up twice - once prior to downloading and again post downloading.  This was because GetUrl was being reached twice, initially to determine the download url and then again to determine whether the download was an archive.

This change introduces a new function which takes the download url and uses that to determine whether its an archive.  This removes the additional round trip and the associated output.  The new function is also covered by an additional test.

## Motivation and Context

- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Fixes #1063 

## How Has This Been Tested?

### Functional before and after:

```sh
➜  arkade git:(isArchive) arkade get popeye                                        
Downloading: popeye
2024/05/11 07:49:17 Looking up version for popeye
2024/05/11 07:49:17 Found: v0.21.3
Downloading: https://github.com/derailed/popeye/releases/download/v0.21.3/popeye_Darwin_amd64.tar.gz
17.64 MiB / 17.64 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2877672800/popeye_Darwin_amd64.tar.gz written.
2024/05/11 07:49:20 Looking up version for popeye
2024/05/11 07:49:20 Found: v0.21.3
2024/05/11 07:49:20 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2877672800/popeye
2024/05/11 07:49:20 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2877672800/popeye to /Users/rgee0/.arkade/bin/popeye

Wrote: /Users/rgee0/.arkade/bin/popeye (60.24MB)

➜  arkade git:(isArchive) ./arkade get popeye                                        
Downloading: popeye
2024/05/11 07:49:26 Looking up version for popeye
2024/05/11 07:49:26 Found: v0.21.3
Downloading: https://github.com/derailed/popeye/releases/download/v0.21.3/popeye_Darwin_amd64.tar.gz
17.64 MiB / 17.64 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2167759258/popeye_Darwin_amd64.tar.gz written.
2024/05/11 07:49:29 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2167759258/popeye
2024/05/11 07:49:29 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2167759258/popeye to /Users/rgee0/.arkade/bin/popeye

Wrote: /Users/rgee0/.arkade/bin/popeye (60.24MB)
```

### make e2e
```
➜  arkade git:(isArchive) make e2e 
...
PASS
coverage: 60.2% of statements
ok      github.com/alexellis/arkade/pkg/get     16.141s coverage: 60.2% of statements
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
