### PR TITLE
Move Hashicorp tools to GH Version Strategy

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1237,6 +1237,64 @@ func Test_DownloadK9s(t *testing.T) {
 	}
 }
 
+func Test_DownloadPopeye(t *testing.T) {
+	tools := MakeTools()
+	name := "popeye"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v0.21.2"
+
+	tests := []test{
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Windows_amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Linux_amd64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Darwin_amd64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Darwin_arm64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Linux_arm64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Linux_armv7.tar.gz",
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("\nwant: %s, \n got: %s", tc.url, got)
+		}
+	}
+}
+
 func Test_DownloadEtcd(t *testing.T) {
 	tools := MakeTools()
 	name := "etcd"
@@ -6762,20 +6820,32 @@ func Test_DownloadAtuin(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "v15.0.0"
+	const toolVersion = "v18.2.0"
 
 	tests := []test{
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-aarch64-apple-darwin.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-aarch64-unknown-linux-gnu.tar.gz",
+		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/atuinsh/atuin/releases/download/v15.0.0/atuin-v15.0.0-x86_64-unknown-linux-gnu.tar.gz`,
+			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-x86_64-unknown-linux-gnu.tar.gz",
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/atuinsh/atuin/releases/download/v15.0.0/atuin-v15.0.0-x86_64-apple-darwin.tar.gz`,
+			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-x86_64-apple-darwin.tar.gz",
 		},
 	}
 
@@ -6785,7 +6855,7 @@ func Test_DownloadAtuin(t *testing.T) {
 			t.Fatal(err)
 		}
 		if got != tc.url {
-			t.Errorf("want: %s, got: %s", tc.url, got)
+			t.Errorf("\nwant: %s, \n got: %s", tc.url, got)
 		}
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -779,6 +779,8 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 				{{ $arch = "arm64" }}
 			{{- else if eq .Arch "x86_64" -}}
 				{{ $arch = "amd64" }}
+			{{- else if eq .Arch "armv7l" -}}
+				{{ $arch = "armv7" }}
 			{{- end -}}
 
 			{{.Version}}/{{.Name}}_{{ $os }}_{{ $arch }}.tar.gz`,
@@ -819,11 +821,11 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "hashicorp",
-			Repo:        "terraform",
-			Name:        "terraform",
-			Version:     "1.7.4",
-			Description: "Infrastructure as Code for major cloud providers.",
+			Owner:           "hashicorp",
+			Repo:            "terraform",
+			Name:            "terraform",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "Infrastructure as Code for major cloud providers.",
 			URLTemplate: `
 			{{$arch := ""}}
 			{{- if eq .Arch "x86_64" -}}
@@ -841,7 +843,7 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			{{$os = "windows"}}
 			{{- end -}}
 
-			https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`,
+			https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.zip`,
 		})
 
 	tools = append(tools,
@@ -959,16 +961,16 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "hashicorp",
-			Repo:        "packer",
-			Name:        "packer",
-			Version:     "1.10.1",
-			Description: "Build identical machine images for multiple platforms from a single source configuration.",
+			Owner:           "hashicorp",
+			Repo:            "packer",
+			Name:            "packer",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "Build identical machine images for multiple platforms from a single source configuration.",
 			URLTemplate: `
 			{{$arch := ""}}
 			{{- if eq .Arch "x86_64" -}}
 			{{$arch = "amd64"}}
-			{{- else if eq .Arch "aarch64" -}}
+			{{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
             {{$arch = "arm64"}}
 			{{- else if eq .Arch "armv7l" -}}
 			{{$arch = "arm"}}
@@ -979,16 +981,16 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			{{$os = "windows"}}
 			{{- end -}}
 
-			https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`,
+			https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.zip`,
 		})
 
 	tools = append(tools,
 		Tool{
-			Owner:       "hashicorp",
-			Repo:        "waypoint",
-			Name:        "waypoint",
-			Version:     "0.11.4",
-			Description: "Easy application deployment for Kubernetes and Amazon ECS",
+			Owner:           "hashicorp",
+			Repo:            "waypoint",
+			Name:            "waypoint",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "Easy application deployment for Kubernetes and Amazon ECS",
 			URLTemplate: `
 			{{$arch := .Arch}}
 			{{- if eq .Arch "x86_64" -}}
@@ -1004,7 +1006,7 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			{{$os = "windows"}}
 			{{- end -}}
 
-			https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`})
+			https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.zip`})
 
 	tools = append(tools,
 		Tool{
@@ -2954,11 +2956,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "hashicorp",
-			Repo:        "vault",
-			Name:        "vault",
-			Version:     "1.11.2",
-			Description: "A tool for secrets management, encryption as a service, and privileged access management.",
+			Owner:           "hashicorp",
+			Repo:            "vault",
+			Name:            "vault",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "A tool for secrets management, encryption as a service, and privileged access management.",
 			URLTemplate: `
 			{{$arch := ""}}
 			{{- if eq .Arch "x86_64" -}}
@@ -2976,7 +2978,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			{{$os = "windows"}}
 			{{- end -}}
 
-			https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`,
+			https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.zip`,
 		})
 
 	tools = append(tools,
@@ -3831,6 +3833,8 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 
 					{{- if (or (eq .Arch "x86_64") (eq .Arch "amd64")) -}}
 						{{$arch = "x86_64"}}
+					{{- else if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
+						{{$arch = "aarch64"}}
 					{{- end -}}
 
 					https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}-{{.Version}}-{{$arch}}-{{$os}}.{{$ext}}`,


### PR DESCRIPTION
## Description

Hashicorp tools were fixed at a version and had been called out in issues for being dated.  This change moves all hashicorp tools, except for vagrant, to the `githubversionstrategy` for determining latest.

Also included are:

* a quick fix to `popeye` to include `arm7l` support and add associated tests
* atuin fix to include arm64 support

## Motivation and Context
Hashicorp issues have been raised previously and change aligns with the version strategy approach to determining versions.

- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Fixes #962 

## How Has This Been Tested?

### Functional for Hashicorp tools
```
➜  arkade git:(hashicorp) make build                                                 
go build
➜  arkade git:(hashicorp) ./arkade get terraform                                     
Downloading: terraform
2024/05/11 09:00:18 Looking up version for terraform
2024/05/11 09:00:18 Found: v1.8.3
Downloading: https://releases.hashicorp.com/terraform/1.8.3/terraform_1.8.3_darwin_amd64.zip
26.36 MiB / 26.36 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-1040516841/terraform_1.8.3_darwin_amd64.zip written.
Name: terraform_1.8.3_darwin_amd64.zip, size: 276375392024/05/11 09:00:22 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-1040516841/terraform
2024/05/11 09:00:22 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-1040516841/terraform to /Users/rgee0/.arkade/bin/terraform

Wrote: /Users/rgee0/.arkade/bin/terraform (91.01MB)

➜  arkade git:(hashicorp) ./arkade get packer                                        
Downloading: packer
2024/05/11 09:00:31 Looking up version for packer
2024/05/11 09:00:31 Found: v1.10.3
Downloading: https://releases.hashicorp.com/packer/1.10.3/packer_1.10.3_darwin_amd64.zip
16.21 MiB / 16.21 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-1576988151/packer_1.10.3_darwin_amd64.zip written.
Name: packer_1.10.3_darwin_amd64.zip, size: 170018342024/05/11 09:00:33 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-1576988151/packer
2024/05/11 09:00:33 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-1576988151/packer to /Users/rgee0/.arkade/bin/packer

Wrote: /Users/rgee0/.arkade/bin/packer (58.03MB)

➜  arkade git:(hashicorp) ./arkade get waypoint                                      
Downloading: waypoint
2024/05/11 09:00:38 Looking up version for waypoint
2024/05/11 09:00:38 Found: v0.11.4
Downloading: https://releases.hashicorp.com/waypoint/0.11.4/waypoint_0.11.4_darwin_amd64.zip
83.73 MiB / 83.73 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-4275061740/waypoint_0.11.4_darwin_amd64.zip written.
Name: waypoint_0.11.4_darwin_amd64.zip, size: 87793018^[[A2024/05/11 09:00:47 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-4275061740/waypoint
2024/05/11 09:00:47 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-4275061740/waypoint to /Users/rgee0/.arkade/bin/waypoint

Wrote: /Users/rgee0/.arkade/bin/waypoint (166.6MB)

➜  arkade git:(hashicorp) ./arkade get vault                                         
Downloading: vault
2024/05/11 09:00:52 Looking up version for vault
2024/05/11 09:00:52 Found: v1.16.2
Downloading: https://releases.hashicorp.com/vault/1.16.2/vault_1.16.2_darwin_amd64.zip
143.87 MiB / 143.87 MiB [-------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-3727998193/vault_1.16.2_darwin_amd64.zip written.
Name: vault_1.16.2_darwin_amd64.zip, size: 1508607732024/05/11 09:01:09 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-3727998193/vault
2024/05/11 09:01:09 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-3727998193/vault to /Users/rgee0/.arkade/bin/vault

Wrote: /Users/rgee0/.arkade/bin/vault (425.6MB)

➜  arkade git:(hashicorp) 
```

### make e2e
```
➜  arkade git:(hashicorp) make e2e
...
PASS
coverage: 61.1% of statements
ok      github.com/alexellis/arkade/pkg/get     15.964s coverage: 61.1% of statements
```

### test-tool.sh popeye

```sh
➜  arkade git:(hashicorp) go build && ./hack/test-tool.sh popeye
+ ./arkade get popeye --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=mcvIB1SKQnwjlitRzVX6/6cB1ltvpIUQoAtUyhriZ/0PZ7H2RJJo4NQWkItLPf/OT1BaF-QFwY2s-oEOw1I, stripped
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/popeye
/Users/rgee0/.arkade/bin/popeye: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=7kL4hk19RKruiVgkbr5O/KSVHZD69pPcskfMIW3Q5/FYRl0PrEDRF1Z-bLZIhA/i9vGZtiS30vs0g66Gyrt, stripped
+ rm /Users/rgee0/.arkade/bin/popeye
+ echo

+ ./arkade get popeye --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/popeye.exe
/Users/rgee0/.arkade/bin/popeye.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/popeye.exe
+ echo
```

### test-tool.sh atuin (windows binary unavailable)

```sh
➜  arkade git:(hashicorp) go build && ./hack/test-tool.sh atuin 
+ ./arkade get atuin --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/atuin
/Users/rgee0/.arkade/bin/atuin: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/atuin
+ echo

+ ./arkade get atuin --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/atuin
/Users/rgee0/.arkade/bin/atuin: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/atuin
+ echo

+ ./arkade get atuin --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/atuin
/Users/rgee0/.arkade/bin/atuin: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=e45afc608ce46f90ba0392b7f2edc0122bbd4ee5, for GNU/Linux 3.2.0, stripped
+ rm /Users/rgee0/.arkade/bin/atuin
+ echo

+ ./arkade get atuin --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/atuin
/Users/rgee0/.arkade/bin/atuin: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=ff572ad717d266e67e156ba02ae1fb538bb19d4c, for GNU/Linux 3.7.0, stripped
+ rm /Users/rgee0/.arkade/bin/atuin
+ echo

+ ./arkade get atuin --arch x86_64 --os mingw --quiet

The requested version of atuin is not available or configured in arkade for mingw/x86_64

* Check if a binary is available from the project for your Operating System
* View the atuin releases page: https://github.com/atuinsh/atuin/releases
* Feel free to raise an issue at https://github.com/alexellis/arkade/issues for help

Error: server returned status: 404
```

### test-tool.sh terraform

```sh
➜  arkade git:(hashicorp) go build && ./hack/test-tool.sh terraform
+ ./arkade get terraform --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=CpQmWceVi6IG07QhDVDA/-PNr21IQMN6lBUo_oYNE/b1jkmskH-RIPSk7op7z7/ymMG1spInI3R34m3YFWU, stripped
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=q2B1pSQ4KezkSCDw_rEx/EseGQP_fMgTQCLgE7Knn/zZ7dIputq3WkbGQSV71Y/gBhf2m1vUTB6XpcZEOJm, stripped
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/terraform.exe
/Users/rgee0/.arkade/bin/terraform.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/terraform.exe
+ echo

```

### test-tool.sh packer

```sh
➜  arkade git:(hashicorp) go build && ./hack/test-tool.sh packer
+ ./arkade get packer --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/packer
/Users/rgee0/.arkade/bin/packer: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/packer
+ echo

+ ./arkade get packer --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/packer
/Users/rgee0/.arkade/bin/packer: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/packer
+ echo

+ ./arkade get packer --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/packer
/Users/rgee0/.arkade/bin/packer: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=qBll5cF0bleQ7CIOP4rb/CcP_DLU0ohrkWFvg0IKa/6vgl_OY_PsLYNKom1XlO/EAh_O_eq9Pb29KGQ8ag8, stripped
+ rm /Users/rgee0/.arkade/bin/packer
+ echo

+ ./arkade get packer --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/packer
/Users/rgee0/.arkade/bin/packer: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=vLexrhO6-vU6QWQ_Dx3d/XQtlggEBF5lz8ZzxKSVF/NXu7L6WjDXsiL_TrcQ5Y/F_PINxkktX8eR6lr82x5, stripped
+ rm /Users/rgee0/.arkade/bin/packer
+ echo

+ ./arkade get packer --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/packer.exe
/Users/rgee0/.arkade/bin/packer.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
+ rm /Users/rgee0/.arkade/bin/packer.exe
+ echo

```

### test-tool.sh waypoint

```sh
➜  arkade git:(hashicorp) go build && ./hack/test-tool.sh waypoint 
+ ./arkade get waypoint --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=BjDrvGk2_OENbAmfM4_R/CGUUh7-1wMXER25McDxC/1i57FFiXSIruqmWnjvs4/5sdVBfZtWFZJDh6uvhYC, stripped
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/waypoint
/Users/rgee0/.arkade/bin/waypoint: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=Nsi8i0X2eROpyhD7qSbo/_QSuviOi4kfcoXVBELI9/LgPi6pJBqW3aWC35itaR/lGpvhE6Fy1W3NY5CfZhE, stripped
+ rm /Users/rgee0/.arkade/bin/waypoint
+ echo

+ ./arkade get waypoint --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/waypoint.exe
/Users/rgee0/.arkade/bin/waypoint.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
+ rm /Users/rgee0/.arkade/bin/waypoint.exe
+ echo
```

### test-tool.sh vault

```sh
➜  arkade git:(hashicorp) go build && ./hack/test-tool.sh vault   
+ ./arkade get vault --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/vault
/Users/rgee0/.arkade/bin/vault: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/vault
+ echo

+ ./arkade get vault --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/vault
/Users/rgee0/.arkade/bin/vault: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/vault
+ echo

+ ./arkade get vault --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/vault
/Users/rgee0/.arkade/bin/vault: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=R-UprXiWgwFhw9ZPyTCB/ei9YtV00iXiAbLOHJfpw/WnT4g9jIg7t8mgaiAqjH/Xa6Q37z549d2OsFVEzam, with debug_info, not stripped
+ rm /Users/rgee0/.arkade/bin/vault
+ echo

+ ./arkade get vault --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/vault
/Users/rgee0/.arkade/bin/vault: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=gVdJb77RvWqjCKxkl319/EdX9xr-lGyXoUMrD44Xa/xYvxPEZRv3U2TfWz5GE0/EMe6C9w3uSQu9ZtmPYtt, with debug_info, not stripped
+ rm /Users/rgee0/.arkade/bin/vault
+ echo

+ ./arkade get vault --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/vault.exe
/Users/rgee0/.arkade/bin/vault.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/vault.exe
+ echo
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
