### PR TITLE
Ignore latest tags in chart upgrade

### DIFF
--- a/cmd/chart/upgrade.go
+++ b/cmd/chart/upgrade.go
@@ -185,7 +185,7 @@ func updateImages(iName string, v bool) (bool, string, error) {
 	laterVersionB := false
 
 	// AE: Don't upgrade to an RC tag, even if it's newer.
-	if latestTag != tag && !strings.Contains(latestTag, "-rc") {
+	if tagIsUpgradeable(tag, latestTag) {
 
 		laterVersionB = true
 
@@ -196,4 +196,10 @@ func updateImages(iName string, v bool) (bool, string, error) {
 	}
 
 	return laterVersionB, iName, nil
+}
+
+func tagIsUpgradeable(currentTag, latestTag string) bool {
+
+	return latestTag != currentTag && !strings.Contains(strings.ToLower(latestTag), "-rc") && !strings.EqualFold(currentTag, "latest")
+
 }

--- a/cmd/chart/upgrade_test.go
+++ b/cmd/chart/upgrade_test.go
@@ -1,0 +1,57 @@
+package chart
+
+import (
+	"testing"
+)
+
+func Test_tagIsUpgradable(t *testing.T) {
+	tests := []struct {
+		title    string
+		current  string
+		latest   string
+		expected bool
+	}{
+		{
+			title:    "Upgradeable",
+			current:  "1.0.0",
+			latest:   "1.1.0",
+			expected: true,
+		},
+		{
+			title:    "Same version",
+			current:  "1.0.0",
+			latest:   "1.0.0",
+			expected: false,
+		},
+		{
+			title:    "latest is RC",
+			current:  "1.0.0",
+			latest:   "1.0.0-RC",
+			expected: false,
+		},
+		{
+			title:    "latest is rc",
+			current:  "1.0.0",
+			latest:   "1.0.0-rc",
+			expected: false,
+		},
+		{
+			title:    "current is 'latest'",
+			current:  "latest",
+			latest:   "1.0.0",
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+
+		t.Run(tc.title, func(t *testing.T) {
+
+			upgradeableRes := tagIsUpgradeable(tc.current, tc.latest)
+
+			if upgradeableRes != tc.expected {
+				t.Fatalf("want: %t\n got: %t\n", tc.expected, upgradeableRes)
+			}
+		})
+	}
+}

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -3351,41 +3351,6 @@ func Test_DownloadKubestr(t *testing.T) {
 	}
 }
 
-//(Temporarily disable k10multicluster as the binaries are not available at v7.0.0)
-/*func Test_DownloadK10multicluster(t *testing.T) {
-	tools := MakeTools()
-	name := "k10multicluster"
-	v := "4.0.6"
-	tool := getTool(name, tools)
-
-	tests := []test{
-		{
-			os:      "darwin",
-			arch:    arch64bit,
-			version: v,
-			url:     `https://github.com/kastenhq/external-tools/releases/download/4.0.6/k10multicluster_4.0.6_macOS_amd64.tar.gz`,
-		},
-		{
-			os:      "linux",
-			arch:    arch64bit,
-			version: v,
-			url:     `https://github.com/kastenhq/external-tools/releases/download/4.0.6/k10multicluster_4.0.6_linux_amd64.tar.gz`,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.os+" "+tc.arch+" "+tc.version, func(r *testing.T) {
-			got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != tc.url {
-				t.Errorf("want: %s, got: %s", tc.url, got)
-			}
-		})
-	}
-}*/
-
 func Test_DownloadK10tools(t *testing.T) {
 	tools := MakeTools()
 	name := "k10tools"

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -2032,29 +2032,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Repo}}
 			BinaryTemplate: `{{.Name}}`,
 		})
 
-	//(Temporarily disable k10multicluster as the binaries are not available at v7.0.0)
-	/*  tools = append(tools,
-		Tool{
-			Owner:       "kastenhq",
-			Repo:        "external-tools",
-			Name:        "k10multicluster",
-			Description: "Multi-cluster support for K10.",
-
-			BinaryTemplate: `
-	{{ $osStr := "linux" }}
-	{{ $archStr := "amd64" }}
-
-	{{- if eq .Arch "aarch64" -}}
-	{{ $archStr = "arm64" }}
-	{{- end -}}
-
-	{{- if eq .OS "darwin" -}}
-	{{ $osStr = "macOS" }}
-	{{- end -}}
-
-	{{.Name}}_{{.Version}}_{{$osStr}}_{{$archStr}}.tar.gz`,
-		})
-	*/
 	tools = append(tools,
 		Tool{
 			Owner:       "kastenhq",


### PR DESCRIPTION
## Description
As described in #1086 the `chart upgrade` command was upgrading `latest` tags which was undesirable.

This change causes the upgrade command to ignore any images tagged `latest`. 
It also addresses an edge-case around `-RC` tags which was highlighted by the additional test created in this change.
The k10mulitcluster tool that was disabled has also been removed, so closes #1082 

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer
Fixes #1086 

## How Has This Been Tested?

Functionally tested by using the faasd `docker-compose.yaml`.
Initially ran `chart upgrade` on the file as is, and one change was found:
```sh
➜  arkade git:(ignoreLatest) ✗ ./arkade chart upgrade -f faasd.yaml -v
2024/06/13 09:37:33 Verifying images in: faasd.yaml
2024/06/13 09:37:33 Found 4 images
2024/06/13 09:37:34 [ghcr.io/openfaas/gateway] 0.27.5 => 0.27.7
```
This image was then changed to `ghcr.io/openfaas/gateway:latest` and the command run again:
```sh
➜  arkade git:(ignoreLatest) ✗ ./arkade chart upgrade -f faasd.yaml -v
2024/06/13 09:37:50 Verifying images in: faasd.yaml
2024/06/13 09:37:50 Found 4 images
```

The new test passes as show in the pipeline

No new tool has been added.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
