### PR TITLE
fix chart upgrade to handle v prefix

### DIFF
--- a/cmd/chart/upgrade.go
+++ b/cmd/chart/upgrade.go
@@ -103,14 +103,14 @@ Otherwise, it returns a non-zero exit code and the updated values.yaml file.`,
 			sort.Sort(sort.Reverse(semver.Collection(vs)))
 
 			latestTag := vs[0].String()
-
+			// Semver is "eating" the "v" prefix, so we need to add it back, if it was there in first place
+			if strings.HasPrefix(tag, "v") {
+				latestTag = "v" + latestTag
+			}
 			// AE: Don't upgrade to an RC tag, even if it's newer.
 			if latestTag != tag && !strings.Contains(latestTag, "-rc") {
 				updated++
-				// Semver is "eating" the "v" prefix, so we need to add it back, if it was there in first place
-				if strings.HasPrefix(tag, "v") {
-					latestTag = "v" + latestTag
-				}
+
 				filtered[k] = fmt.Sprintf("%s:%s", imageName, latestTag)
 				if verbose {
 					log.Printf("[%s] %s => %s", imageName, tag, latestTag)


### PR DESCRIPTION
## Description

It was noted that after a chart upgrade if the upgrade command was run for a second time it would update two images within openfaas/values.yaml.

This was due to the prom images which are prefixed by v.  This case  was being handled after the check of whether the latestTag != tag.

This change moves the handling of this case prior to the if statement.

<!--- Describe your changes in detail -->

## Motivation and Context
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

### Before:
```
➜  faas-netes git:(workers) time make upgrade-charts
Upgrading images for all helm charts
2024/06/01 21:04:29 Wrote 9 updates to: ./chart/openfaas/values.yaml
2024/06/01 21:04:30 Wrote 1 updates to: ./chart/kafka-connector/values.yaml
2024/06/01 21:04:34 Wrote 1 updates to: ./chart/queue-worker/values.yaml
make upgrade-charts  1.36s user 1.25s system 30% cpu 8.642 total
➜  faas-netes git:(workers) ✗ time make upgrade-charts
Upgrading images for all helm charts
2024/06/01 21:05:58 Wrote 2 updates to: ./chart/openfaas/values.yaml
make upgrade-charts  1.37s user 1.27s system 15% cpu 16.712 total
➜  faas-netes git:(workers) ✗ time make upgrade-charts
Upgrading images for all helm charts
2024/06/01 21:06:19 Wrote 2 updates to: ./chart/openfaas/values.yaml
make upgrade-charts  1.38s user 1.30s system 16% cpu 16.538 total
```
### After:
```
➜  faas-netes git:(workers) time make upgrade-charts         
Upgrading images for all helm charts
2024/06/01 21:30:19 Wrote 7 updates to: ./chart/openfaas/values.yaml
2024/06/01 21:30:20 Wrote 1 updates to: ./chart/kafka-connector/values.yaml
2024/06/01 21:30:25 Wrote 1 updates to: ./chart/queue-worker/values.yaml
make upgrade-charts  1.37s user 1.26s system 17% cpu 15.437 total
➜  faas-netes git:(workers) ✗ time make upgrade-charts
Upgrading images for all helm charts
make upgrade-charts  1.37s user 1.26s system 16% cpu 15.787 total
```
### Debug / Diagnosis

```
➜  faas-netes git:(workers) arkade chart upgrade --verbose=true -w -f ./chart/openfaas/values.yaml
2024/06/01 21:16:45 Verifying images in: ./chart/openfaas/values.yaml
2024/06/01 21:16:45 Found 17 images
2024/06/01 21:16:49 [prom/prometheus] v2.52.0 => v2.52.0
2024/06/01 21:16:50 [prom/alertmanager] v0.27.0 => v0.27.0
2024/06/01 21:16:53 Wrote 2 updates to: ./chart/openfaas/values.yaml

➜  faas-netes git:(workers) time make upgrade-charts
Upgrading images for all helm charts
...
prom/prometheus:v2.52.0 versus 2.52.0
prom/alertmanager:v0.27.0 versus 0.27.0
...
2024/06/01 21:22:56 Wrote 2 updates to: ./chart/openfaas/values.yaml
```

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh TOOL_NAME
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

- [ ] I have tested this on arm, or have added code to prevent deployment
