### PR TITLE
Add way to hold/ignore images when upgrading compose/charts

### DIFF
--- a/cmd/chart/chart.go
+++ b/cmd/chart/chart.go
@@ -11,12 +11,11 @@ import (
 func MakeChart() *cobra.Command {
 
 	command := &cobra.Command{
-		Use:     "chart",
-		Short:   "Chart utilities",
-		Long:    `Utilities for Helm charts.`,
-		Aliases: []string{"c"},
-		Example: `  arkade chart verify --help
-`,
+		Use:          "chart",
+		Short:        "Chart utilities",
+		Long:         `Utilities for Helm charts.`,
+		Aliases:      []string{"c"},
+		Example:      `  arkade chart verify --help`,
 		SilenceUsage: true,
 	}
 

--- a/cmd/chart/verify.go
+++ b/cmd/chart/verify.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"text/tabwriter"
 
+	"github.com/alexellis/arkade/pkg/config"
 	"github.com/alexellis/arkade/pkg/helm"
 	"github.com/spf13/cobra"
 
@@ -71,8 +72,8 @@ autoscaler          ghcr.io/openfaasltd/autoscaler:0.2.5
 		if err != nil {
 			return err
 		}
-
-		filtered := helm.FilterImagesUptoDepth(values, depth)
+		cfg := &config.ArkadeConfig{}
+		filtered := helm.FilterImagesUptoDepth(values, depth, "", cfg)
 		if len(filtered) == 0 {
 			return fmt.Errorf("no images found in %s", file)
 		}

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ArkadeConfig struct {
+	Ignore []string `yaml:"ignore"`
+}
+
+func Load(file string) (*ArkadeConfig, error) {
+
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &ArkadeConfig{}
+
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add way to hold/ignore images when upgrading compose/charts

## Motivation and Context

When upgrading image versions in a compose file or helm chart there are cases where certain components like a database version should be static and not change.

This change introduces a more generic concept than previously planned of an arkade config file. The ignore section includes paths to images which should be ignored and filtered out prior to looking up new images.

## How Has This Been Tested?

Tested with the OpenFaaS pro-builder chart, with the path buildkit.image, I was able to ignore only that image whilst having the other images inspected/updated.

![image](https://github.com/user-attachments/assets/cc099e85-66fb-4f6b-a1d7-f0a2e3971c27)

```
go run . chart upgrade -f ~/go/src/github.com/openfaas/faas-netes/chart/pro-builder/values.yaml  --verbose
2025/01/30 11:38:21 Verifying images in: /home/alex/go/src/github.com/openfaas/faas-netes/chart/pro-builder/values.yaml
2025/01/30 11:38:21 Found 2 images
2025/01/30 11:38:22 [moby/buildkit] v0.15.1-rootless => v0.19.0-rootless
```

Then `arkade.yaml` was placed next to values.yaml:

```
ignore:
  - buildkit.image
```

Buildkit was ignored:

```
go run . chart upgrade -f ~/go/src/github.com/openfaas/faas-netes/chart/pro-builder/values.yaml  --verbose
2025/01/30 11:39:04 Verifying images in: /home/alex/go/src/github.com/openfaas/faas-netes/chart/pro-builder/values.yaml
2025/01/30 11:39:04 Found 1 images
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

The documentation has been updated in the cobra command and within the examples.