### PR TITLE
feat: add `ark update readme` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,24 +239,27 @@ arkade system install containerd \
   --systemd
 ```
 
-Run the following to see what's available `arkade system install`:
+### Catalog of System Installs:
+<!-- start system content -->
+| SYSTEM INSTALL  |          DESCRIPTION          |
+|-----------------|-------------------------------|
+| actions-runner  | Install GitHub Actions Runner |
+| buildkitd       | Install Buildkitd             |
+| caddy           | Install Caddy Server          |
+| cni             | Install CNI plugins           |
+| containerd      | Install containerd            |
+| firecracker     | Install Firecracker           |
+| gitlab-runner   | Install GitLab Runner         |
+| go              | Install Go                    |
+| node            | Install Node.js               |
+| node_exporter   | Install Node Exporter         |
+| prometheus      | Install Prometheus            |
+| pwsh            | Install Powershell            |
+| registry        | Install registry              |
+| tc-redirect-tap | Install tc-redirect-tap       |
+ There are 14 system installations available. 
 
-```
-  actions-runner  Install GitHub Actions Runner
-  buildkitd       Install Buildkitd
-  caddy           Install Caddy Server
-  cni             Install CNI plugins
-  containerd      Install containerd
-  firecracker     Install Firecracker
-  gitlab-runner   Install GitLab Runner
-  go              Install Go
-  node            Install Node.js
-  node_exporter   Install Node Exporter
-  prometheus      Install Prometheus
-  pwsh            Install Powershell
-  registry        Install registry
-  tc-redirect-tap Install tc-redirect-tap
-```
+<!-- end system content -->
 
 The initial set of system apps is now complete, learn more in the original proposal: [Feature: system packages for Linux servers, CI and workstations #654](https://github.com/alexellis/arkade/issues/654)
 
@@ -695,8 +698,8 @@ An app is software or an add-on for your Kubernetes cluster.
 A CLI or "tool" is a command line tool that you run directly on your own workstation or a CI runner.
 
 ### Catalog of Apps
-
-|          TOOL           |                             DESCRIPTION                             |
+<!-- start apps content -->
+|           APP           |                             DESCRIPTION                             |
 |-------------------------|---------------------------------------------------------------------|
 | argocd                  | Install argocd                                                      |
 | cassandra               | Install cassandra                                                   |
@@ -750,13 +753,13 @@ A CLI or "tool" is a command line tool that you run directly on your own worksta
 | traefik2                | Install traefik2                                                    |
 | vault                   | Install vault                                                       |
 | waypoint                | Install Waypoint                                                    |
+ There are 52 apps that you can install on your cluster. 
 
-There are 52 apps that you can install on your cluster.
-
+<!-- end apps content -->
 > Note to contributors, run `go build && ./arkade install --print-table` to generate this list
 
 ### Catalog of CLIs
-
+<!-- start tools content -->
 |                                     TOOL                                     |                                                                            DESCRIPTION                                                                            |
 |------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [actions-usage](https://github.com/self-actuated/actions-usage)              | Get usage insights from GitHub Actions.                                                                                                                           |
@@ -926,4 +929,6 @@ There are 52 apps that you can install on your cluster.
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                                             |
 | [yt-dlp](https://github.com/yt-dlp/yt-dlp)                                   | Fork of youtube-dl with additional features and fixes                                                                                                             |
 There are 166 tools, use `arkade get NAME` to download one.
-> Note to contributors, run `go build && ./arkade get --format markdown` to generate this list
+
+<!-- end tools content -->
+> Note to contributors, run `go build && ./arkade update readme` to update this list

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -74,17 +74,17 @@ and provides a fast and easy alternative to a package manager.`,
 
 			if len(format) > 0 {
 				if get.TableFormat(format) == get.MarkdownStyle {
-					get.CreateToolsTable(tools, get.MarkdownStyle)
+					fmt.Print(get.CreateToolsTable(tools, get.MarkdownStyle))
 				} else if get.TableFormat(format) == get.ListStyle {
 					for _, r := range tools {
 						fmt.Printf("%s\n", r.Name)
 					}
 
 				} else {
-					get.CreateToolsTable(tools, get.TableStyle)
+					fmt.Print(get.CreateToolsTable(tools, get.TableStyle))
 				}
 			} else {
-				get.CreateToolsTable(tools, get.TableStyle)
+				fmt.Print(get.CreateToolsTable(tools, get.TableStyle))
 			}
 			return nil
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,8 +5,8 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"sort"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -46,27 +46,7 @@ command.`,
 		printTable, _ := command.Flags().GetBool("print-table")
 
 		if printTable {
-			table := tablewriter.NewWriter(os.Stdout)
-			table.SetHeader([]string{"Tool", "Description"})
-
-			table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
-			table.SetCenterSeparator("|")
-			table.SetAutoWrapText(false)
-
-			appSortedList := make([]string, 0, len(appList))
-
-			for a := range appList {
-				appSortedList = append(appSortedList, a)
-			}
-			sort.Strings(appSortedList)
-
-			for _, k := range appSortedList {
-				table.Append([]string{k, appList[k].Installer().Short})
-			}
-
-			table.Render()
-
-			fmt.Printf("\nThere are %d apps that you can install on your cluster.\n", len(appList))
+			fmt.Print(CreateAppsTable(appList))
 			return nil
 		}
 
@@ -180,4 +160,32 @@ func NewArkadeApp(cmd func() *cobra.Command, msg string) ArkadeApp {
 		Installer:   cmd,
 		InfoMessage: msg,
 	}
+}
+
+func CreateAppsTable(apps map[string]ArkadeApp) string {
+
+	tableString := &strings.Builder{}
+	table := tablewriter.NewWriter(tableString)
+	table.SetHeader([]string{"App", "Description"})
+	table.SetCaption(true,
+		fmt.Sprintf("\nThere are %d apps that you can install on your cluster.\n", len(apps)))
+
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetCenterSeparator("|")
+	table.SetAutoWrapText(false)
+
+	appSortedList := make([]string, 0, len(apps))
+
+	for a := range apps {
+		appSortedList = append(appSortedList, a)
+	}
+	sort.Strings(appSortedList)
+
+	for _, k := range appSortedList {
+		table.Append([]string{k, apps[k].Installer().Short})
+	}
+
+	table.Render()
+
+	return tableString.String()
 }

--- a/cmd/system/install.go
+++ b/cmd/system/install.go
@@ -4,6 +4,11 @@
 package system
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -40,4 +45,34 @@ func MakeInstall() *cobra.Command {
 	command.AddCommand(MakeInstallNodeExporter())
 
 	return command
+}
+
+func CreateSystemTable(sys []*cobra.Command) string {
+
+	tableString := &strings.Builder{}
+	table := tablewriter.NewWriter(tableString)
+	table.SetHeader([]string{"System Install", "Description"})
+	table.SetCaption(true,
+		fmt.Sprintf("\nThere are %d system installations available.\n", len(sys)))
+
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetCenterSeparator("|")
+	table.SetAutoWrapText(false)
+
+	var sysMap = make(map[string]string, len(sys))
+	sortedList := make([]string, 0, len(sys))
+
+	for _, s := range sys {
+		sysMap[s.Use] = s.Short
+		sortedList = append(sortedList, s.Use)
+	}
+	sort.Strings(sortedList)
+
+	for _, sysInst := range sortedList {
+		table.Append([]string{sysInst, sysMap[sysInst]})
+	}
+
+	table.Render()
+
+	return tableString.String()
 }

--- a/cmd/update/readme.go
+++ b/cmd/update/readme.go
@@ -1,0 +1,86 @@
+// Copyright (c) arkade author(s) 2022. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package update
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	install "github.com/alexellis/arkade/cmd"
+	system "github.com/alexellis/arkade/cmd/system"
+	"github.com/alexellis/arkade/pkg/get"
+	"github.com/spf13/cobra"
+)
+
+func MakeReadme() *cobra.Command {
+	var command = &cobra.Command{
+		Use:   "readme",
+		Short: "Update the system / tools / apps tables in the readme",
+		Long: `
+A command for contributors to use when adding or updating any of the developer tools
+to quickly perform an in-place update of the various tables within the readme .`,
+		Example:       `  arkade update readme`,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+	}
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+
+		var readmeTables = make(map[string]string)
+
+		//update system installs <!-- start system content -->
+		systemList := system.MakeInstall().Commands()
+		readmeTables["system"] = system.CreateSystemTable(systemList)
+
+		//update apps  <!-- start apps content -->
+		appList := install.GetApps()
+		readmeTables["apps"] = install.CreateAppsTable(appList)
+
+		//update tools  <!-- start tools content -->
+		tools := get.MakeTools()
+		sort.Sort(tools)
+		readmeTables["tools"] = get.CreateToolsTable(tools, get.MarkdownStyle)
+
+		return writeTableToReadme(readmeTables)
+
+	}
+	return command
+}
+
+func writeTableToReadme(tables map[string]string) error {
+
+	filePath := "README.md"
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		panic(fmt.Errorf("failed to read file: %w", err))
+	}
+	content := string(fileContent)
+
+	for k, v := range tables {
+
+		startMarker := fmt.Sprintf("<!-- start %s content -->", k)
+		endMarker := fmt.Sprintf("<!-- end %s content -->", k)
+
+		startIdx := strings.Index(content, startMarker)
+		endIdx := strings.Index(content, endMarker)
+		if startIdx == -1 || endIdx == -1 || startIdx > endIdx {
+			return fmt.Errorf("%s readme markers not found or are in incorrect order", k)
+		}
+
+		content = content[:startIdx+len(startMarker)] + "\n" +
+			v + "\n" +
+			content[endIdx:]
+
+		fmt.Printf("Updated %s table.\n", k)
+	}
+
+	err = os.WriteFile(filePath, []byte(content), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write to file: %w", err)
+	}
+
+	fmt.Println("README tables updated successfully")
+	return nil
+}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,7 +1,7 @@
 // Copyright (c) arkade author(s) 2022. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-package cmd
+package update
 
 import (
 	"fmt"
@@ -62,7 +62,10 @@ version twice.`,
 		fmt.Println("\n", aec.Bold.Apply(pkg.SupportMessageShort))
 
 		return nil
+
 	}
+
+	command.AddCommand(MakeReadme())
 	return command
 }
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alexellis/arkade/cmd/chart"
 	"github.com/alexellis/arkade/cmd/oci"
 	"github.com/alexellis/arkade/cmd/system"
+	"github.com/alexellis/arkade/cmd/update"
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +28,7 @@ func main() {
 	rootCmd.AddCommand(cmd.MakeInstall())
 	rootCmd.AddCommand(cmd.MakeVersion())
 	rootCmd.AddCommand(cmd.MakeInfo())
-	rootCmd.AddCommand(cmd.MakeUpdate())
+	rootCmd.AddCommand(update.MakeUpdate())
 	rootCmd.AddCommand(cmd.MakeGet())
 	rootCmd.AddCommand(cmd.MakeUninstall())
 	rootCmd.AddCommand(cmd.MakeShellCompletion())

--- a/pkg/get/table.go
+++ b/pkg/get/table.go
@@ -2,7 +2,7 @@ package get
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 )
@@ -16,8 +16,10 @@ const (
 )
 
 // CreateToolTable creates table to show the avaiable CLI tools
-func CreateToolsTable(tools Tools, format TableFormat) {
-	table := tablewriter.NewWriter(os.Stdout)
+func CreateToolsTable(tools Tools, format TableFormat) string {
+
+	tableString := &strings.Builder{}
+	table := tablewriter.NewWriter(tableString)
 
 	table.SetCaption(true,
 		fmt.Sprintf("There are %d tools, use `arkade get NAME` to download one.", len(tools)))
@@ -50,4 +52,5 @@ func CreateToolsTable(tools Tools, format TableFormat) {
 	}
 
 	table.Render()
+	return tableString.String()
 }


### PR DESCRIPTION
## Description

Adds a subcommand to update that will update the README tables in situ. This will be useful to contributors who are adding system installs / apps / tools as it will remove the need for the existing manual mechanism to update the appropriate tables in the readme.  Running `arkade update readme` will update each of the three tables in the readme, ready to be committed with their change.


## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Discussed on the community call

## How Has This Been Tested?

### Functional
```
➜  arkade git:(updateReadmeTables) ✗ ./arkade update readme
Updated system table.
Updated apps table.
Updated tools table.
README tables updated successfully
```
README shows new format as per commit included in this change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [x ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
