### PR TITLE
feat: add step cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -936,6 +936,7 @@ There are 53 apps that you can install on your cluster.
 | [sops](https://github.com/getsops/sops)                                      | Simple and flexible tool for managing secrets                                                                                                                     |
 | [ssync](https://github.com/alexellis/ssync)                                  | Sync files from one machine to another.                                                                                                                           |
 | [starship](https://github.com/starship/starship)                             | The minimal, blazing-fast, and infinitely customizable prompt for any shell!                                                                                      |
+| [step](https://github.com/smallstep/cli)                                     | A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.                                                                                   |
 | [stern](https://github.com/stern/stern)                                      | Multi pod and container log tailing for Kubernetes.                                                                                                               |
 | [syft](https://github.com/anchore/syft)                                      | CLI tool and library for generating a Software Bill of Materials from container images and filesystems                                                            |
 | [talosctl](https://github.com/siderolabs/talos)                              | The command-line tool for managing Talos Linux OS.                                                                                                                |
@@ -961,7 +962,6 @@ There are 53 apps that you can install on your cluster.
 | [websocat](https://github.com/vi/websocat)                                   | Command-line client for WebSockets, like netcat/socat but for WebSockets                                                                                          |
 | [yq](https://github.com/mikefarah/yq)                                        | Portable command-line YAML processor.                                                                                                                             |
 | [yt-dlp](https://github.com/yt-dlp/yt-dlp)                                   | Fork of youtube-dl with additional features and fixes                                                                                                             |
-There are 191 tools, use `arkade get NAME` to download one.                                                                                                                                                                                         
-
+There are 192 tools, use `arkade get NAME` to download one.                                                                                                                                                                                         
 
 > Note to contributors, run `go run . get --format markdown` to generate this list

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -9236,6 +9236,58 @@ func Test_DownloadStarship(t *testing.T) {
 	}
 }
 
+func Test_DownloadStep(t *testing.T) {
+	tools := MakeTools()
+	name := "step"
+
+	tool := getTool(name, tools)
+
+	const toolVersion = "v0.28.7"
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://dl.smallstep.com/gh-release/cli/gh-release-header/v0.28.7/step_linux_0.28.7_amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://dl.smallstep.com/gh-release/cli/gh-release-header/v0.28.7/step_linux_0.28.7_arm64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://dl.smallstep.com/gh-release/cli/gh-release-header/v0.28.7/step_darwin_0.28.7_amd64.tar.gz",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://dl.smallstep.com/gh-release/cli/gh-release-header/v0.28.7/step_darwin_0.28.7_arm64.tar.gz",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://dl.smallstep.com/gh-release/cli/gh-release-header/v0.28.7/step_windows_0.28.7_amd64.zip",
+		},
+	}
+	verify := false
+	for _, tc := range tests {
+		got, _, err := tool.GetURL(tc.os, tc.arch, tc.version, verify)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
+}
+
 func Test_DownloadDyff(t *testing.T) {
 	tools := MakeTools()
 	name := "dyff"

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -5107,6 +5107,44 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/starship-
 
 	tools = append(tools,
 		Tool{
+			Owner:           "smallstep",
+			Repo:            "cli",
+			Name:            "step",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.",
+			BinaryTemplate:  `step`,
+			URLTemplate: `
+{{$os := ""}}
+{{$arch := ""}}
+{{$ext := "tar.gz"}}
+{{- if eq .OS "linux" -}}
+	{{$os = "linux"}}
+	{{- if eq .Arch "x86_64" -}}
+		{{$arch = "amd64"}}
+	{{ else if eq .Arch "aarch64" -}}
+		{{$arch = "arm64"}}
+	{{ else if eq .Arch "armv7l" -}}
+		{{$arch = "arm7"}}
+	{{- end -}}
+{{- else if eq .OS "darwin" -}}
+	{{$os = "darwin"}}
+	{{- if eq .Arch "x86_64" -}}
+		{{$arch = "amd64"}}
+	{{ else if eq .Arch "arm64" -}}
+		{{$arch = "arm64"}}
+	{{- end -}}
+{{- else if HasPrefix .OS "ming" -}}
+	{{$os = "windows"}}
+	{{$ext = "zip"}}
+	{{- if eq .Arch "x86_64" -}}
+		{{$arch = "amd64"}}
+	{{- end -}}
+{{- end -}}
+https://dl.smallstep.com/gh-release/cli/gh-release-header/{{.Version}}/step_{{$os}}_{{.VersionNumber}}_{{$arch}}.{{$ext}}`,
+		})
+
+	tools = append(tools,
+		Tool{
 			Owner:          "homeport",
 			Repo:           "dyff",
 			Name:           "dyff",


### PR DESCRIPTION
## Description

Add step cli.

FYI: step cli assets are hosted on the company's servers while source code and releases are hosted at github. I didn't see a way to make arkade handle such scenario well. If it was possible to specify the versioning strategy explicitly, instead of deriving it from the URL template, it would a bit cleaner. I opted for the most simple approach of adding an anchor to the URL that matches the github version strategy. I created #1229 to track the issue.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh step

+ file /home/jceb/.arkade/bin/step
/home/jceb/.arkade/bin/step: gzip compressed data, max compression, original size modulo 2^32 41640448
+ rm /home/jceb/.arkade/bin/step
+ echo

+ ./arkade get step --arch x86_64 --os darwin --quiet
+ file /home/jceb/.arkade/bin/step
/home/jceb/.arkade/bin/step: gzip compressed data, max compression, original size modulo 2^32 43195904
+ rm /home/jceb/.arkade/bin/step
+ echo

+ ./arkade get step --arch x86_64 --os linux --quiet
+ file /home/jceb/.arkade/bin/step
/home/jceb/.arkade/bin/step: gzip compressed data, max compression, original size modulo 2^32 42291200
+ rm /home/jceb/.arkade/bin/step
+ echo

+ ./arkade get step --arch aarch64 --os linux --quiet
+ file /home/jceb/.arkade/bin/step
/home/jceb/.arkade/bin/step: gzip compressed data, max compression, original size modulo 2^32 40569344
+ rm /home/jceb/.arkade/bin/step
+ echo

+ ./arkade get step --arch x86_64 --os mingw --quiet
+ file /home/jceb/.arkade/bin/step.exe
/home/jceb/.arkade/bin/step.exe: Zip archive data, at least v2.0 to extract, compression method=deflate
+ rm /home/jceb/.arkade/bin/step.exe
+ echo
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [x] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
