### PR TITLE
feat: add hold file for `chart upgrade`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ mc
 /arkade-*
 /faas-cli*
 test.out
-docker-compose.yaml
+docker-compose.yaml*

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ db:
 Associated hold file:
 
 ```
-postgres:16
+db.image
 ```
 
 ```bash
@@ -413,7 +413,7 @@ arkade chart upgrade -f \
 2023/01/03 10:12:54 [nats] 2.9.2 => 2.9.10
 ```
 
-Within the uprgade activity `postgres:16` is no longer included.
+Within the upgrade activity `postgres:16` is no longer included.
 
 Supported:
 

--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ The directory that contains the Helm chart should be a Git repository. If the fl
 
 There are two commands built into arkade designed for software vendors and open source maintainers.
 
-* `arkade helm chart upgrade` - run this command to scan for container images and update them automatically by querying a remote registry. 
-* `arkade helm chart verify` - after changing the contents of a values.yaml or docker-compose.yaml file, this command will check each image exists on a remote registry
+* `arkade chart upgrade` - run this command to scan for container images and update them automatically by querying a remote registry. 
+* `arkade chart verify` - after changing the contents of a values.yaml or docker-compose.yaml file, this command will check each image exists on a remote registry
 
 Whilst end-users may use a GitOps-style tool to deploy charts and update their versions, maintainers need to make conscious decisions about when and which images to change within a Helm chart or compose file.
 
@@ -375,6 +375,45 @@ arkade chart upgrade -f \
   ~/go/src/github.com/openfaas/faasd/docker-compose.yaml \
   --write
 ```
+
+### Holding image versions within a Helm chart
+
+With the command `arkade chart upgrade` you can add a `.hold` associated with a `values.yaml` file, e.g. `values.yaml.hold` to exclude the specified images from the version update.
+
+Original YAML file:
+
+```yaml
+stan:
+  # Image used for nats deployment when using async with NATS-Streaming.
+  image: nats-streaming:0.24.6
+
+db:
+  image: postgres:16
+```
+
+Associated hold file:
+
+```
+postgres:16
+```
+
+```bash
+arkade chart upgrade -f \
+  ~/go/src/github.com/openfaas/faas-netes/chart/openfaas/values.yaml \
+  --verbose
+
+2023/01/03 10:12:47 Verifying images in: /home/alex/go/src/github.com/openfaas/faas-netes/chart/openfaas/values.yaml
+2023/01/03 10:12:47 Found 18 images
+2023/01/03 10:12:47 Found 1 image to hold/ignore in values.yaml.hold
+2023/01/03 10:12:47 Processing 17 images
+2023/01/03 10:12:48 [natsio/prometheus-nats-exporter] 0.8.0 => 0.10.1
+2023/01/03 10:12:50 [nats-streaming] 0.24.6 => 0.25.2
+2023/01/03 10:12:52 [prom/prometheus] v2.38.0 => 2.41.0
+2023/01/03 10:12:54 [prom/alertmanager] v0.24.0 => 0.25.0
+2023/01/03 10:12:54 [nats] 2.9.2 => 2.9.10
+```
+
+Within the uprgade activity `postgres:16` is no longer included.
 
 Supported:
 

--- a/cmd/chart/upgrade.go
+++ b/cmd/chart/upgrade.go
@@ -93,7 +93,7 @@ Otherwise, it returns a non-zero exit code and the updated values.yaml file.`,
 			return err
 		}
 
-		filtered := helm.FilterImagesUptoDepth(values, depth)
+		filtered := helm.FilterImagesUptoDepth(values, depth, 0, "")
 		if len(filtered) == 0 {
 			return fmt.Errorf("no images found in %s", file)
 		}
@@ -144,8 +144,8 @@ Otherwise, it returns a non-zero exit code and the updated values.yaml file.`,
 			}()
 		}
 
-		for k := range filtered {
-			workChan <- k
+		for _, v := range filtered {
+			workChan <- v
 		}
 
 		close(workChan)
@@ -297,8 +297,9 @@ func readFileLines(filename string) ([]string, error) {
 func removeHoldImages(fullset map[string]string, held []string) map[string]string {
 
 	for _, h := range held {
+		serviceName := strings.TrimSuffix(h, ".image")
 		for k := range fullset {
-			if strings.EqualFold(h, k[len(k)-len(h):]) {
+			if strings.EqualFold(serviceName, k) {
 				delete(fullset, k)
 			}
 		}

--- a/cmd/chart/upgrade_test.go
+++ b/cmd/chart/upgrade_test.go
@@ -384,91 +384,47 @@ func TestRemoveHoldImages(t *testing.T) {
 		{
 			name: "Basic exclusion",
 			fullset: map[string]string{
-				"registry/img1:16": "going",
-				"registry/img1:17": "staying",
-				"registry/img1:18": "staying",
+				"going":    "registry/img1:16",
+				"staying1": "registry/img1:17",
+				"staying2": "registry/img1:18",
 			},
 			held: []string{
-				"img1:16",
+				"going.image",
 			},
 			expected: map[string]string{
-				"registry/img1:17": "staying",
-				"registry/img1:18": "staying",
+				"staying1": "registry/img1:17",
+				"staying2": "registry/img1:18",
 			},
 		},
 		{
 			name: "Basic exclusion / muli-match",
 			fullset: map[string]string{
-				"registry/img1:16": "going",
-				"registry/img1:17": "going",
-				"registry/img1:18": "staying",
+				"going1":  "registry/img1:16",
+				"going2":  "registry/img1:17",
+				"staying": "registry/img1:18",
 			},
 			held: []string{
-				"img1:16",
-				"img1:17",
+				"going1.image",
+				"going2.image",
 			},
 			expected: map[string]string{
-				"registry/img1:18": "staying",
+				"staying": "registry/img1:18",
 			},
 		},
 		{
 			name: "No match",
 			fullset: map[string]string{
-				"registry/img1:17": "staying",
-				"registry/img1:18": "staying",
-				"registry/img1:19": "staying",
+				"staying1": "registry/img1:17",
+				"staying2": "registry/img1:18",
+				"staying3": "registry/img1:19",
 			},
 			held: []string{
-				"img1:16",
+				"going.image",
 			},
 			expected: map[string]string{
-				"registry/img1:17": "staying",
-				"registry/img1:18": "staying",
-				"registry/img1:19": "staying",
-			},
-		},
-		{
-			name: "Different Repos images match",
-			fullset: map[string]string{
-				"registry/repo/img1:16":  "going",
-				"registry/repo2/img1:16": "going",
-				"registry/repo3/img1:18": "staying",
-			},
-			held: []string{
-				"img1:16",
-			},
-			expected: map[string]string{
-				"registry/repo3/img1:18": "staying",
-			},
-		},
-		{
-			name: "Different Repos images match / full path exclude",
-			fullset: map[string]string{
-				"registry/repo/img1:16":  "going",
-				"registry/repo2/img1:16": "staying",
-				"registry/repo3/img1:18": "staying",
-			},
-			held: []string{
-				"registry/repo/img1:16",
-			},
-			expected: map[string]string{
-				"registry/repo2/img1:16": "staying",
-				"registry/repo3/img1:18": "staying",
-			},
-		},
-		{
-			name: "Different Repos images match / two exclude",
-			fullset: map[string]string{
-				"registry/repo/img1:16":  "going",
-				"registry/repo2/img1:16": "going",
-				"registry/repo3/img1:18": "staying",
-			},
-			held: []string{
-				"registry/repo/img1:16",
-				"img1:16",
-			},
-			expected: map[string]string{
-				"registry/repo3/img1:18": "staying",
+				"staying1": "registry/img1:17",
+				"staying2": "registry/img1:18",
+				"staying3": "registry/img1:19",
 			},
 		},
 		{

--- a/cmd/chart/verify.go
+++ b/cmd/chart/verify.go
@@ -72,7 +72,7 @@ autoscaler          ghcr.io/openfaasltd/autoscaler:0.2.5
 			return err
 		}
 
-		filtered := helm.FilterImagesUptoDepth(values, depth)
+		filtered := helm.FilterImagesUptoDepth(values, depth, 0, "")
 		if len(filtered) == 0 {
 			return fmt.Errorf("no images found in %s", file)
 		}

--- a/pkg/helm/io.go
+++ b/pkg/helm/io.go
@@ -59,18 +59,22 @@ func ReplaceValuesInHelmValuesFile(values map[string]string, yamlPath string) (s
 
 // FilterImagesUptoDepth takes a ValuesMap and returns a map of images that
 // were found upto max level
-func FilterImagesUptoDepth(values ValuesMap, depth int) map[string]string {
+func FilterImagesUptoDepth(values ValuesMap, depth int, level int, component string) map[string]string {
 	images := map[string]string{}
 
 	for k, v := range values {
 
+		if level == 1 {
+			component = k
+		}
+
 		if k == "image" && reflect.TypeOf(v).Kind() == reflect.String {
 			imageUrl := v.(string)
-			images[imageUrl] = imageUrl
+			images[component] = imageUrl
 		}
 
 		if c, ok := v.(ValuesMap); ok && depth > 0 {
-			images = mergeMaps(images, FilterImagesUptoDepth(c, depth-1))
+			images = mergeMaps(images, FilterImagesUptoDepth(c, depth-1, level+1, component))
 		}
 	}
 	return images


### PR DESCRIPTION
## Description
Adds a feature to the `chart upgrade` command such that images within the target file can be ignored during the upgrade if they are detailed in a hold file.  To be considered the file should follow the name of the yaml file passed by `-f` suffixed with `.hold`, e.g. upgrading `docker-compose.yaml` would look for a `docker-compose.yaml.hold`.

The hold file format is:

```
component1.image
db.image
...
nats.image
```

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Closes #1132


## How Has This Been Tested?
TBC



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
