### PR TITLE
fix: resolve kubescape failure in CI

### DIFF
--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -3784,23 +3784,46 @@ func Test_DownloadKubescape(t *testing.T) {
 	tools := MakeTools()
 	name := "kubescape"
 
+	const toolVersion = "v3.0.47"
+
 	tool := getTool(name, tools)
 
 	tests := []test{
 		{
 			os:      "darwin",
-			version: "v1.0.69",
-			url:     `https://github.com/kubescape/kubescape/releases/download/v1.0.69/kubescape-macos-latest`,
+			arch:    archDarwinARM64,
+			version: toolVersion,
+			url:     "https://github.com/kubescape/kubescape/releases/download/v3.0.47/kubescape_3.0.47_darwin_arm64",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/kubescape/kubescape/releases/download/v3.0.47/kubescape_3.0.47_darwin_amd64",
 		},
 		{
 			os:      "linux",
-			version: "v1.0.69",
-			url:     `https://github.com/kubescape/kubescape/releases/download/v1.0.69/kubescape-ubuntu-latest`,
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/kubescape/kubescape/releases/download/v3.0.47/kubescape_3.0.47_linux_arm64",
+		},
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/kubescape/kubescape/releases/download/v3.0.47/kubescape_3.0.47_linux_amd64",
 		},
 		{
 			os:      "ming",
-			version: "v1.0.69",
-			url:     `https://github.com/kubescape/kubescape/releases/download/v1.0.69/kubescape-windows-latest`,
+			arch:    archARM64,
+			version: toolVersion,
+			url:     "https://github.com/kubescape/kubescape/releases/download/v3.0.47/kubescape_3.0.47_windows_arm64.exe",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: toolVersion,
+			url:     "https://github.com/kubescape/kubescape/releases/download/v3.0.47/kubescape_3.0.47_windows_amd64.exe",
 		},
 	}
 
@@ -3811,7 +3834,7 @@ func Test_DownloadKubescape(t *testing.T) {
 				t.Fatal(err)
 			}
 			if got != tc.url {
-				t.Errorf("want: %s, got: %s", tc.url, got)
+				t.Errorf("\nwant: %s, \n got: %s", tc.url, got)
 			}
 		})
 	}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -2340,22 +2340,28 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "kubescape",
-			Repo:        "kubescape",
-			Name:        "kubescape",
-			Description: "kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by NSA and CISA",
+			Owner:           "kubescape",
+			Repo:            "kubescape",
+			Name:            "kubescape",
+			Description:     "kubescape is the first tool for testing if Kubernetes is deployed securely as defined in Kubernetes Hardening Guidance by NSA and CISA",
+			VersionStrategy: GitHubVersionStrategy,
 			BinaryTemplate: `
-		{{$osStr := ""}}
-		{{ if HasPrefix .OS "ming" -}}
-		{{$osStr = "windows"}}
-		{{- else if eq .OS "linux" -}}
-		{{$osStr = "ubuntu"}}
-		{{- else if eq .OS "darwin" -}}
-		{{$osStr = "macos"}}
-		{{- end -}}
-
-
-		{{.Name}}-{{$osStr}}-latest`,
+								{{$arch := "amd64"}}
+								{{$osStr := .OS }}
+								{{$ext := ""}}
+	
+								{{if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+									{{$arch = "arm64"}}
+								{{- else if eq .Arch "x86_64" -}}
+									{{$arch = "amd64"}}
+								{{- end -}}
+	
+								{{ if HasPrefix .OS "ming" -}}
+									{{$osStr = "windows"}}
+									{{$ext = ".exe"}}
+								{{- end -}}
+	
+								{{.Name}}_{{.VersionNumber}}_{{$osStr}}_{{$arch}}{{$ext}}`,
 		})
 	tools = append(tools,
 		Tool{


### PR DESCRIPTION
## Description
Kubescape was configured to look for '-latest'.  Binaries with that suffix no longer existed. 
This change converts it to use gitHubVersionStrategy.

## Motivation and Context
CI was running red

## How Has This Been Tested?

### make e2e
```sh
➜  arkade git:(fixKubescape) ✗ make e2e
CGO_ENABLED=0 go test github.com/alexellis/arkade/pkg/get -cover --tags e2e -v
...
PASS
coverage: 57.7% of statements
ok  	github.com/alexellis/arkade/pkg/get	7.629s	coverage: 57.7% of statements
````

### /hack/test-tool.sh
```sh
➜  arkade git:(fixKubescape) ✗ ./hack/test-tool.sh kubescape
+ ./arkade get kubescape --arch arm64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kubescape
/Users/rgee0/.arkade/bin/kubescape: Mach-O 64-bit executable arm64
+ rm /Users/rgee0/.arkade/bin/kubescape
+ echo

+ ./arkade get kubescape --arch x86_64 --os darwin --quiet
+ file /Users/rgee0/.arkade/bin/kubescape
/Users/rgee0/.arkade/bin/kubescape: Mach-O 64-bit executable x86_64
+ rm /Users/rgee0/.arkade/bin/kubescape
+ echo

+ ./arkade get kubescape --arch x86_64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kubescape
/Users/rgee0/.arkade/bin/kubescape: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=3d1d0f2bc969320c4ccc04167bb3ee6833f96203, stripped
+ rm /Users/rgee0/.arkade/bin/kubescape
+ echo

+ ./arkade get kubescape --arch aarch64 --os linux --quiet
+ file /Users/rgee0/.arkade/bin/kubescape
/Users/rgee0/.arkade/bin/kubescape: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=59fffbf09f54bc775ada0a1feb8d5882511f5b09, stripped
+ rm /Users/rgee0/.arkade/bin/kubescape
+ echo

+ ./arkade get kubescape --arch x86_64 --os mingw --quiet
+ file /Users/rgee0/.arkade/bin/kubescape.exe
/Users/rgee0/.arkade/bin/kubescape.exe: PE32+ executable (console) x86-64, for MS Windows
+ rm /Users/rgee0/.arkade/bin/kubescape.exe
+ echo
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment
