### PR TITLE
feat: add labctl to tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ kubeconfig
 mc
 /arkade-*
 /faas-cli*
+test.out

--- a/README.md
+++ b/README.md
@@ -824,8 +824,8 @@ There are 52 apps that you can install on your cluster.
 | [k3s](https://github.com/k3s-io/k3s)                                         | Lightweight Kubernetes                                                                                                                                          |
 | [k3sup](https://github.com/alexellis/k3sup)                                  | Bootstrap Kubernetes with k3s over SSH < 1 min.                                                                                                                 |
 | [k9s](https://github.com/derailed/k9s)                                       | Provides a terminal UI to interact with your Kubernetes clusters.                                                                                               |
-| [kail](https://github.com/boz/kail)                                          | Kubernetes log viewer.                                                                                                                       
-| [keploy](https://github.com/keploy/keploy)                                    | Generate tests and stubs for your application that actually work!                                                                                                                                           |
+| [kail](https://github.com/boz/kail)                                          | Kubernetes log viewer.                                                                                                                                          |
+| [keploy](https://github.com/keploy/keploy)                                   | Test generation for Developers. Generate tests and stubs for your application that actually work!                                                               |
 | [kgctl](https://github.com/squat/kilo)                                       | A CLI to manage Kilo, a multi-cloud network overlay built on WireGuard and designed for Kubernetes.                                                             |
 | [kim](https://github.com/rancher/kim)                                        | Build container images inside of Kubernetes. (Experimental)                                                                                                     |
 | [kind](https://github.com/kubernetes-sigs/kind)                              | Run local Kubernetes clusters using Docker container nodes.                                                                                                     |
@@ -853,6 +853,7 @@ There are 52 apps that you can install on your cluster.
 | [kwok](https://github.com/kubernetes-sigs/kwok)                              | KWOK stands for Kubernetes WithOut Kubelet, responsible for simulating the lifecycle of fake nodes, pods, and other Kubernetes API resources                    |
 | [kwokctl](https://github.com/kubernetes-sigs/kwok)                           | CLI tool designed to streamline the creation and management of clusters, with nodes simulated by `kwok`                                                         |
 | [kyverno](https://github.com/kyverno/kyverno)                                | CLI to apply and test Kyverno policies outside a cluster.                                                                                                       |
+| [labctl](https://github.com/iximiuz/labctl)                                  | iximiuz Labs control - start remote microVM playgrounds from the command line.                                                                                  |
 | [lazydocker](https://github.com/jesseduffield/lazydocker)                    | A simple terminal UI for both docker and docker-compose, written in Go with the gocui library.                                                                  |
 | [lazygit](https://github.com/jesseduffield/lazygit)                          | A simple terminal UI for git commands.                                                                                                                          |
 | [linkerd2](https://github.com/linkerd/linkerd2)                              | Ultralight, security-first service mesh for Kubernetes.                                                                                                         |
@@ -912,6 +913,6 @@ There are 52 apps that you can install on your cluster.
 | [waypoint](https://github.com/hashicorp/waypoint)                            | Easy application deployment for Kubernetes and Amazon ECS                                                                                                       |
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                                           |
 | [yt-dlp](https://github.com/yt-dlp/yt-dlp)                                   | Fork of youtube-dl with additional features and fixes                                                                                                           |
-There are 153 tools, use `arkade get NAME` to download one.
+There are 155 tools, use `arkade get NAME` to download one.
 
 > Note to contributors, run `go build && ./arkade get --format markdown` to generate this list

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -7778,3 +7778,41 @@ func Test_Download_k0sctl(t *testing.T) {
 		}
 	}
 }
+
+func Test_Download_labctl(t *testing.T) {
+	tools := MakeTools()
+	name := "labctl"
+	const toolVersion = "v0.1.8"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_darwin_amd64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_darwin_arm64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_linux_amd64.tar.gz",
+		},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Fatalf("\nwant: %s\ngot:  %s", tc.url, got)
+		}
+	}
+}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -4240,5 +4240,31 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 						keploy_{{$os}}_{{$arch}}.{{$ext}}
 						`,
 		})
+	tools = append(tools,
+		Tool{
+			Owner:       "iximiuz",
+			Repo:        "labctl",
+			Name:        "labctl",
+			Description: "iximiuz Labs control - start remote microVM playgrounds from the command line.",
+			BinaryTemplate: `
+							{{ $os := .OS }}
+							{{ $arch := .Arch }}
+							{{ $ext := "tar.gz" }}
+	
+							{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
+							    {{ $arch = "arm64" }}
+							{{- else if eq .Arch "x86_64" -}}
+								{{ $arch = "amd64" }}
+							{{- end -}}
+							
+							{{- if eq .OS "darwin" -}}
+								{{$os = "darwin"}}
+							{{- else if eq .OS "linux" -}}
+								{{ $os = "linux" }}
+							{{- end -}}
+	
+							labctl_{{$os}}_{{$arch}}.{{$ext}}
+							`,
+		})
 	return tools
 }


### PR DESCRIPTION
## Description

* Adds https://github.com/iximiuz/labctl to tools
* Adds tests covering the currently provided binaries:
[labctl_darwin_amd64.tar.gz](https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_darwin_amd64.tar.gz)
[labctl_darwin_arm64.tar.gz](https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_darwin_arm64.tar.gz)
[labctl_linux_amd64.tar.gz](https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_linux_amd64.tar.gz)
* Updates tools table in `readme` pushing number from 153 to 155
* adds `test.out` to `.gitignore` to aid provision of testing detail in similar PRs (`make e2e >> test.out`)

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Closes #1120 

## How Has This Been Tested?

### Functional
```
➜  arkade git:(addLabctl) ✗ ./arkade get labctl
Downloading: labctl
2024/09/29 08:09:51 Looking up version for labctl
2024/09/29 08:09:51 Found: v0.1.8
Downloading: https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_darwin_arm64.tar.gz
3.75 MiB / 3.75 MiB [------------------------------------------------------------------------] 100.00%
/var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-3122922133/labctl_darwin_arm64.tar.gz written.
2024/09/29 08:09:52 Extracted: /var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-3122922133/labctl
2024/09/29 08:09:52 Copying /var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-3122922133/labctl to /Users/rgee0/.arkade/bin/labctl

Wrote: /Users/rgee0/.arkade/bin/labctl (10.04MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/labctl

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/labctl /usr/local/bin/

👏 Say thanks for arkade and sponsor Alex via GitHub: https://github.com/sponsors/alexellis
```

### make e2e
```
➜  arkade git:(addLabctl) make e2e 
CGO_ENABLED=0 go test github.com/alexellis/arkade/pkg/get -cover --tags e2e -v
...
PASS
coverage: 61.4% of statements
ok  	github.com/alexellis/arkade/pkg/get	11.499s	coverage: 61.4% of statements

```

### test-tool

404 for arm64/linux and windows is to be expected as only three binaries are provided by the project

```
➜  arkade git:(addLabctl) ✗ ./hack/test-tool.sh labctl                  
+ ./arkade get labctl --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/labctl
/Users/rgee0/.arkade/bin/labctl: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/labctl
+ echo

+ ./arkade get labctl --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/labctl
/Users/rgee0/.arkade/bin/labctl: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/labctl
+ echo

+ ./arkade get labctl --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/labctl
/Users/rgee0/.arkade/bin/labctl: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=N-wCX2ZCOQodVI3nE40b/fGBBClGPVWk-HCFn6UjQ/ClrZeruPWUht1VtkinxR/I-KQk-e8MG2W4qu1Dnf8, stripped
+ rm /Users/rgee0/.arkade/bin/labctl
+ echo

+ ./arkade get labctl --arch aarch64 --os linux --quiet

The requested version of labctl is not available or configured in arkade for linux/aarch64

* Check if a binary is available from the project for your Operating System
* View the labctl releases page: https://github.com/iximiuz/labctl/releases
* Feel free to raise an issue at https://github.com/alexellis/arkade/issues for help

Error: server returned status: 404

+ ./arkade get labctl --arch x86_64 --os mingw --quiet

The requested version of labctl is not available or configured in arkade for mingw/x86_64

* Check if a binary is available from the project for your Operating System
* View the labctl releases page: https://github.com/iximiuz/labctl/releases
* Feel free to raise an issue at https://github.com/alexellis/arkade/issues for help

Error: server returned status: 404
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
