### PR TITLE
Resolve latest CLI releases

### DIFF
--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +23,6 @@ import (
 const GitHubVersionStrategy = "github"
 const GitLabVersionStrategy = "gitlab"
 const k8sVersionStrategy = "k8s"
-const ClaudeStrategy = `claude`
 const AmpStrategy = `amp`
 
 const HashicorpShasumStrategy = `hashicorp-sha`
@@ -61,6 +61,11 @@ func retryWithBackoff(fn func() (string, error), maxRetries int, initialBackoff 
 }
 
 func isPermanentError(err error) bool {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.Op == "parse" {
+		return true
+	}
+
 	// 404, 429 are permanent errors
 	if strings.Contains(err.Error(), "404") {
 		return true
@@ -135,11 +140,6 @@ var releaseLocations = map[string]ReleaseLocation{
 	k8sVersionStrategy: {
 		Url:     "https://dl.k8s.io/release/stable.txt",
 		Timeout: time.Second * 10,
-		Method:  http.MethodGet,
-	},
-	ClaudeStrategy: {
-		Url:     "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/latest",
-		Timeout: time.Second * 5,
 		Method:  http.MethodGet,
 	},
 	AmpStrategy: {

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -338,6 +339,25 @@ func Test_FormatUrl(t *testing.T) {
 				t.Fatalf("\nwant: %s\ngot:  %s", tc.expected, result)
 			}
 		})
+	}
+}
+
+func TestRetryWithBackoffDoesNotRetryURLParseErrors(t *testing.T) {
+	attempts := 0
+	_, requestErr := http.NewRequest(http.MethodGet, "https://example.com/%!(EXTRA string=vagrant)", nil)
+	if requestErr == nil {
+		t.Fatal("expected malformed URL to return an error")
+	}
+
+	_, err := retryWithBackoff(func() (string, error) {
+		attempts++
+		return "", requestErr
+	}, 10, 0)
+	if err == nil {
+		t.Fatal("expected retryWithBackoff to return the URL parse error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected one attempt for a URL parse error, got %d", attempts)
 	}
 }
 
@@ -1045,27 +1065,27 @@ func Test_DownloadKubeseal(t *testing.T) {
 		{os: "mingw64_nt-10.0-18362",
 			arch:    arch64bit,
 			version: "v0.17.4",
-			url:     "https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-windows-amd64.tar.gz"},
+			url:     "https://github.com/bitnami/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-windows-amd64.tar.gz"},
 		{os: "linux",
 			arch:    arch64bit,
 			version: "v0.17.4",
-			url:     "https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-linux-amd64.tar.gz"},
+			url:     "https://github.com/bitnami/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-linux-amd64.tar.gz"},
 		{os: "darwin",
 			arch:    archDarwinARM64,
 			version: "v0.17.4",
-			url:     "https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-darwin-arm64.tar.gz"},
+			url:     "https://github.com/bitnami/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-darwin-arm64.tar.gz"},
 		{os: "darwin",
 			arch:    arch64bit,
 			version: "v0.17.4",
-			url:     "https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-darwin-amd64.tar.gz"},
+			url:     "https://github.com/bitnami/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-darwin-amd64.tar.gz"},
 		{os: "linux",
 			arch:    archARM7,
 			version: "v0.17.4",
-			url:     "https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-linux-arm.tar.gz"},
+			url:     "https://github.com/bitnami/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-linux-arm.tar.gz"},
 		{os: "linux",
 			arch:    archARM64,
 			version: "v0.17.4",
-			url:     "https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-linux-arm64.tar.gz"},
+			url:     "https://github.com/bitnami/sealed-secrets/releases/download/v0.17.4/kubeseal-0.17.4-linux-arm64.tar.gz"},
 	}
 	for _, tc := range tests {
 		got, _, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
@@ -3186,25 +3206,25 @@ func Test_DownloadInfluxCli(t *testing.T) {
 		{
 			os:      "windows",
 			arch:    arch64bit,
-			version: "2.0.7",
+			version: "v2.0.7",
 			url:     `https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.0.7-windows-amd64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
-			version: "2.0.7",
+			version: "v2.0.7",
 			url:     `https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.0.7-linux-amd64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
-			version: "2.0.7",
+			version: "v2.0.7",
 			url:     `https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.0.7-linux-arm64.tar.gz`,
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
-			version: "2.0.7",
+			version: "v2.0.7",
 			url:     `https://dl.influxdata.com/influxdb/releases/influxdb2-client-2.0.7-darwin-amd64.tar.gz`,
 		},
 	}
@@ -3219,6 +3239,42 @@ func Test_DownloadInfluxCli(t *testing.T) {
 		}
 	}
 
+}
+
+func Test_DownloadVagrant(t *testing.T) {
+	tools := MakeTools()
+	tool := getTool("vagrant", tools)
+
+	tests := []test{
+		{
+			os:      "linux",
+			arch:    arch64bit,
+			version: "v2.4.9",
+			url:     "https://releases.hashicorp.com/vagrant/2.4.9/vagrant_2.4.9_linux_amd64.zip",
+		},
+		{
+			os:      "darwin",
+			arch:    arch64bit,
+			version: "v2.4.9",
+			url:     "https://releases.hashicorp.com/vagrant/2.4.9/vagrant_2.4.9_darwin_amd64.zip",
+		},
+		{
+			os:      "ming",
+			arch:    arch64bit,
+			version: "v2.4.9",
+			url:     "https://releases.hashicorp.com/vagrant/2.4.9/vagrant_2.4.9_windows_amd64.zip",
+		},
+	}
+
+	for _, tc := range tests {
+		got, _, err := tool.GetURL(tc.os, tc.arch, tc.version, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.url {
+			t.Errorf("want: %s, got: %s", tc.url, got)
+		}
+	}
 }
 
 func Test_DownloadInletsProCli(t *testing.T) {
@@ -3407,36 +3463,54 @@ func Test_DownloadCodex(t *testing.T) {
 
 }
 
-func Test_DownloadKim(t *testing.T) {
+func Test_DownloadKimi(t *testing.T) {
 	tools := MakeTools()
-	name := "kim"
+	name := "kimi"
 
 	tool := getTool(name, tools)
 
 	tests := []test{
 		{
-			os:      "ming",
-			arch:    arch64bit,
-			version: "v0.1.0-alpha.12",
-			url:     `https://github.com/rancher/kim/releases/download/v0.1.0-alpha.12/kim-windows-amd64.exe`,
-		},
-		{
 			os:      "linux",
 			arch:    arch64bit,
-			version: "v0.1.0-alpha.12",
-			url:     `https://github.com/rancher/kim/releases/download/v0.1.0-alpha.12/kim-linux-amd64`,
+			version: "1.49.0",
+			url:     `https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-unknown-linux-gnu.tar.gz`,
+			binary:  "kimi",
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
-			version: "v0.1.0-alpha.12",
-			url:     `https://github.com/rancher/kim/releases/download/v0.1.0-alpha.12/kim-linux-arm64`,
+			version: "1.49.0",
+			url:     `https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-unknown-linux-gnu.tar.gz`,
+			binary:  "kimi",
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
-			version: "v0.1.0-alpha.12",
-			url:     `https://github.com/rancher/kim/releases/download/v0.1.0-alpha.12/kim-darwin-amd64`,
+			version: "1.49.0",
+			url:     `https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-apple-darwin.tar.gz`,
+			binary:  "kimi",
+		},
+		{
+			os:      "darwin",
+			arch:    archDarwinARM64,
+			version: "1.49.0",
+			url:     `https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-aarch64-apple-darwin.tar.gz`,
+			binary:  "kimi",
+		},
+		{
+			os:      "mingw64_nt-10.0-18362",
+			arch:    arch64bit,
+			version: "1.49.0",
+			url:     `https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-pc-windows-msvc.zip`,
+			binary:  "kimi",
+		},
+		{
+			os:      "windows",
+			arch:    arch64bit,
+			version: "1.49.0",
+			url:     `https://github.com/MoonshotAI/kimi-cli/releases/download/1.49.0/kimi-1.49.0-x86_64-pc-windows-msvc.zip`,
+			binary:  "kimi",
 		},
 	}
 
@@ -3448,6 +3522,15 @@ func Test_DownloadKim(t *testing.T) {
 			}
 			if got != tc.url {
 				r.Errorf("\nwant: %s\ngot:  %s", tc.url, got)
+			}
+			if len(tc.binary) > 0 {
+				binary, err := GetBinaryName(tool, tc.os, tc.arch, tc.version)
+				if err != nil {
+					r.Fatal(err)
+				}
+				if binary != tc.binary {
+					r.Errorf("\nwant: %s\ngot:  %s", tc.binary, binary)
+				}
 			}
 		})
 	}
@@ -5001,14 +5084,20 @@ func Test_DownloadKumactl(t *testing.T) {
 		{
 			os:      "darwin",
 			arch:    arch64bit,
-			version: "1.4.1",
-			url:     "https://download.konghq.com/mesh-alpine/kuma-1.4.1-darwin-amd64.tar.gz",
+			version: "v2.14.2",
+			url:     "https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-darwin-amd64/versions/2.14.2/kuma-2.14.2-darwin-amd64.tar.gz",
 		},
 		{
 			os:      "linux",
 			arch:    arch64bit,
-			version: "1.4.1",
-			url:     "https://download.konghq.com/mesh-alpine/kuma-1.4.1-ubuntu-amd64.tar.gz",
+			version: "v2.14.2",
+			url:     "https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-amd64/versions/2.14.2/kuma-2.14.2-linux-amd64.tar.gz",
+		},
+		{
+			os:      "linux",
+			arch:    archARM64,
+			version: "v2.14.2",
+			url:     "https://packages.konghq.com/public/kuma-binaries-release/raw/names/kuma-linux-arm64/versions/2.14.2/kuma-2.14.2-linux-arm64.tar.gz",
 		},
 	}
 
@@ -6701,31 +6790,31 @@ func Test_GrafanaAgent(t *testing.T) {
 			os:      "linux",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-linux-amd64.zip",
+			url:     "https://github.com/grafana-cold-storage/agent/releases/download/v0.31.0/grafana-agent-linux-amd64.zip",
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-linux-arm64.zip",
+			url:     "https://github.com/grafana-cold-storage/agent/releases/download/v0.31.0/grafana-agent-linux-arm64.zip",
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-darwin-amd64.zip",
+			url:     "https://github.com/grafana-cold-storage/agent/releases/download/v0.31.0/grafana-agent-darwin-amd64.zip",
 		},
 		{
 			os:      "darwin",
 			arch:    archDarwinARM64,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-darwin-arm64.zip",
+			url:     "https://github.com/grafana-cold-storage/agent/releases/download/v0.31.0/grafana-agent-darwin-arm64.zip",
 		},
 		{
 			os:      "ming",
 			arch:    arch64bit,
 			version: version,
-			url:     "https://github.com/grafana/agent/releases/download/v0.31.0/grafana-agent-windows-amd64.exe.zip",
+			url:     "https://github.com/grafana-cold-storage/agent/releases/download/v0.31.0/grafana-agent-windows-amd64.exe.zip",
 		},
 	}
 
@@ -7644,31 +7733,31 @@ func Test_DownloadKubeBurner(t *testing.T) {
 			os:      "linux",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-linux-x86_64.tar.gz`,
+			url:     `https://github.com/kube-burner/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-linux-x86_64.tar.gz`,
 		},
 		{
 			os:      "darwin",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-darwin-x86_64.tar.gz`,
+			url:     `https://github.com/kube-burner/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-darwin-x86_64.tar.gz`,
 		},
 		{
 			os:      "linux",
 			arch:    archARM64,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-linux-arm64.tar.gz`,
+			url:     `https://github.com/kube-burner/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-linux-arm64.tar.gz`,
 		},
 		{
 			os:      "darwin",
 			arch:    archDarwinARM64,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-darwin-arm64.tar.gz`,
+			url:     `https://github.com/kube-burner/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-darwin-arm64.tar.gz`,
 		},
 		{
 			os:      "ming",
 			arch:    arch64bit,
 			version: toolVersion,
-			url:     `https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-windows-x86_64.zip`,
+			url:     `https://github.com/kube-burner/kube-burner/releases/download/v1.8.1/kube-burner-V1.8.1-windows-x86_64.zip`,
 		},
 	}
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -223,12 +223,12 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{$fileNa
 	// Claude Code CLI
 	tools = append(tools,
 		Tool{
-			Owner:          "anthropic",
-			Repo:           "claude",
+			Owner:          "anthropics",
+			Repo:           "claude-code",
 			Name:           "claude",
 			Description:    "Claude Code.",
 			VerifyStrategy: ClaudeShasumStrategy,
-			VerifyTemplate: `https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{.Version}}/manifest.json`, VersionStrategy: ClaudeStrategy,
+			VerifyTemplate: `https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{.VersionNumber}}/manifest.json`, VersionStrategy: GitHubVersionStrategy,
 			URLTemplate: `
 {{$os := .OS}}
 {{$arch := .Arch}}
@@ -247,7 +247,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{$fileNa
 {{ $os = "linux" }}
 {{- end -}}
 
-https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{.Version}}/{{$os}}-{{$arch}}/claude
+https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{{.VersionNumber}}/{{$os}}-{{$arch}}/claude
 `})
 
 	// Amp CLI
@@ -593,7 +593,6 @@ https://dl.k8s.io/release/{{.Version}}/bin/{{$os}}/{{$arch}}/kubectl{{$ext}}`})
 			Owner:       "loft-sh",
 			Repo:        "devpod",
 			Name:        "devpod",
-			Version:     "v0.7.0-alpha.34",
 			Description: "Codespaces but open-source, client-only and unopinionated: Works with any IDE and lets you use any cloud, kubernetes or just localhost docker.",
 			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
 {{.Name}}-windows-amd64.exe
@@ -881,10 +880,10 @@ https://github.com/alexellis/kubetrim/releases/download/{{.Version}}/{{$fileName
 	// tool, and there's no way to filter, so the version has to be hard-coded.
 	tools = append(tools,
 		Tool{
-			Owner:       "bitnami-labs",
+			Owner:       "bitnami",
 			Repo:        "sealed-secrets",
 			Name:        "kubeseal",
-			Version:     "v0.30.0",
+			Version:     "v0.38.4",
 			Description: "A Kubernetes controller and tool for one-way encrypted Secrets",
 			BinaryTemplate: `{{$arch := ""}}
 		{{- if eq .Arch "aarch64" -}}
@@ -974,15 +973,19 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "linkerd",
-			Repo:        "linkerd2",
-			Name:        "linkerd2",
-			Version:     "stable-2.9.1",
-			Description: "Ultralight, security-first service mesh for Kubernetes.",
+			Owner:           "linkerd",
+			Repo:            "linkerd2",
+			Name:            "linkerd2",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "Ultralight, security-first service mesh for Kubernetes.",
 			BinaryTemplate: `{{ if HasPrefix .OS "ming" -}}
 {{.Name}}-cli-{{.Version}}-windows.exe
 {{- else if eq .OS "darwin" -}}
+{{- if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+{{.Name}}-cli-{{.Version}}-darwin-arm64
+{{- else -}}
 {{.Name}}-cli-{{.Version}}-darwin
+{{- end -}}
 {{- else if eq .Arch "x86_64" -}}
 {{.Name}}-cli-{{.Version}}-linux-amd64
 {{- else if eq .Arch "aarch64" -}}
@@ -993,12 +996,12 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "kubernetes-sigs",
-			Repo:        "kubebuilder",
-			Name:        "kubebuilder",
-			NoExtension: true,
-			Version:     "3.1.0",
-			Description: "Framework for building Kubernetes APIs using custom resource definitions (CRDs).",
+			Owner:           "kubernetes-sigs",
+			Repo:            "kubebuilder",
+			Name:            "kubebuilder",
+			NoExtension:     true,
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "Framework for building Kubernetes APIs using custom resource definitions (CRDs).",
 			URLTemplate: `{{$arch := "arm64"}}
 			{{- if eq .Arch "x86_64" -}}
 			{{$arch = "amd64"}}
@@ -1010,7 +1013,7 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			{{- else if eq .OS "darwin" -}}
 			{{$osStr = "darwin"}}
 			{{- end -}}
-			https://github.com/kubernetes-sigs/kubebuilder/releases/download/v{{.Version}}/kubebuilder_{{$osStr}}_{{$arch}}`,
+			https://github.com/kubernetes-sigs/kubebuilder/releases/download/v{{.VersionNumber}}/kubebuilder_{{$osStr}}_{{$arch}}`,
 		})
 
 	tools = append(tools,
@@ -1019,7 +1022,6 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
 			Repo:        "kustomize",
 			Name:        "kustomize",
 			Description: "Customization of kubernetes YAML configurations",
-			Version:     "v5.0.3",
 			BinaryTemplate: `
 	{{$osStr := ""}}
 	{{$ext := "tar.gz"}}
@@ -1030,7 +1032,11 @@ https://github.com/inlets/inletsctl/releases/download/{{.Version}}/{{$fileName}}
   {{$osStr = "linux_arm64"}}
 	{{- end -}}
 	{{- else if eq .OS "darwin" -}}
+	{{- if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+	{{$osStr = "darwin_arm64"}}
+	{{- else -}}
 	{{$osStr = "darwin_amd64"}}
+	{{- end -}}
 	{{- end -}}
 	{{ if HasPrefix .OS "ming" -}}
 	{{$osStr = "windows_amd64"}}
@@ -1381,11 +1387,11 @@ https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.Version
 
 	tools = append(tools,
 		Tool{
-			Owner:       "opentofu",
-			Repo:        "opentofu",
-			Name:        "tofu",
-			Version:     "v1.6.2",
-			Description: "OpenTofu lets you declaratively manage your cloud infrastructure",
+			Owner:           "opentofu",
+			Repo:            "opentofu",
+			Name:            "tofu",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "OpenTofu lets you declaratively manage your cloud infrastructure",
 			BinaryTemplate: `
 			{{$extStr := ".zip"}}
 
@@ -1410,11 +1416,11 @@ https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.Version
 
 	tools = append(tools,
 		Tool{
-			Owner:       "hashicorp",
-			Repo:        "vagrant",
-			Name:        "vagrant",
-			Version:     "2.2.19",
-			Description: "Tool for building and distributing development environments.",
+			Owner:           "hashicorp",
+			Repo:            "vagrant",
+			Name:            "vagrant",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "Tool for building and distributing development environments.",
 			URLTemplate: `{{$arch := .Arch}}
 
 	{{- if eq .Arch "x86_64" -}}
@@ -1428,7 +1434,7 @@ https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.Version
 	{{$os = "windows"}}
 	{{- end -}}
 
-	https://releases.hashicorp.com/{{.Name}}/{{.Version}}/{{.Name}}_{{.Version}}_{{$os}}_{{$arch}}.zip`})
+	https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.VersionNumber}}_{{$os}}_{{$arch}}.zip`})
 
 	tools = append(tools,
 		Tool{
@@ -2140,34 +2146,33 @@ https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.Version
 			{{.Name}}{{$os}}{{$arch}}{{$ext}}`,
 		})
 
+	// kim is no longer maintained (last release Oct 2021), removed from arkade.
+
 	tools = append(tools,
 		Tool{
-			Owner:       "rancher",
-			Repo:        "kim",
-			Name:        "kim",
-			Version:     "v0.1.0-beta.4",
-			Description: "Build container images inside of Kubernetes. (Experimental)",
-			BinaryTemplate: `
-			{{ $ext := "" }}
-			{{ $osStr := "linux" }}
-			{{ if HasPrefix .OS "ming" -}}
-			{{	$osStr = "windows" }}
-			{{ $ext = ".exe" }}
-			{{- else if eq .OS "darwin" -}}
-			{{  $osStr = "darwin" }}
-			{{- end -}}
-
-			{{ $archStr := "amd64" }}
-
-			{{- if eq .Arch "armv6l" -}}
-			{{ $archStr = "arm" }}
-			{{- else if eq .Arch "armv7l" -}}
-			{{ $archStr = "arm" }}
-			{{- else if eq .Arch "aarch64" -}}
-			{{ $archStr = "arm64" }}
-			{{- end -}}
-
-			{{.Name}}-{{$osStr}}-{{$archStr}}{{$ext}}`,
+			Owner:       "MoonshotAI",
+			Repo:        "kimi-cli",
+			Name:        "kimi",
+			Description: "CLI for the Kimi AI assistant.",
+			URLTemplate: `
+{{$arch := .Arch}}
+{{- if or (eq .Arch "x86_64") (eq .Arch "amd64") -}}
+{{$arch = "x86_64"}}
+{{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+{{$arch = "aarch64"}}
+{{- end -}}
+{{$os := .OS}}
+{{$ext := "tar.gz"}}
+{{- if or (HasPrefix .OS "ming") (eq .OS "windows") -}}
+{{$os = "pc-windows-msvc"}}
+{{$ext = "zip"}}
+{{- else if eq .OS "darwin" -}}
+{{$os = "apple-darwin"}}
+{{- else if eq .OS "linux" -}}
+{{$os = "unknown-linux-gnu"}}
+{{- end -}}
+https://github.com/MoonshotAI/kimi-cli/releases/download/{{.Version}}/kimi-{{.Version}}-{{$arch}}-{{$os}}.{{$ext}}`,
+			BinaryTemplate: `kimi`,
 		},
 	)
 
@@ -2288,11 +2293,11 @@ https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.Version
 		})
 	tools = append(tools,
 		Tool{
-			Owner:       "influxdata",
-			Repo:        "influxdb",
-			Name:        "influx",
-			Version:     "2.0.8",
-			Description: "InfluxDB's command line interface (influx) is an interactive shell for the HTTP API.",
+			Owner:           "influxdata",
+			Repo:            "influx-cli",
+			Name:            "influx",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "InfluxDB's command line interface (influx) is an interactive shell for the HTTP API.",
 			URLTemplate: `{{$arch := .Arch}}
 		{{ if eq .Arch "x86_64" -}}
 		{{$arch = "amd64"}}
@@ -2305,7 +2310,7 @@ https://releases.hashicorp.com/{{.Name}}/{{.VersionNumber}}/{{.Name}}_{{.Version
 		{{$ext = ".zip"}}
 		{{- end -}}
 
-				https://dl.{{.Owner}}.com/{{.Repo}}/releases/{{.Repo}}2-client-{{.Version}}-{{.OS}}-{{$arch}}{{$ext}}`,
+				https://dl.influxdata.com/influxdb/releases/influxdb2-client-{{.VersionNumber}}-{{.OS}}-{{$arch}}{{$ext}}`,
 		})
 
 	tools = append(tools,
@@ -2408,6 +2413,8 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				`,
 		})
 
+	// johanhaleby/kubetail is a raw script rather than a release binary.
+	// Its download URL needs a tag, so leave this version pinned.
 	tools = append(tools,
 		Tool{
 			Owner:       "johanhaleby",
@@ -2444,7 +2451,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Owner:       "getporter",
 			Repo:        "porter",
 			Name:        "porter",
-			Version:     "v0.38.4",
 			Description: "With Porter you can package your application artifact, tools, etc. as a bundle that can distribute and install.",
 			BinaryTemplate: `
 			{{ $ext := "" }}
@@ -2457,6 +2463,9 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			{{- end -}}
 
 			{{ $archStr := "amd64" }}
+			{{- if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+			{{ $archStr = "arm64" }}
+			{{- end -}}
 			{{.Name}}-{{$osStr}}-{{$archStr}}{{$ext}}`,
 		})
 	tools = append(tools,
@@ -2622,7 +2631,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Owner:       "aquasecurity",
 			Repo:        "tfsec",
 			Name:        "tfsec",
-			Version:     "v0.57.1",
 			Description: "Security scanner for your Terraform code",
 			BinaryTemplate: `{{ $ext := "" }}
 				{{ $osStr := "linux" }}
@@ -2634,7 +2642,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 				{{- end -}}
 
 				{{ $archStr := "amd64" }}
-				{{- if eq .Arch "aarch64" -}}
+				{{- if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
 				{{ $archStr = "arm64" }}
 				{{- end -}}
 				{{.Name}}-{{$osStr}}-{{$archStr}}{{$ext}}`,
@@ -2948,26 +2956,28 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "kumahq",
-			Repo:        "kuma",
-			Name:        "kumactl",
-			Version:     "1.4.1",
-			Description: "kumactl is a CLI to interact with Kuma and its data",
+			Owner:           "kumahq",
+			Repo:            "kuma",
+			Name:            "kumactl",
+			VersionStrategy: GitHubVersionStrategy,
+			Description:     "kumactl is a CLI to interact with Kuma and its data",
 			URLTemplate: `
 			{{$osStr := ""}}
 			{{$archStr := ""}}
 			{{- if HasPrefix .OS "linux" -}}
-			{{$osStr = "ubuntu"}}
+			{{$osStr = "linux"}}
 			{{- else if eq .OS "darwin" -}}
 			{{$osStr = "darwin"}}
 			{{- end -}}
 
 			{{- if eq .Arch "x86_64" -}}
 			{{$archStr = "amd64"}}
+			{{- else if or (eq .Arch "aarch64") (eq .Arch "arm64") -}}
+			{{$archStr = "arm64"}}
 			{{- else -}}
 			{{$archStr = .Arch}}
 			{{- end -}}
-			https://download.konghq.com/mesh-alpine/{{.Repo}}-{{.Version}}-{{$osStr}}-{{$archStr}}.tar.gz`,
+			https://packages.konghq.com/public/kuma-binaries-release/raw/names/{{.Repo}}-{{$osStr}}-{{$archStr}}/versions/{{.VersionNumber}}/{{.Repo}}-{{.VersionNumber}}-{{$osStr}}-{{$archStr}}.tar.gz`,
 			BinaryTemplate: `{{.Name}}`,
 		})
 
@@ -3694,7 +3704,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Owner:       "instrumenta",
 			Repo:        "kubeval",
 			Name:        "kubeval",
-			Version:     "v0.16.1",
 			Description: "Validate your Kubernetes configuration files, supports multiple Kubernetes versions",
 			BinaryTemplate: `
 				{{$os := .OS}}
@@ -3810,9 +3819,11 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			BinaryTemplate: `{{.Name}}-{{.Version}}`,
 		})
 
+	// grafana-agent repo moved from grafana/agent to grafana-cold-storage/agent.
+	// v0.44.3 (latest) has no binaries, only source archives, so pinned at v0.44.2.
 	tools = append(tools,
 		Tool{
-			Owner:       "grafana",
+			Owner:       "grafana-cold-storage",
 			Repo:        "agent",
 			Name:        "grafana-agent",
 			Version:     "v0.44.2",
@@ -3855,7 +3866,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 
 						{{ if HasPrefix .OS "ming" -}}
 						{{$os = "windows"}}
-						{{$ext = ".exe"}}
 						{{- end -}}
 						grafana-agent-{{$os}}-{{$arch}}{{$ext}}
 						`,
@@ -4288,10 +4298,9 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 
 	tools = append(tools,
 		Tool{
-			Owner:       "cloud-bulldozer",
+			Owner:       "kube-burner",
 			Repo:        "kube-burner",
 			Name:        "kube-burner",
-			Version:     "v1.8.1",
 			Description: "A tool aimed at stressing Kubernetes clusters by creating or deleting a high quantity of objects.",
 			BinaryTemplate: `
  					{{$os := .OS}}
@@ -4307,15 +4316,15 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 						{{$ext = "zip"}}
  					{{- end -}}
 
- 					{{- if eq .Arch "aarch64" -}}
- 						{{$arch = "arm64"}}
- 					{{- else if eq .Arch "arm64" -}}
- 						{{ $arch = "arm64" }}
- 					{{- else if eq .Arch "x86_64" -}}
- 						{{ $arch = "x86_64" }}
- 					{{- end -}}
+					{{- if eq .Arch "aarch64" -}}
+						{{$arch = "arm64"}}
+					{{- else if eq .Arch "arm64" -}}
+						{{ $arch = "arm64" }}
+					{{- else if eq .Arch "x86_64" -}}
+						{{$arch = "x86_64"}}
+					{{- end -}}
 
- 					{{.Name}}-V{{.VersionNumber}}-{{$os}}-{{$arch}}.{{$ext}}
+					{{.Name}}-V{{.VersionNumber}}-{{$os}}-{{$arch}}.{{$ext}}
  					`,
 		})
 
@@ -5157,7 +5166,6 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Owner:           "grafana",
 			Repo:            "alloy",
 			Name:            "alloy",
-			Version:         "v1.17.1",
 			VersionStrategy: GitHubVersionStrategy,
 			Description:     "OpenTelemetry Collector distribution with programmable pipelines",
 			URLTemplate: `


### PR DESCRIPTION
## What changed

- Resolve unpinned tools from GitHub's `/releases/latest` HTML redirect, including tools whose binaries are served from HashiCorp, InfluxData, Kong, Grafana, or Google CDNs.
- Remove stale pins and update moved repositories for DevPod, Linkerd, Kubebuilder, Kustomize, OpenTofu, Vagrant, Porter, tfsec, Kuma, kubeval, kube-burner, Alloy, Influx CLI, Claude Code, and Kimi.
- Remove the obsolete Rancher `kim` entry and add MoonshotAI Kimi CLI.
- Keep and document the remaining pins:
  - kubeseal: mixed release streams in the upstream repository.
  - johanhaleby/kubetail: raw shell script requiring a tag; this remains the original log tailer.
  - grafana-agent: latest moved repository release has no binaries.
- Stop retrying malformed URL parse errors as if they were transient server failures.
- Correct ARM and native-Windows asset selection, CDN paths, archive extraction, and version-number normalisation.

## HashiCorp and CDN versioning

HashiCorp tools use GitHub tags for version discovery and HashiCorp CDN paths for downloads. GitHub's leading `v` is removed for CDN paths. The custom HashiCorp API strategy is not used.

Claude Code now uses `anthropics/claude-code` GitHub releases for version discovery while retaining its GCS download and manifest verification.

## Validation

- `make e2e` — passed, 48.7% coverage.
- `go test ./...` — passed.
- Independent read-only Codex sub-agent review — approved after fixing OpenTofu version resolution and native-Windows Kimi URL generation.
- `gofmt -l pkg/get/get.go pkg/get/get_test.go pkg/get/tools.go` — clean.
- `git diff --check` — clean.
- `hack/test-tool.sh` sequential multi-architecture verification completed for all touched tools.

Available targets produced correctly typed binaries/scripts, including:

- Mach-O arm64/x86_64
- ELF x86-64/ARM aarch64
- PE32+ Windows x86-64
- Original kubetail produced its Bourne-Again shell script on all probes.

Expected upstream 404s:

- Vagrant: only Linux amd64 is published.
- Kustomize and Kubebuilder: no Windows asset.
- Influx CLI: no Darwin arm64 or Windows asset.
- Kuma: no Windows asset.
- kubeval: no Darwin arm64 or Linux arm64 asset.
- Claude Code CDN: no Windows asset.

No wrong-architecture fallback remains for the verified combinations.
