### PR TITLE
Fix opencode binary templates

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -9189,13 +9189,13 @@ func Test_DownloadOpencode(t *testing.T) {
 			os:      "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     "https://github.com/sst/opencode/releases/download/v0.4.41/opencode-linux-x64.zip",
+			url:     "https://github.com/sst/opencode/releases/download/v0.4.41/opencode-linux-x64.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
 			version: toolVersion,
-			url:     "https://github.com/sst/opencode/releases/download/v0.4.41/opencode-linux-arm64.zip",
+			url:     "https://github.com/sst/opencode/releases/download/v0.4.41/opencode-linux-arm64.tar.gz",
 		},
 		{
 			os:      "mingw64_nt-10.0-18362",

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -64,9 +64,9 @@ func MakeTools() Tools {
 {{.Name}}-darwin-x64.zip
   {{- end -}}
 {{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
-{{.Name}}-linux-arm64.zip
+{{.Name}}-linux-arm64.tar.gz
 {{- else -}}
-{{.Name}}-linux-x64.zip
+{{.Name}}-linux-x64.tar.gz
 {{- end -}}`,
 		})
 
@@ -971,12 +971,12 @@ kluctl_{{.Version}}_{{$os}}_{{$arch}}.{{if HasPrefix .OS "ming"}}zip{{else}}tar.
 				{{- else if eq .Arch "armv7l" -}}
 				{{$arch = "arm"}}
 				{{- end -}}
-	
+
 				{{$os := .OS}}
 				{{ if HasPrefix .OS "ming" -}}
 				{{$os = "windows"}}
 				{{- end -}}
-	
+
 				https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.zip`,
 		})
 
@@ -1108,18 +1108,18 @@ https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.Version
 			Version:     "2.2.19",
 			Description: "Tool for building and distributing development environments.",
 			URLTemplate: `{{$arch := .Arch}}
-	
+
 	{{- if eq .Arch "x86_64" -}}
 	{{$arch = "amd64"}}
 	{{- else if eq .Arch "armv7l" -}}
 	{{$arch = "arm"}}
 	{{- end -}}
-	
+
 	{{$os := .OS}}
 	{{ if HasPrefix .OS "ming" -}}
 	{{$os = "windows"}}
 	{{- end -}}
-	
+
 	https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`})
 
 	tools = append(tools,
@@ -2289,12 +2289,12 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 							{{$os := .OS}}
 							{{$arch := .Arch}}
 							{{$ext := ".tar.gz"}}
-				
+
 							{{- if HasPrefix .OS "ming" -}}
 								{{$os = "windows"}}
 								{{$ext = ".zip"}}
 							{{- end -}}
-		
+
 							{{- if eq .Arch "x86_64" -}}
 		                        {{$arch = "amd64"}}
 							{{- else if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
@@ -4238,11 +4238,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				{{ $os := .OS }}
 				{{ $arch := .Arch }}
 				{{ $ext := "" }}
-	
+
 				{{- if (eq .Arch "aarch64") -}}
 					{{ $ext = "-aarch64" }}
 				{{- end -}}
-	
+
 				cloud-hypervisor-static{{$ext}}`,
 		})
 
@@ -4256,11 +4256,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 					{{ $os := .OS }}
 					{{ $arch := .Arch }}
 					{{ $ext := "" }}
-		
+
 					{{- if (eq .Arch "aarch64") -}}
 						{{ $ext = "-aarch64" }}
 					{{- end -}}
-		
+
 					ch-remote-static{{$ext}}`,
 		})
 
@@ -4322,7 +4322,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 					{{ if HasPrefix .OS "ming" -}}
 					{{$os = "windows"}}
 					{{$ext = ".exe"}}
-					{{- end -}}	
+					{{- end -}}
 
 					regctl-{{$os}}-{{$arch}}{{$ext}}
 					`,
@@ -4382,18 +4382,18 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				{{$os := .OS}}
 				{{$arch := .Arch}}
 				{{$ext := "tar.gz"}}
-	
+
 				{{- if HasPrefix .OS "ming" -}}
 				{{ $os = "windows" }}
 				{{ $ext = "exe" }}
 			{{- end -}}
-	
+
 				{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 					{{$arch = "arm64"}}
 				{{- else if eq .Arch "x86_64" -}}
 					{{ $arch = "amd64" }}
 				{{- end -}}
-	
+
 				{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.{{$ext}}`,
 		})
 
@@ -4454,9 +4454,9 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 						{{ if HasPrefix .OS "ming" -}}
 							{{$os = "windows"}}
 							{{ $ext := "tar.gz" }}
-						
+
 						{{- end -}}
-						
+
 						{{- if eq .OS "darwin" -}}
 							{{$os = "darwin"}}
 							{{$arch = "all"}}
@@ -4477,19 +4477,19 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 							{{ $os := .OS }}
 							{{ $arch := .Arch }}
 							{{ $ext := "tar.gz" }}
-	
+
 							{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 							    {{ $arch = "arm64" }}
 							{{- else if eq .Arch "x86_64" -}}
 								{{ $arch = "amd64" }}
 							{{- end -}}
-							
+
 							{{- if eq .OS "darwin" -}}
 								{{$os = "darwin"}}
 							{{- else if eq .OS "linux" -}}
 								{{ $os = "linux" }}
 							{{- end -}}
-	
+
 							labctl_{{$os}}_{{$arch}}.{{$ext}}
 							`,
 		})
@@ -4532,22 +4532,22 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 							{{ $os := .OS }}
 							{{ $arch := .Arch }}
 							{{ $ext := "tar.gz" }}
-	
+
 							{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 							    {{ $arch = "arm64" }}
 							{{- end -}}
-	
+
 							{{ if HasPrefix .OS "ming" -}}
 								{{$os = "Windows"}}
 								{{ $ext = "zip" }}
 							{{- end -}}
-							
+
 							{{- if eq .OS "darwin" -}}
 								{{$os = "Darwin"}}
 							{{- else if eq .OS "linux" -}}
 								{{ $os = "Linux" }}
 							{{- end -}}
-	
+
 							duplik8s_{{$os}}_{{$arch}}.{{$ext}}
 							`,
 		})
@@ -4568,13 +4568,13 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 					{{- else if eq .Arch "armv7l" -}}
 						{{ $arch = "arm" }}
 					{{- end -}}
-					
+
 					{{$os := .OS}}
 					{{ if HasPrefix .OS "ming" -}}
 					{{$ext = ".exe" }}
 					{{$os = "windows"}}
 					{{- end -}}
-					
+
 					https://releases.crossplane.io/stable/{{.Version}}/bin/{{$os}}_{{$arch}}/crank{{$ext}}`,
 		})
 
@@ -4589,7 +4589,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 							{{$os := .OS}}
 							{{$arch := .Arch}}
 							{{$ext := "tar.gz"}}
-				
+
 							{{- if eq .OS "darwin" -}}
 								{{$os = "Darwin"}}
 							{{- else if eq .OS "linux" -}}
@@ -4598,11 +4598,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 								{{$os = "Windows"}}
 								{{$ext = "zip"}}
 							{{- end -}}
-		
+
 							{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 								{{$arch = "arm64"}}
 							{{- end -}}
-		
+
 						rosa_{{$os}}_{{$arch}}.{{$ext}}
 						`,
 		})
@@ -4617,7 +4617,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			BinaryTemplate: `
 								{{$os := .OS}}
 								{{$arch := .Arch}}
-			
+
 								{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 									{{$arch = "arm64"}}
 								{{- else if eq .Arch "x86_64" -}}
@@ -4625,7 +4625,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 								{{- else if eq .Arch "armv7l" -}}
                                     {{$arch = "arm32"}}
 								{{- end -}}
-			
+
 							kubie-{{$os}}-{{$arch}}
 							`,
 		})
@@ -4645,7 +4645,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 									{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 										{{$arch = "arm64"}}
 									{{- end -}}
-						
+
 									{{- if eq .OS "darwin" -}}
 										{{$os = "Darwin"}}
 										{{$arch = "all"}}
@@ -4655,7 +4655,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 										{{$os = "Windows"}}
 										{{$ext = ".exe"}}
 									{{- end -}}
-				
+
 								eks-node-viewer_{{$os}}_{{$arch}}{{$ext}}
 								`,
 		})
@@ -4671,7 +4671,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 								{{$os := .OS}}
 								{{$arch := .Arch}}
 								{{$ext := "zip"}}
-					
+
 								{{- if eq .OS "darwin" -}}
 									{{$os = "osx"}}
 								{{- else if eq .OS "linux" -}}
@@ -4679,7 +4679,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 								{{- else if HasPrefix .OS "ming" -}}
 									{{$os = "windows"}}
 								{{- end -}}
-			
+
 								{{- if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 									{{$arch = "arm64"}}
 								{{- else if eq .Arch "x86_64" -}}
@@ -4687,7 +4687,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 								{{- else if eq .Arch "armv7l" -}}
                                     {{$arch = "arm-v7"}}
 								{{- end -}}
-			
+
 							rclone-{{.Version}}-{{$os}}-{{$arch}}.{{$ext}}
 							`,
 		})
@@ -4772,7 +4772,7 @@ https://github.com/grafana/alloy/releases/download/{{.Version}}/{{$fileName}}`,
 									{{$os := .OS}}
 									{{$arch := .Arch}}
 									{{$ext := "tar.gz"}}
-	
+
 									{{- if eq .Arch "x86_64" -}}
 											{{$arch = "amd64"}}
 									{{- else if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
@@ -4780,7 +4780,7 @@ https://github.com/grafana/alloy/releases/download/{{.Version}}/{{$fileName}}`,
 									{{- else if eq .Arch "armv7l" -}}
                                             {{$arch = "arm"}}
 									{{- end -}}
-	
+
 								gitwho_{{.Version}}_{{$os}}_{{$arch}}.{{$ext}}
 								`,
 		})
@@ -4795,18 +4795,18 @@ https://github.com/grafana/alloy/releases/download/{{.Version}}/{{$fileName}}`,
 								{{$os := .OS}}
 								{{$arch := .Arch}}
 								{{$ext := "tar.gz"}}
-		
+
 								{{- if eq .Arch "x86_64" -}}
 									{{$arch = "x64"}}
 								{{- else if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 									{{$arch = "arm64"}}
 								{{- end -}}
-								
+
 								{{- if HasPrefix .OS "ming" -}}
 									{{$os = "windows"}}
 									{{$ext = "zip"}}
 								{{- end -}}
-		
+
 								{{.Name}}-{{.Version}}-{{$os}}-{{$arch}}.{{$ext}}
 									`,
 		})
@@ -5047,11 +5047,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/dyff_{{.V
 									{{- else if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 										{{$arch = "arm64"}}
 									{{- end -}}
-									
+
 									{{- if HasPrefix .OS "ming" -}}
 										{{$os = "windows"}}
 									{{- end -}}
-			
+
 				{{.Name}}-{{$os}}-{{$arch}}`,
 			URLTemplate: `
 									{{$os := .OS}}
@@ -5064,12 +5064,12 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/dyff_{{.V
 									{{- else if (or (eq .Arch "aarch64") (eq .Arch "arm64")) -}}
 										{{$arch = "arm64"}}
 									{{- end -}}
-									
+
 									{{- if HasPrefix .OS "ming" -}}
 										{{$os = "windows"}}
 										{{$ext = "exe.zip"}}
 									{{- end -}}
-			
+
 									https://github.com/grafana/loki/releases/download/{{.Version}}/{{.Name}}-{{$os}}-{{$arch}}.{{$ext}}`,
 		})
 


### PR DESCRIPTION
Update the release url template for OpenCode.

Starting with v1.0.92 of OpenCode Linux releases use `tar.gz` instead of `.zip`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

Getting OpenCode on Linux failed with: `Error: server returned status: 404`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified download for `amd64` and `arm64` Linux

```
go run . get  opencode --progress=false --arch amd64 --os linux
Downloading: opencode
2025/11/24 18:18:42 Looking up version for: opencode
2025/11/24 18:18:42 Found: v1.0.107
Downloading: https://github.com/sst/opencode/releases/download/v1.0.107/opencode-linux-x64.tar.gz
/tmp/arkade-2469233309/opencode-linux-x64.tar.gz written.
2025/11/24 18:18:43 Extracted: /tmp/arkade-2469233309/opencode
2025/11/24 18:18:43 Copying /tmp/arkade-2469233309/opencode to /home/welteki/.arkade/bin/opencode
```

```
go run . get  opencode --progress=false --arch arm64 --os linux
Downloading: opencode
2025/11/24 18:19:36 Looking up version for: opencode
2025/11/24 18:19:36 Found: v1.0.107
Downloading: https://github.com/sst/opencode/releases/download/v1.0.107/opencode-linux-arm64.tar.gz
/tmp/arkade-61635695/opencode-linux-arm64.tar.gz written.
2025/11/24 18:19:38 Extracted: /tmp/arkade-61635695/opencode
2025/11/24 18:19:38 Copying /tmp/arkade-61635695/opencode to /home/welteki/.arkade/bin/opencode
```

If updating or adding a new CLI to `arkade get`, run:

```
go build && ./hack/test-tool.sh TOOL_NAME
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
