### PR TITLE
Fix traefik2 install for current Helm chart

### DIFF
--- a/cmd/apps/traefik2_app.go
+++ b/cmd/apps/traefik2_app.go
@@ -52,7 +52,7 @@ func MakeInstallTraefik2() *cobra.Command {
 			return err
 		}
 
-		err = helm.AddHelmRepo("traefik", "https://helm.traefik.io/traefik", updateRepo)
+		err = helm.AddHelmRepo("traefik", "https://traefik.github.io/charts", updateRepo)
 		if err != nil {
 			return fmt.Errorf("Unable to add repo %s", err)
 		}
@@ -74,15 +74,15 @@ func MakeInstallTraefik2() *cobra.Command {
 		}
 		overrides["service.type"] = svc
 
-		overrides["additional.checkNewVersion"] = "false"
-		overrides["additional.sendAnonymousUsage"] = "false"
+		overrides["global.checkNewVersion"] = "false"
+		overrides["global.sendAnonymousUsage"] = "false"
 
 		if dashboard {
-			overrides["dashboard.ingressRoute"] = "true"
+			overrides["ingressRoute.dashboard.enabled"] = "true"
 		}
 
 		if ingressProvider {
-			overrides["additionalArguments"] = `{--providers.kubernetesingress}`
+			overrides["additionalArguments[0]"] = "--providers.kubernetesingress"
 		}
 
 		customFlags, err := command.Flags().GetStringArray("set")


### PR DESCRIPTION
## Description

Update the traefik2 app installer to work with the current Traefik Helm chart.

- Update Helm repo URL from `https://helm.traefik.io/traefik` to `https://traefik.github.io/charts`
- Update Helm values to match the current chart schema:
  - `additional.checkNewVersion` -> `global.checkNewVersion`
  - `additional.sendAnonymousUsage` -> `global.sendAnonymousUsage`
  - `dashboard.ingressRoute` -> `ingressRoute.dashboard.enabled`
  - `additionalArguments` string -> indexed array format

## Motivation and Context

`arkade install traefik2` fails with:

```
Error: UPGRADE FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
traefik:
- (root): Additional property additional is not allowed
```

The Traefik Helm chart has been updated and the old value keys are no longer valid.

- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Ran `go build && ./arkade install traefik2` against a live cluster. Install completed successfully deploying Traefik v3.6.7.

```
Release "traefik" has been upgraded. Happy Helming!
NAME: traefik
LAST DEPLOYED: Wed Feb 11 13:44:08 2026
NAMESPACE: kube-system
STATUS: deployed
REVISION: 2
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have tested this on arm, or have added code to prevent deployment