### PR TITLE
refactor: consolidate version finding across version strategies

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -70,6 +70,40 @@ func TestGetToolVersion(t *testing.T) {
 	}
 }
 
+func Test_FormatUrl(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		owner    string
+		repo     string
+		expected string
+	}{
+		{
+			name:     "URL with placeholders",
+			url:      "https://github.com/%s/%s",
+			owner:    "ownerName",
+			repo:     "repoName",
+			expected: "https://github.com/ownerName/repoName",
+		},
+		{
+			name:     "URL without placeholders",
+			url:      "https://github.com/example",
+			owner:    "ownerName",
+			repo:     "repoName",
+			expected: "https://github.com/example",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := formatUrl(tc.url, tc.owner, tc.repo)
+			if result != tc.expected {
+				t.Fatalf("\nwant: %s\ngot:  %s", tc.expected, result)
+			}
+		})
+	}
+}
+
 func Test_MakeSureNoDuplicates(t *testing.T) {
 	count := map[string]int{}
 	tools := MakeTools()
@@ -7804,6 +7838,56 @@ func Test_Download_labctl(t *testing.T) {
 			arch:    arch64bit,
 			version: toolVersion,
 			url:     "https://github.com/iximiuz/labctl/releases/download/v0.1.8/labctl_linux_amd64.tar.gz",
+		},
+	}
+	for _, tc := range tests {
+		got, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Fatalf("\nwant: %s\ngot:  %s", tc.url, got)
+		}
+	}
+}
+
+func Test_Download_glab(t *testing.T) {
+	tools := MakeTools()
+	name := "glab"
+	const toolVersion = "v1.48.0"
+
+	tool := getTool(name, tools)
+
+	tests := []test{
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_darwin_amd64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_darwin_arm64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_linux_amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_linux_arm64.tar.gz",
+		},
+		{
+			os:      "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_windows_amd64.zip",
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -4266,5 +4266,33 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 							labctl_{{$os}}_{{$arch}}.{{$ext}}
 							`,
 		})
+
+	tools = append(tools,
+		Tool{
+			Owner:           "gitlab-org",
+			Repo:            "cli",
+			Name:            "glab",
+			Description:     "A GitLab CLI tool bringing GitLab to your command line.",
+			VersionStrategy: GitLabVersionStrategy,
+			URLTemplate: `
+			{{ $osStr := .OS }}
+            {{ $arch := .Arch }}
+			{{ $extStr := "tar.gz" }}
+
+            {{- if eq .Arch "x86_64" -}}
+            {{$arch = "amd64"}}
+            {{- else if eq .Arch "armv6l" -}}
+            {{$arch = "armv6"}}
+            {{- else if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
+			{{$arch = "arm64"}}
+            {{- end -}}
+
+            {{- if HasPrefix .OS "ming" -}}
+            {{$osStr = "windows"}}
+			{{$extStr = "zip"}}
+            {{- end -}}
+
+            https://gitlab.com/{{.Owner}}/{{.Repo}}/-/releases/{{.Version}}/downloads/{{.Name}}_{{.VersionNumber}}_{{$osStr}}_{{$arch}}.{{$extStr}}`,
+		})
 	return tools
 }


### PR DESCRIPTION
## Description

Initially there was a single version strategy of 'github' which meant the location was standardised.  Then came k8s as a version strategy which took a different approach and so needed a different implementation.  Later came Gitlab which required another implementation.

This change consolidates the various release finding approaches into a single function, which varied based on attributes held about the release 'platform'.

As a demonstration of the benefit of the approach GitLab has been added as a release platform and the GitLab CLI which is hosted on gitlab has been added as a tool - superseding #1122

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Fixes #1119
Closes #1122

## How Has This Been Tested?

### Functional
* GitLab as a target:
```
➜  arkade git:(refactorVersionStrategy) ✗ ./arkade get glab           
Downloading: glab
2024/10/24 08:57:38 Looking up version for glab
2024/10/24 08:57:38 Found: v1.48.0
Downloading: https://gitlab.com/gitlab-org/cli/-/releases/v1.48.0/downloads/glab_1.48.0_darwin_arm64.tar.gz
8.58 MiB / 8.58 MiB [------------------------------------------------------------------------] 100.00%
/var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-2393411434/glab_1.48.0_darwin_arm64.tar.gz written.
2024/10/24 08:57:45 Extracted: /var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-2393411434/glab
2024/10/24 08:57:45 Copying /var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-2393411434/glab to /Users/rgee0/.arkade/bin/glab

Wrote: /Users/rgee0/.arkade/bin/glab (26.39MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/glab

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/glab /usr/local/bin/

👏 Say thanks for arkade and sponsor Alex via GitHub: https://github.com/sponsors/alexellis
```

* k8s as a target:
```
➜  arkade git:(refactorVersionStrategy) ✗ ./arkade get kubectl
Downloading: kubectl
2024/10/24 08:59:08 Looking up version for kubectl
2024/10/24 08:59:08 Found: v1.31.2
Downloading: https://dl.k8s.io/release/v1.31.2/bin/darwin/arm64/kubectl
53.94 MiB / 53.94 MiB [----------------------------------------------------------------------] 100.00%
/var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-3928752036/kubectl written.
2024/10/24 08:59:43 Copying /var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-3928752036/kubectl to /Users/rgee0/.arkade/bin/kubectl

Wrote: /Users/rgee0/.arkade/bin/kubectl (56.56MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/kubectl

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/kubectl /usr/local/bin/

👏 Say thanks for arkade and sponsor Alex via GitHub: https://github.com/sponsors/alexellis
```
* GitHub as a target:
```
➜  arkade git:(refactorVersionStrategy) ✗ ./arkade get doctl  
Downloading: doctl
2024/10/24 09:00:32 Looking up version for doctl
2024/10/24 09:00:32 Found: v1.116.0
Downloading: https://github.com/digitalocean/doctl/releases/download/v1.116.0/doctl-1.116.0-darwin-arm64.tar.gz
14.93 MiB / 14.93 MiB [-----------------------------------------------------------------------------------] 100.00%
/var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-1576317659/doctl-1.116.0-darwin-arm64.tar.gz written.
2024/10/24 09:00:46 Extracted: /var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-1576317659/doctl
2024/10/24 09:00:46 Copying /var/folders/22/3b_f27kj3s37lbfqz_fq44jw0000gp/T/arkade-1576317659/doctl to /Users/rgee0/.arkade/bin/doctl

Wrote: /Users/rgee0/.arkade/bin/doctl (33.42MB)

# Add arkade binary directory to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/Users/rgee0/.arkade/bin/doctl

# Or install with:
sudo mv /Users/rgee0/.arkade/bin/doctl /usr/local/bin/

👏 Say thanks for arkade and sponsor Alex via GitHub: https://github.com/sponsors/alexellis
```

### make e2e
```
➜  arkade git:(refactorVersionStrategy) ✗ make e2e > test.out 
CGO_ENABLED=0 go test github.com/alexellis/arkade/pkg/get -cover --tags e2e -v
PASS
coverage: 61.3% of statements
ok  	github.com/alexellis/arkade/pkg/get	13.181s	coverage: 61.3% of statements
```

### test-tool.sh glab
```
➜  arkade git:(refactorVersionStrategy) ✗ ./hack/test-tool.sh glab                 
+ ./arkade get glab --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/glab
/Users/rgee0/.arkade/bin/glab: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/glab
+ echo

+ ./arkade get glab --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/glab
/Users/rgee0/.arkade/bin/glab: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/glab
+ echo

+ ./arkade get glab --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/glab
/Users/rgee0/.arkade/bin/glab: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=uwazKG5VKE5W00rj_npV/E3YCRTLkOyj3bmbkrZHQ/eURhXbgLky2O-dymcnU2/14vR3vV6H0_SA-aqAi-k, stripped
+ rm /Users/rgee0/.arkade/bin/glab
+ echo

+ ./arkade get glab --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/glab
/Users/rgee0/.arkade/bin/glab: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=jut912ugLxi2Z0cNNilS/pI1RtLJ83L-JAHOcV40R/cee75MwDUCQV-XKSg262/p6i-81wBESyx43yfh_p5, stripped
+ rm /Users/rgee0/.arkade/bin/glab
+ echo

+ ./arkade get glab --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/glab.exe
/Users/rgee0/.arkade/bin/glab.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/glab.exe
+ echo
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

- [ ] I have tested this on arm, or have added code to prevent deployment
