### PR TITLE
fix: mitigate effect on tags of semVer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ mc
 /arkade-*
 /faas-cli*
 test.out
+docker-compose.yaml

--- a/cmd/chart/upgrade.go
+++ b/cmd/chart/upgrade.go
@@ -176,11 +176,7 @@ func updateImages(iName string, v bool) (bool, string, error) {
 
 	sort.Sort(sort.Reverse(semver.Collection(vs)))
 
-	latestTag := vs[0].String()
-	// Semver is "eating" the "v" prefix, so we need to add it back, if it was there in first place
-	if strings.HasPrefix(tag, "v") {
-		latestTag = "v" + latestTag
-	}
+	latestTag := vs[0].Original()
 
 	laterVersionB := false
 

--- a/cmd/chart/upgrade_test.go
+++ b/cmd/chart/upgrade_test.go
@@ -103,3 +103,58 @@ func Test_tagIsUpgradable(t *testing.T) {
 		})
 	}
 }
+
+func TestGetLatestTag(t *testing.T) {
+	tests := []struct {
+		name             string
+		discoveredTags   []string
+		expectedTagVal   string
+		expectedIsSemVer bool
+	}{
+		{
+			name:             "Valid semantic tags",
+			discoveredTags:   []string{"v1.0.0", "v2.1.0", "v2.3.4", "v2.3.3"},
+			expectedTagVal:   "v2.3.4",
+			expectedIsSemVer: true,
+		},
+		{
+			name:             "No valid semantic tags",
+			discoveredTags:   []string{"invalid", "v.a.b", "xyz"},
+			expectedTagVal:   "",
+			expectedIsSemVer: false,
+		},
+		{
+			name:             "Empty list",
+			discoveredTags:   []string{},
+			expectedTagVal:   "",
+			expectedIsSemVer: false,
+		},
+		{
+			name:             "Mixed valid and invalid tags",
+			discoveredTags:   []string{"v1.0.0", "invalid", "v2.1.0-beta", "v1.2.3"},
+			expectedTagVal:   "v2.1.0-beta",
+			expectedIsSemVer: true,
+		},
+		{
+			name:             "similar tag values",
+			discoveredTags:   []string{"17", "17.0", "17.0.0"},
+			expectedTagVal:   "17",
+			expectedIsSemVer: true,
+		},
+		{
+			name:             "similar tag values different arrival order",
+			discoveredTags:   []string{"17.0", "17", "17.0.0"},
+			expectedTagVal:   "17.0",
+			expectedIsSemVer: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tagVal, isSemVer := getLatestTag(tc.discoveredTags)
+			if tagVal != tc.expectedTagVal || isSemVer != tc.expectedIsSemVer {
+				t.Fatalf("\nwant: (%s, %v) \n got: (%s, %v)\n", tc.expectedTagVal, tc.expectedIsSemVer, tagVal, isSemVer)
+			}
+		})
+	}
+}

--- a/cmd/chart/upgrade_test.go
+++ b/cmd/chart/upgrade_test.go
@@ -104,46 +104,67 @@ func Test_tagIsUpgradable(t *testing.T) {
 	}
 }
 
-func TestGetLatestTag(t *testing.T) {
+func TestGetCandidateTag(t *testing.T) {
 	tests := []struct {
 		name             string
 		discoveredTags   []string
+		currentTag       string
 		expectedTagVal   string
 		expectedIsSemVer bool
 	}{
 		{
 			name:             "Valid semantic tags",
 			discoveredTags:   []string{"v1.0.0", "v2.1.0", "v2.3.4", "v2.3.3"},
+			currentTag:       "v2.3.3",
 			expectedTagVal:   "v2.3.4",
 			expectedIsSemVer: true,
 		},
 		{
 			name:             "No valid semantic tags",
 			discoveredTags:   []string{"invalid", "v.a.b", "xyz"},
+			currentTag:       "v2.3.3",
 			expectedTagVal:   "",
 			expectedIsSemVer: false,
 		},
 		{
 			name:             "Empty list",
 			discoveredTags:   []string{},
+			currentTag:       "v2.3.3",
 			expectedTagVal:   "",
 			expectedIsSemVer: false,
 		},
 		{
 			name:             "Mixed valid and invalid tags",
-			discoveredTags:   []string{"v1.0.0", "invalid", "v2.1.0-beta", "v1.2.3"},
-			expectedTagVal:   "v2.1.0-beta",
+			discoveredTags:   []string{"v1.2", "v1.0.0", "invalid", "v2.1.0-beta", "v1.2.4"},
+			currentTag:       "v1.2.3",
+			expectedTagVal:   "v1.2.4",
+			expectedIsSemVer: true,
+		},
+		{
+			name:             "Mixed valid and invalid tags",
+			discoveredTags:   []string{"v1.2", "v1.0.0", "invalid", "v2.1.0-beta", "v1.3.3"},
+			currentTag:       "v1.2.3",
+			expectedTagVal:   "v1.3.3",
 			expectedIsSemVer: true,
 		},
 		{
 			name:             "similar tag values",
 			discoveredTags:   []string{"17", "17.0", "17.0.0"},
+			currentTag:       "16",
 			expectedTagVal:   "17",
 			expectedIsSemVer: true,
 		},
 		{
 			name:             "similar tag values different arrival order",
 			discoveredTags:   []string{"17.0", "17", "17.0.0"},
+			currentTag:       "16",
+			expectedTagVal:   "17",
+			expectedIsSemVer: true,
+		},
+		{
+			name:             "similar tag values different current format",
+			discoveredTags:   []string{"17.0", "17", "17.0.0"},
+			currentTag:       "16.0",
 			expectedTagVal:   "17.0",
 			expectedIsSemVer: true,
 		},
@@ -151,9 +172,202 @@ func TestGetLatestTag(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tagVal, isSemVer := getLatestTag(tc.discoveredTags)
+			tagVal, isSemVer := getCandidateTag(tc.discoveredTags, tc.currentTag)
 			if tagVal != tc.expectedTagVal || isSemVer != tc.expectedIsSemVer {
 				t.Fatalf("\nwant: (%s, %v) \n got: (%s, %v)\n", tc.expectedTagVal, tc.expectedIsSemVer, tagVal, isSemVer)
+			}
+		})
+	}
+}
+
+func TestAttributesMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		c        tagAttributes
+		n        tagAttributes
+		expected bool
+	}{
+		{
+			name: "All matching attributes",
+			c: tagAttributes{
+				hasSuffix: true,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v1.2.3-beta",
+			},
+			n: tagAttributes{
+				hasSuffix: true,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v1.2.3-beta",
+			},
+			expected: true,
+		},
+		{
+			name: "Different hasSuffix",
+			c: tagAttributes{
+				hasSuffix: true,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v1.2.3-beta",
+			},
+			n: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v1.2.3",
+			},
+			expected: false,
+		},
+		{
+			name: "Different hasMajor",
+			c: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v1.2.3",
+			},
+			n: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  false,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v0.2.3",
+			},
+			expected: false,
+		},
+		{
+			name: "All attributes false",
+			c: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  false,
+				hasMinor:  false,
+				hasPatch:  false,
+				original:  "",
+			},
+			n: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  false,
+				hasMinor:  false,
+				hasPatch:  false,
+				original:  "any",
+			},
+			expected: true,
+		},
+		{
+			name: "Different hasMinor and hasPatch",
+			c: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  false,
+				original:  "v1.2",
+			},
+			n: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  true,
+				hasMinor:  false,
+				hasPatch:  true,
+				original:  "v1.0.1",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.c.attributesMatch(tc.n)
+			if result != tc.expected {
+				t.Fatalf("\nwant: %t \n got: %t\n", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestGetTagAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		tag      string
+		expected tagAttributes
+	}{
+		{
+			name: "Full semantic version with suffix",
+			tag:  "v1.2.3-beta",
+			expected: tagAttributes{
+				hasSuffix: true,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v1.2.3-beta",
+			},
+		},
+		{
+			name: "Full semantic version without suffix",
+			tag:  "v1.2.3",
+			expected: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  true,
+				original:  "v1.2.3",
+			},
+		},
+		{
+			name: "Major and minor version without suffix",
+			tag:  "v1.2",
+			expected: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  true,
+				hasMinor:  true,
+				hasPatch:  false,
+				original:  "v1.2",
+			},
+		},
+		{
+			name: "Only major version without suffix",
+			tag:  "v1",
+			expected: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  true,
+				hasMinor:  false,
+				hasPatch:  false,
+				original:  "v1",
+			},
+		},
+		{
+			name: "Empty string",
+			tag:  "",
+			expected: tagAttributes{
+				hasSuffix: false,
+				hasMajor:  false,
+				hasMinor:  false,
+				hasPatch:  false,
+				original:  "",
+			},
+		},
+		{
+			name: "Version with suffix only",
+			tag:  "v1-beta",
+			expected: tagAttributes{
+				hasSuffix: true,
+				hasMajor:  true,
+				hasMinor:  false,
+				hasPatch:  false,
+				original:  "v1-beta",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getTagAttributes(tc.tag)
+			if result != tc.expected {
+				t.Fatalf("\nwant: %v \n got: %v\n", tc.expected, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

A chart upgrade which contained postgres:16 highlighted that the current approach to parsing tags meant that 16 moved to 17.0.0 which doesnt exist. We can alleviate this by using .Original() from semVer once the most recent tag has been found.  Using this also removes the need to manipulate the resulting string in the event of the image using a leading V

## Motivation and Context
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

### Pre:

```sh
➜  arkade git:(master) ✗ make build
go build
➜  arkade git:(master) ✗ ./arkade chart upgrade -f ./docker-compose.yaml  -w -v
2024/10/30 17:39:16 Verifying images in: ./docker-compose.yaml
2024/10/30 17:39:16 Found 4 images
2024/10/30 17:39:16 [ghcr.io/openfaas/gateway] 0.27.8 => 0.27.9
2024/10/30 17:39:17 [docker.io/postgres] 16 => 17.0.0
2024/10/30 17:39:17 Wrote 2 updates to: ./docker-compose.yaml
```

### Post

```sh
➜  arkade git:(pgVersions2) make build
go build
➜  arkade git:(pgVersions2) ./arkade chart upgrade -f ./docker-compose.yaml  -w -v
2024/10/30 17:40:40 Verifying images in: ./docker-compose.yaml
2024/10/30 17:40:40 Found 4 images
2024/10/30 17:40:41 [ghcr.io/openfaas/gateway] 0.27.8 => 0.27.9
2024/10/30 17:40:41 [docker.io/postgres] 16 => 17.0
2024/10/30 17:40:41 Wrote 2 updates to: ./docker-compose.yaml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
