### PR TITLE
feat: improve `install` error when app doesnt exist

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,14 +4,17 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
 	"github.com/alexellis/arkade/cmd/apps"
+	"github.com/alexellis/arkade/pkg/get"
 )
 
 type ArkadeApp struct {
@@ -100,7 +103,7 @@ To request a new app, raise a GitHub issue at:
 			}
 		}
 		if app == nil {
-			return fmt.Errorf("no such app: %s, run \"arkade install --help\" for a list of apps", name)
+			return errors.New(checkForTool(name, get.MakeTools()))
 		}
 
 		return nil
@@ -180,4 +183,14 @@ func NewArkadeApp(cmd func() *cobra.Command, msg string) ArkadeApp {
 		Installer:   cmd,
 		InfoMessage: msg,
 	}
+}
+
+func checkForTool(appName string, tools []get.Tool) string {
+
+	for _, tool := range tools {
+		if strings.EqualFold(tool.Name, appName) {
+			return fmt.Sprintf("no such app. %s is available as a tool, run \"arkade get %s\" to get it", appName, appName)
+		}
+	}
+	return fmt.Sprintf("no such app: %s, run \"arkade install --help\" for a list of apps", appName)
 }

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) arkade author(s) 2022. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/alexellis/arkade/pkg/get"
+)
+
+type Tool = get.Tool
+
+func TestCheckForTool(t *testing.T) {
+	tests := []struct {
+		name       string
+		appName    string
+		tools      []Tool
+		want       string
+		expectFail bool
+	}{
+		{
+			name:    "Tool exists but expected is wrong",
+			appName: "kubectl",
+			tools: []Tool{
+				{Name: "kubectl"},
+				{Name: "helm"},
+				{Name: "k9s"},
+			},
+			want:       "this test should fail",
+			expectFail: true,
+		},
+		{
+			name:    "Tool exists",
+			appName: "kubectl",
+			tools: []Tool{
+				{Name: "kubectl"},
+				{Name: "helm"},
+				{Name: "k9s"},
+			},
+			want:       "no such app. kubectl is available as a tool, run \"arkade get kubectl\" to get it",
+			expectFail: false,
+		},
+		{
+			name:    "Tool does not exist",
+			appName: "randomtool",
+			tools: []Tool{
+				{Name: "kubectl"},
+				{Name: "helm"},
+			},
+			want:       "no such app: randomtool, run \"arkade install --help\" for a list of apps",
+			expectFail: false,
+		},
+		{
+			name:    "Case-insensitive match",
+			appName: "KUBECTL",
+			tools: []Tool{
+				{Name: "kubectl"},
+				{Name: "helm"},
+			},
+			want:       "no such app. KUBECTL is available as a tool, run \"arkade get KUBECTL\" to get it",
+			expectFail: false,
+		},
+		{
+			name:       "Empty tool list",
+			appName:    "kubectl",
+			tools:      []Tool{},
+			want:       "no such app: kubectl, run \"arkade install --help\" for a list of apps",
+			expectFail: false,
+		},
+		{
+			name:    "Empty app name",
+			appName: "",
+			tools: []Tool{
+				{Name: "kubectl"},
+			},
+			want:       "no such app: , run \"arkade install --help\" for a list of apps",
+			expectFail: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkForTool(tc.appName, tc.tools)
+			if got != tc.want && !tc.expectFail {
+				t.Errorf("%s\nwant: %s\n got: %s",
+					tc.name, tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

When trying to install an app that doesnt exist the error message would advise the user that the app doesnt exist and that they should run `install --help` to see what is available.

However, there may be situations where the user is using the wrong verb because they are trying to get a tool, rather than an app.  This change introduces a check when an app not found error is encountered to see whether a tool with the user provided name exists and advises them accordingly.

also adds associated test.

## Motivation and Context

- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
discussed on the community call on 20/11


## How Has This Been Tested?

### Functional
Tried the helm example with isnt an app but will resolve to a tool.  Then tried `burt` which is neither app nor tool.
```
➜  arkade git:(addGetPrompt) make build                                                         
go build
➜  arkade git:(addGetPrompt) ./arkade install helm                                              
Error: no such app. helm is available as a tool, run "arkade get helm" to get it
➜  arkade git:(addGetPrompt) ./arkade install burt                                              
Error: no such app: burt, run "arkade install --help" for a list of apps
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
