### PR TITLE
Add kube-score to available tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ There are 56 apps that you can install on your cluster.
 | [kube-bench](https://github.com/aquasecurity/kube-bench)                     | Checks whether Kubernetes is deployed securely by running the checks documented in the CIS Kubernetes Benchmark.                                                |
 | [kube-burner](https://github.com/cloud-bulldozer/kube-burner)                | A tool aimed at stressing Kubernetes clusters by creating or deleting a high quantity of objects.                                                               |
 | [kube-linter](https://github.com/stackrox/kube-linter)                       | KubeLinter is a static analysis tool that checks Kubernetes YAML files and Helm charts to ensure the applications represented in them adhere to best practices. |
+| [kube-score](https://github.com/zegl/kube-score)                             | A tool that performs static code analysis of your Kubernetes object definitions.                                                                                |
 | [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder)                | Framework for building Kubernetes APIs using custom resource definitions (CRDs).                                                                                |
 | [kubecm](https://github.com/sunny0826/kubecm)                                | Easier management of kubeconfig.                                                                                                                                |
 | [kubeconform](https://github.com/yannh/kubeconform)                          | A FAST Kubernetes manifests validator, with support for Custom Resources                                                                                        |
@@ -912,6 +913,6 @@ There are 56 apps that you can install on your cluster.
 | [waypoint](https://github.com/hashicorp/waypoint)                            | Easy application deployment for Kubernetes and Amazon ECS                                                                                                       |
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                                           |
 | [yt-dlp](https://github.com/yt-dlp/yt-dlp)                                   | Fork of youtube-dl with additional features and fixes                                                                                                           |
-There are 152 tools, use `arkade get NAME` to download one.
+There are 153 tools, use `arkade get NAME` to download one.
 
 > Note to contributors, run `arkade get --format markdown` to generate this list

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -7400,3 +7400,62 @@ func Test_DownloadFaasd(t *testing.T) {
 		}
 	}
 }
+
+func Test_DownloadKubeScore(t *testing.T) {
+	tools := MakeTools()
+	name := "kube-score"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v1.18.0"
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_linux_amd64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_darwin_amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_linux_arm64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_darwin_arm64.tar.gz",
+		},
+		{
+			os:      "ming",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_windows_arm64.exe",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_windows_amd64.exe",
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("\nwant: %s, \n got: %s", tc.url, got)
+		}
+	}
+
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -4168,5 +4168,30 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 					`,
 		})
 
+	tools = append(tools,
+		Tool{
+			Owner:       "zegl",
+			Repo:        "kube-score",
+			Name:        "kube-score",
+			Description: "A tool that performs static code analysis of your Kubernetes object definitions.",
+			BinaryTemplate: `
+			{{$os := .OS}}
+			{{$arch := .Arch}}
+			{{$ext := "tar.gz"}}
+
+			{{- if HasPrefix .OS "ming" -}}
+			{{ $os = "windows" }}
+			{{ $ext = "exe" }}
+		{{- end -}}
+
+			{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
+				{{$arch = "arm64"}}
+			{{- else if eq .Arch "x86_64" -}}
+				{{ $arch = "amd64" }}
+			{{- end -}}
+
+			{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.{{$ext}}`,
+		})
+
 	return tools
 }


### PR DESCRIPTION
## Description
Add kube-score  (and associated tests) to available tools

## Motivation and Context

- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Fixes #1001

## How Has This Been Tested?

### functional on darwin x86_64

```sh
➜  arkade git:(kubescore) ✗ make build
go build
➜  arkade git:(kubescore) ✗ ./arkade get kube-score
Downloading: kube-score
2024/05/11 11:11:02 Looking up version for kube-score
2024/05/11 11:11:02 Found: v1.18.0
Downloading: https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_darwin_amd64.tar.gz
6.32 MiB / 6.32 MiB [----------------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2159499095/kube-score_1.18.0_darwin_amd64.tar.gz written.
2024/05/11 11:11:04 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2159499095/kube-score
2024/05/11 11:11:04 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2159499095/kube-score to /Users/rgee0/.arkade/bin/kube-score

Wrote: /Users/rgee0/.arkade/bin/kube-score (21.23MB)
```

### make e2e

```sh
➜  arkade git:(kubescore) ✗ make e2e
...
PASS
coverage: 61.2% of statements
ok      github.com/alexellis/arkade/pkg/get     16.697s coverage: 61.2% of statements
```

### test-tool kube-score

```sh
➜  arkade git:(kubescore) go build && ./hack/test-tool.sh kube-score       
+ ./arkade get kube-score --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kube-score
/Users/rgee0/.arkade/bin/kube-score: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/kube-score
+ echo

+ ./arkade get kube-score --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kube-score
/Users/rgee0/.arkade/bin/kube-score: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/kube-score
+ echo

+ ./arkade get kube-score --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kube-score
/Users/rgee0/.arkade/bin/kube-score: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=xApvPOQccxisMNbrnSWr/eEsLrRU9XzVzynRVFKgC/lrlngbAWIEHvG7IA69Lu/78f5xYHyUu3tgUMIz7Iz, stripped
+ rm /Users/rgee0/.arkade/bin/kube-score
+ echo

+ ./arkade get kube-score --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kube-score
/Users/rgee0/.arkade/bin/kube-score: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=oDVksJmeFMw-SNSFQGVY/LDwNKiUFK-M6ry01YbsE/dw7jnsJE2GjtZRHJJqx1/fjAdHSAFhUpkgJG27T47, stripped
+ rm /Users/rgee0/.arkade/bin/kube-score
+ echo

+ ./arkade get kube-score --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/kube-score.exe
/Users/rgee0/.arkade/bin/kube-score.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/kube-score.exe
+ echo
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
