### PR TITLE
Fix URL for Kubernetes version strategy

### DIFF
--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -133,7 +133,7 @@ var releaseLocations = map[string]ReleaseLocation{
 		Method:  http.MethodHead,
 	},
 	k8sVersionStrategy: {
-		Url:     "https://cdn.dl.k8s.io/release/stable.txt",
+		Url:     "https://dl.k8s.io/release/stable.txt",
 		Timeout: time.Second * 10,
 		Method:  http.MethodGet,
 	},


### PR DESCRIPTION
## Description

Use `dl.k8s.io` instead of `cdn.dl.k8s.io` (currently down and not endorsed to be referenced directly).

See: https://github.com/kubernetes/k8s.io/issues/9052#issuecomment-3907398966

## Motivation and Context

```
~ ❯ curl https://cdn.dl.k8s.io/release/stable.txt
curl: (6) Could not resolve host: cdn.dl.k8s.io

~ ✗ curl https://dl.k8s.io/release/stable.txt
v1.35.1%
```

## How Has This Been Tested?

Not E2E. Only verified via curl command above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have tested this on arm, or have added code to prevent deployment
