### PR TITLE
Add consul as a tool & fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,7 @@ There are 56 apps that you can install on your cluster.
 | [clusterctl](https://github.com/kubernetes-sigs/cluster-api)                 | The clusterctl CLI tool handles the lifecycle of a Cluster API management cluster                                                                               |
 | [cmctl](https://github.com/cert-manager/cert-manager)                        | cmctl is a CLI tool that helps you manage cert-manager and its resources inside your cluster.                                                                   |
 | [conftest](https://github.com/open-policy-agent/conftest)                    | Write tests against structured configuration data using the Open Policy Agent Rego query language                                                               |
+| [consul](https://github.com/hashicorp/consul)                                | A solution to connect and configure applications across dynamic, distributed infrastructure                                                                     |
 | [copa](https://github.com/project-copacetic/copacetic)                       | CLI for patching container images                                                                                                                               |
 | [cosign](https://github.com/sigstore/cosign)                                 | Container Signing, Verification and Storage in an OCI registry.                                                                                                 |
 | [cr](https://github.com/helm/chart-releaser)                                 | Hosting Helm Charts via GitHub Pages and Releases                                                                                                               |
@@ -913,6 +914,6 @@ There are 56 apps that you can install on your cluster.
 | [waypoint](https://github.com/hashicorp/waypoint)                            | Easy application deployment for Kubernetes and Amazon ECS                                                                                                       |
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                                           |
 | [yt-dlp](https://github.com/yt-dlp/yt-dlp)                                   | Fork of youtube-dl with additional features and fixes                                                                                                           |
-There are 153 tools, use `arkade get NAME` to download one.
+There are 154 tools, use `arkade get NAME` to download one.
 
 > Note to contributors, run `arkade get --format markdown` to generate this list

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -246,35 +246,35 @@ func Test_GetDownloadURLs(t *testing.T) {
 	}{
 		{
 			name:    "kubectl",
-			url:     "https://dl.k8s.io/release/" + kubectlVersion + "/bin/linux/amd64/kubectl",
+			url:     "https://dl.k8s.io/release/v1.29.1/bin/linux/amd64/kubectl",
 			version: kubectlVersion,
 			os:      "linux",
 			arch:    "x86_64",
 		},
 		{
 			name:    "kubectl",
-			url:     "https://dl.k8s.io/release/" + kubectlVersion + "/bin/darwin/amd64/kubectl",
+			url:     "https://dl.k8s.io/release/v1.29.1/bin/darwin/amd64/kubectl",
 			version: kubectlVersion,
 			os:      "darwin",
 			arch:    "x86_64",
 		},
 		{
 			name:    "kubectl",
-			url:     "https://dl.k8s.io/release/" + kubectlVersion + "/bin/linux/arm64/kubectl",
+			url:     "https://dl.k8s.io/release/v1.29.1/bin/linux/arm64/kubectl",
 			version: kubectlVersion,
 			os:      "linux",
 			arch:    "aarch64",
 		},
 		{
 			name:    "kubectl",
-			url:     "https://dl.k8s.io/release/" + kubectlVersion + "/bin/darwin/arm64/kubectl",
+			url:     "https://dl.k8s.io/release/v1.29.1/bin/darwin/arm64/kubectl",
 			version: kubectlVersion,
 			os:      "darwin",
 			arch:    archDarwinARM64,
 		},
 		{
 			name:    "kubectl",
-			url:     "https://dl.k8s.io/release/" + kubectlVersion + "/bin/linux/amd64/kubectl",
+			url:     "https://dl.k8s.io/release/v1.29.1/bin/linux/amd64/kubectl",
 			version: kubectlVersion,
 			os:      "linux",
 			arch:    "x86_64",
@@ -1250,37 +1250,37 @@ func Test_DownloadPopeye(t *testing.T) {
 			os:      "ming",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Windows_amd64.tar.gz",
+			url:     "https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Windows_amd64.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Linux_amd64.tar.gz",
+			url:     "https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Linux_amd64.tar.gz",
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Darwin_amd64.tar.gz",
+			url:     "https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Darwin_amd64.tar.gz",
 		},
 		{
 			os:      "darwin",
 			arch:    archDarwinARM64,
 			version: toolVersion,
-			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Darwin_arm64.tar.gz",
+			url:     "https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Darwin_arm64.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
 			version: toolVersion,
-			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Linux_arm64.tar.gz",
+			url:     "https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Linux_arm64.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    archARM7,
 			version: toolVersion,
-			url:     "https://github.com/derailed/popeye/releases/download/" + toolVersion + "/popeye_Linux_armv7.tar.gz",
+			url:     "https://github.com/derailed/popeye/releases/download/v0.21.2/popeye_Linux_armv7.tar.gz",
 		},
 	}
 
@@ -1432,6 +1432,64 @@ func Test_DownloadWaypoint(t *testing.T) {
 		}
 		if got != tc.url {
 			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
+func Test_DownloadConsul(t *testing.T) {
+	tools := MakeTools()
+	name := "consul"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "1.18.1"
+
+	tests := []test{
+		{
+			os:      "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     `https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_windows_amd64.zip`,
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_linux_amd64.zip",
+		},
+		{
+			os:      "linux",
+			arch:    archARM7,
+			version: toolVersion,
+			url:     "https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_linux_arm.zip",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_linux_arm64.zip",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_darwin_arm64.zip",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_darwin_amd64.zip",
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("\nwant: %s, \n got: %s", tc.url, got)
 		}
 	}
 }
@@ -6827,25 +6885,25 @@ func Test_DownloadAtuin(t *testing.T) {
 			os:      "darwin",
 			arch:    archDarwinARM64,
 			version: toolVersion,
-			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-aarch64-apple-darwin.tar.gz",
+			url:     "https://github.com/atuinsh/atuin/releases/download/v18.2.0/atuin-v18.2.0-aarch64-apple-darwin.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
 			version: toolVersion,
-			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-aarch64-unknown-linux-gnu.tar.gz",
+			url:     "https://github.com/atuinsh/atuin/releases/download/v18.2.0/atuin-v18.2.0-aarch64-unknown-linux-gnu.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-x86_64-unknown-linux-gnu.tar.gz",
+			url:     "https://github.com/atuinsh/atuin/releases/download/v18.2.0/atuin-v18.2.0-x86_64-unknown-linux-gnu.tar.gz",
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     "https://github.com/atuinsh/atuin/releases/download/" + toolVersion + "/atuin-" + toolVersion + "-x86_64-apple-darwin.tar.gz",
+			url:     "https://github.com/atuinsh/atuin/releases/download/v18.2.0/atuin-v18.2.0-x86_64-apple-darwin.tar.gz",
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -822,6 +822,31 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 	tools = append(tools,
 		Tool{
 			Owner:           "hashicorp",
+			Repo:            "consul",
+			Name:            "consul",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "A solution to connect and configure applications across dynamic, distributed infrastructure",
+			URLTemplate: `
+				{{$arch := ""}}
+				{{- if eq .Arch "x86_64" -}}
+				{{$arch = "amd64"}}
+				{{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+				{{$arch = "arm64"}}
+				{{- else if eq .Arch "armv7l" -}}
+				{{$arch = "arm"}}
+				{{- end -}}
+	
+				{{$os := .OS}}
+				{{ if HasPrefix .OS "ming" -}}
+				{{$os = "windows"}}
+				{{- end -}}
+	
+				https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.zip`,
+		})
+
+	tools = append(tools,
+		Tool{
+			Owner:           "hashicorp",
 			Repo:            "terraform",
 			Name:            "terraform",
 			VersionStrategy: GitHubVersionStrategy,
@@ -830,9 +855,7 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			{{$arch := ""}}
 			{{- if eq .Arch "x86_64" -}}
 			{{$arch = "amd64"}}
-			{{- else if eq .Arch "arm64" -}}
-			{{$arch = "arm64"}}
-			{{- else if eq .Arch "aarch64" -}}
+			{{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
 			{{$arch = "arm64"}}
 			{{- else if eq .Arch "armv7l" -}}
 			{{$arch = "arm"}}


### PR DESCRIPTION
## Description

Adds hashicorp/consul as a tool with associated tests Amends template pattern for hashicorp/terraform to simplify and align with the consul template pattern
Addresses a comment on a previous PR where the project preference is for URLs in the tests to not use variable concatenation

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Fixes #767


## How Has This Been Tested?

### Functional get consul

```sh
➜  arkade git:(consul) ✗ go build && ./arkade get consul
Downloading: consul
2024/05/14 19:13:33 Looking up version for consul
2024/05/14 19:13:33 Found: v1.18.1
Downloading: https://releases.hashicorp.com/consul/1.18.1/consul_1.18.1_darwin_amd64.zip
64.41 MiB / 64.41 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2590627787/consul_1.18.1_darwin_amd64.zip written.
Name: consul_1.18.1_darwin_amd64.zip, size: 675408822024/05/14 19:13:43 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2590627787/consul
2024/05/14 19:13:43 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2590627787/consul to /Users/rgee0/.arkade/bin/consul

Wrote: /Users/rgee0/.arkade/bin/consul (178.1MB)
```

### make e2e

```sh
➜  arkade git:(consul) make e2e
...
PASS
coverage: 61.3% of statements
ok      github.com/alexellis/arkade/pkg/get     17.057s coverage: 61.3% of statements
```

### test-tool.sh
```sh
➜  arkade git:(consul) ✗ go build && ./hack/test-tool.sh consul
+ ./arkade get consul --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/consul
/Users/rgee0/.arkade/bin/consul: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/consul
+ echo

+ ./arkade get consul --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/consul
/Users/rgee0/.arkade/bin/consul: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/consul
+ echo

+ ./arkade get consul --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/consul
/Users/rgee0/.arkade/bin/consul: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=y5LPp24ZZhNnDP284ubb/2BIXzozfTq_kUytkGCR7/0uYO--iYavJs7FCS1rvQ/KQCEHNg-3xt9aIm_DlAy, with debug_info, not stripped
+ rm /Users/rgee0/.arkade/bin/consul
+ echo

+ ./arkade get consul --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/consul
/Users/rgee0/.arkade/bin/consul: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=p55ha8vtSDvMG4eStmHP/5lcKf2QXYh8prK4_NqLY/d85FIYQ7fWuz8kMAaBkH/GB7aLtoLOjvYic5drpH4, with debug_info, not stripped
+ rm /Users/rgee0/.arkade/bin/consul
+ echo

+ ./arkade get consul --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/consul.exe
/Users/rgee0/.arkade/bin/consul.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/consul.exe
+ echo

```

### bonus test-tool for armv7l
```sh
./arkade get consul --arch armv7l --os linux --quiet && file $HOME/.arkade/bin/consul && rm $HOME/.arkade/bin/consul && echo 

/Users/rgee0/.arkade/bin/consul: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=38Zg_JvFEG_WciKC899U/wZdCM6Xix5dMFk9MsL53/uI_WAboiEkoZv5DFYo3v/89zw3nPirkldgp4ozMf5, with debug_info, not stripped

```

### test-tool terraform
```sh
➜  arkade git:(consul) ✗ go build && ./hack/test-tool.sh terraform           
+ ./arkade get terraform --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=CpQmWceVi6IG07QhDVDA/-PNr21IQMN6lBUo_oYNE/b1jkmskH-RIPSk7op7z7/ymMG1spInI3R34m3YFWU, stripped
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/terraform
/Users/rgee0/.arkade/bin/terraform: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=q2B1pSQ4KezkSCDw_rEx/EseGQP_fMgTQCLgE7Knn/zZ7dIputq3WkbGQSV71Y/gBhf2m1vUTB6XpcZEOJm, stripped
+ rm /Users/rgee0/.arkade/bin/terraform
+ echo

+ ./arkade get terraform --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/terraform.exe
/Users/rgee0/.arkade/bin/terraform.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/terraform.exe
+ echo

```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
