### PR TITLE
update doctl tests to standard binary pattern

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1075,30 +1075,51 @@ func Test_DownloadDigitalOcean(t *testing.T) {
 
 	tool := getTool(name, tools)
 
-	const toolVersion = "v1.46.0"
-	const urlTemplate = "https://github.com/digitalocean/doctl/releases/download/v1.46.0/doctl-1.46.0-%s-%s.%s"
+	const toolVersion = "1.107.0"
 
 	tests := []test{
-		{os: "mingw64_nt-10.0-18362",
+		{
+			os:      "mingw64_nt-10.0-18362",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     fmt.Sprintf(urlTemplate, "windows", "amd64", "zip"),
+			url:     "https://github.com/digitalocean/doctl/releases/download/1.107.0/doctl-1.107.0-windows-amd64.zip",
 		},
-		{os: "linux",
+		{
+			os:      "mingw64_nt-10.0-18362",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/digitalocean/doctl/releases/download/1.107.0/doctl-1.107.0-windows-arm64.zip",
+		},
+		{
+			os:      "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     fmt.Sprintf(urlTemplate, "linux", "amd64", "tar.gz"),
+			url:     "https://github.com/digitalocean/doctl/releases/download/1.107.0/doctl-1.107.0-linux-amd64.tar.gz",
 		},
-		{os: "darwin",
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/digitalocean/doctl/releases/download/1.107.0/doctl-1.107.0-linux-arm64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://github.com/digitalocean/doctl/releases/download/1.107.0/doctl-1.107.0-darwin-arm64.tar.gz",
+		},
+		{
+			os:      "darwin",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     fmt.Sprintf(urlTemplate, "darwin", "amd64", "tar.gz"),
+			url:     "https://github.com/digitalocean/doctl/releases/download/1.107.0/doctl-1.107.0-darwin-amd64.tar.gz",
 		},
-		{os: "linux",
+		{
+			os:      "linux",
 			arch:    archARM7,
 			version: toolVersion,
 			// designed to fail with 404 due to no binary being published
-			url: "https://github.com/digitalocean/doctl/releases/download/v1.46.0/doctl-1.46.0-linux-.tar.gz",
+			url: "https://github.com/digitalocean/doctl/releases/download/1.107.0/doctl-1.107.0-linux-.tar.gz",
 		},
 	}
 
@@ -1108,7 +1129,7 @@ func Test_DownloadDigitalOcean(t *testing.T) {
 			t.Fatal(err)
 		}
 		if got != tc.url {
-			t.Errorf("want: %s, got: %s", tc.url, got)
+			t.Errorf("\nwant: %s, \n got: %s", tc.url, got)
 		}
 	}
 }


### PR DESCRIPTION
## Description

#1078 moved doctl over to a binary template pattern but left the urlTemplate references inside the tests.

This change moves the tests for `doctl` over to the standard pattern for a `binaryTemplate` tool

## Motivation and Context
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?

### functional
```sh
➜  arkade git:(doctl) make build                                 
go build
➜  arkade git:(doctl) ./arkade get doctl       
Downloading: doctl
2024/06/06 08:45:50 Looking up version for doctl
2024/06/06 08:45:50 Found: v1.107.0
Downloading: https://github.com/digitalocean/doctl/releases/download/v1.107.0/doctl-1.107.0-darwin-amd64.tar.gz
15.12 MiB / 15.12 MiB [---------------------------------------------------------------------------------------------] 100.00%
/var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2595846796/doctl-1.107.0-darwin-amd64.tar.gz written.
2024/06/06 08:45:52 Extracted: /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2595846796/doctl
2024/06/06 08:45:52 Copying /var/folders/3w/tv6429v51kl_61rd1fr25sgm0000gq/T/arkade-2595846796/doctl to /Users/rgee0/.arkade/bin/doctl

Wrote: /Users/rgee0/.arkade/bin/doctl (32.83MB)
```

### e2e
```sh
➜  arkade git:(doctl) make e2e
CGO_ENABLED=0 go test github.com/alexellis/arkade/pkg/get -cover --tags e2e -v
...
PASS
coverage: 61.2% of statements
ok      github.com/alexellis/arkade/pkg/get     16.265s coverage: 61.2% of statements
```

 ### test-tool.sh
```sh
➜  arkade git:(doctl) make build                                                   
go build
➜  arkade git:(doctl) ./hack/test-tool.sh doctl
+ ./arkade get doctl --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/doctl
/Users/rgee0/.arkade/bin/doctl: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/doctl
/Users/rgee0/.arkade/bin/doctl: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/doctl
/Users/rgee0/.arkade/bin/doctl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=kq9KHvC4kgxvm0B9wjg0/XHes6Wf8FXnCldycDaJo/u_CQFYqAoF-SIQClBsM6/5WfFN-cg8sK4HRo2W9sL, with debug_info, not stripped
+ rm /Users/rgee0/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/doctl
/Users/rgee0/.arkade/bin/doctl: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=70Ctm0l2Yic7VdKGtWnz/TYE8O_nbx80ImpboFzvs/fOj9d1ZzSQtqA2w1Xi4u/UwAaAXnoPDPeHF_SugIh, with debug_info, not stripped
+ rm /Users/rgee0/.arkade/bin/doctl
+ echo

+ ./arkade get doctl --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/doctl.exe
/Users/rgee0/.arkade/bin/doctl.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/doctl.exe
+ echo
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
