### PR TITLE
Update upload-assets workflow action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Make all
         run: make all
       - name: Upload release binaries
-        uses: alexellis/upload-assets@0.4.1
+        uses: alexellis/upload-assets@0.5.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Description

Updates the release publishing workflow to use `alexellis/upload-assets@0.5.0`.

## Motivation and Context

The new version updates the Node.js runtime used by the upload-assets action.

- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

The release workflow was tested in a separate organization. This change only updates the GitHub Actions release upload action version in `.github/workflows/publish.yml`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [ ] I have tested this on arm, or have added code to prevent deployment