### PR TITLE
fix: increase k8s ver strat timeout to 10

### DIFF
--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -83,7 +83,7 @@ var releaseLocations = map[string]ReleaseLocation{
 	},
 	k8sVersionStrategy: {
 		Url:     "https://cdn.dl.k8s.io/release/stable.txt",
-		Timeout: time.Second * 5,
+		Timeout: time.Second * 10,
 		Method:  http.MethodGet,
 	},
 }


### PR DESCRIPTION
## Description
Change increases the client timeout for the k8sVersionStrategy to 10 seconds.  This corresponds with the GH timeout and attempts to mitigate intermittent timeout issues observed during usage.  The GH timeout being increased was positive in adressing similar issues with GH hosted artifacts.

## Motivation and Context
- [x] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))
Mentioned in #778 as a potential mitigation strategy.

## How Has This Been Tested?
Functional only.  As its a timeout increase its more challenging to test the effects, only assure against negative effect.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
