### PR TITLE
Revert "fix flyctl release name"

### DIFF
--- a/.github/workflows/e2e-url-checker.yml
+++ b/.github/workflows/e2e-url-checker.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
         with:

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -5364,13 +5364,13 @@ func Test_DownloadFlyctl(t *testing.T) {
 			os:      "darwin",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/superfly/flyctl/releases/download/v0.0.388/flyctl_0.0.388_macOS_amd64.tar.gz",
+			url:     "https://github.com/superfly/flyctl/releases/download/v0.0.388/flyctl_0.0.388_macOS_x86_64.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/superfly/flyctl/releases/download/v0.0.388/flyctl_0.0.388_Linux_amd64.tar.gz",
+			url:     "https://github.com/superfly/flyctl/releases/download/v0.0.388/flyctl_0.0.388_Linux_x86_64.tar.gz",
 		},
 		{
 			os:      "linux",
@@ -5382,7 +5382,7 @@ func Test_DownloadFlyctl(t *testing.T) {
 			os:      "ming",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/superfly/flyctl/releases/download/v0.0.388/flyctl_0.0.388_Windows_amd64.zip",
+			url:     "https://github.com/superfly/flyctl/releases/download/v0.0.388/flyctl_0.0.388_Windows_x86_64.zip",
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -3017,9 +3017,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				{{$ext = ".zip"}}
 				{{- end -}}
 
-				{{- if eq .Arch "x86_64" -}}
-				{{$arch = "amd64"}}
-				{{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+				{{- if eq .Arch "aarch64" -}}
 				{{$arch = "arm64"}}
 				{{- end -}}
 


### PR DESCRIPTION
Reverts alexellis/arkade#1097

`flyctl` has again reverted to old [style](https://github.com/superfly/flyctl/releases/tag/v0.2.88) of release names.