### PR TITLE
doctl: Resolve versions based on GitHub releases

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1075,7 +1075,7 @@ func Test_DownloadDigitalOcean(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "1.46.0"
+	const toolVersion = "v1.46.0"
 	const urlTemplate = "https://github.com/digitalocean/doctl/releases/download/v1.46.0/doctl-1.46.0-%s-%s.%s"
 
 	tests := []test{
@@ -1091,11 +1091,10 @@ func Test_DownloadDigitalOcean(t *testing.T) {
 			arch:    arch64bit,
 			version: toolVersion,
 			url:     fmt.Sprintf(urlTemplate, "darwin", "amd64", "tar.gz")},
-		// this asserts that we can build a URL for ARM processors, but no asset exists and will yield a 404
 		{os: "linux",
 			arch:    archARM7,
 			version: toolVersion,
-			url:     fmt.Sprintf(urlTemplate, "linux", "", "tar.gz")},
+			url:     fmt.Sprintf(urlTemplate, "linux", "arm64", "tar.gz")},
 	}
 
 	for _, tc := range tests {

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -642,34 +642,32 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "digitalocean",
-			Repo:        "doctl",
-			Name:        "doctl",
-			Version:     "1.56.0",
-			Description: "Official command line interface for the DigitalOcean API.",
-			URLTemplate: `
-		{{$osStr := ""}}
+			Owner:           "digitalocean",
+			Repo:            "doctl",
+			Name:            "doctl",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "Official command line interface for the DigitalOcean API.",
+			BinaryTemplate: `
+		{{$osStr := .OS}}
 		{{ if HasPrefix .OS "ming" -}}
 		{{$osStr = "windows"}}
-		{{- else if eq .OS "linux" -}}
-		{{$osStr = "linux"}}
-		{{- else if eq .OS "darwin" -}}
-		{{$osStr = "darwin"}}
 		{{- end -}}
 
-		{{$archStr := ""}}
+		{{$archStr := .Arch}}
 		{{- if eq .Arch "x86_64" -}}
 		{{$archStr = "amd64"}}
+		{{- else if eq .Arch "armv7l" }}
+		{{$archStr = "arm64"}}
+		{{- else if eq .Arch "aarch64" }}
+		{{$archStr = "arm64"}}
 		{{- end -}}
 
-		{{$archiveStr := ""}}
-		{{ if HasPrefix .OS "ming" -}}
+		{{$archiveStr := "tar.gz"}}
+		{{ if eq $osStr "windows" -}}
 		{{$archiveStr = "zip"}}
-		{{- else -}}
-		{{$archiveStr = "tar.gz"}}
 		{{- end -}}
 
-		https://github.com/digitalocean/doctl/releases/download/v{{.Version}}/doctl-{{.Version}}-{{$osStr}}-{{$archStr}}.{{$archiveStr}}`,
+		doctl-{{.VersionNumber}}-{{$osStr}}-{{$archStr}}.{{$archiveStr}}`,
 		})
 
 	tools = append(tools,


### PR DESCRIPTION
## Description

Previously, doctl was pinned to a rather old release (1.56.0). Use the `GitHubVersionStrategy` to find versions based on GH releases, and simplify URL construction by providing a `BinaryTemplate` rather than a full `URLTemplate`, since the binaries live at standard GitHub release paths.

While we're here, add support for doctl Linux ARM binaries since they are now available.

## Motivation and Context

`arkade get doctl` was downloading a rather old version.

- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

### make e2e

Fails on an unrelated test (`k10multicluster` is broken on its latest release).

### test-tool.sh

```
% hack/test-tool.sh doctl
+ ./arkade get doctl --arch arm64 --os darwin --quiet
+ file /home/awg/.arkade/bin/doctl
/home/awg/.arkade/bin/doctl: Mach-O 64-bit arm64 executable, flags:<|DYLDLINK|PIE>
+ rm /home/awg/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch x86_64 --os darwin --quiet
+ file /home/awg/.arkade/bin/doctl
/home/awg/.arkade/bin/doctl: Mach-O 64-bit x86_64 executable
+ rm /home/awg/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch x86_64 --os linux --quiet
+ file /home/awg/.arkade/bin/doctl
/home/awg/.arkade/bin/doctl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=kq9KHvC4kgxvm0B9wjg0/XHes6Wf8FXnCldycDaJo/u_CQFYqAoF-SIQClBsM6/5WfFN-cg8sK4HRo2W9sL, with debug_info, not stripped
+ rm /home/awg/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch aarch64 --os linux --quiet
+ file /home/awg/.arkade/bin/doctl
/home/awg/.arkade/bin/doctl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=70Ctm0l2Yic7VdKGtWnz/TYE8O_nbx80ImpboFzvs/fOj9d1ZzSQtqA2w1Xi4u/UwAaAXnoPDPeHF_SugIh, with debug_info, not stripped
+ rm /home/awg/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch x86_64 --os mingw --quiet
+ file /home/awg/.arkade/bin/doctl.exe
/home/awg/.arkade/bin/doctl.exe: PE32+ executable (console) x86-64, for MS Windows, 15 sections
+ rm /home/awg/.arkade/bin/doctl.exe
+ echo

```

### Local test

```
% ./arkade get --path . doctl
Downloading: doctl
2024/06/03 10:16:05 Looking up version for doctl
2024/06/03 10:16:05 Found: v1.107.0
Downloading: https://github.com/digitalocean/doctl/releases/download/v1.107.0/doctl-1.107.0-linux-amd64.tar.gz
15.27 MiB / 15.27 MiB [-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
/tmp/arkade-1975906647/doctl-1.107.0-linux-amd64.tar.gz written.
2024/06/03 10:16:06 Extracted: /tmp/arkade-1975906647/doctl
2024/06/03 10:16:06 Copying /tmp/arkade-1975906647/doctl to doctl

Wrote: doctl (33.05MB)

Run the following to copy to install the tool:
sudo install -m 755 doctl /usr/local/bin/doctl

🚀 Speed up GitHub Actions/GitLab CI + reduce costs: https://actuated.dev

% ./doctl version
doctl version 1.107.0-release
Git commit hash: 42fc8b6f
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
