### PR TITLE
Make actions-runner archive-only scriptable

### DIFF
--- a/cmd/system/actions_runner.go
+++ b/cmd/system/actions_runner.go
@@ -5,6 +5,7 @@ package system
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -43,7 +44,7 @@ func MakeInstallActionsRunner() *cobra.Command {
 	command.Flags().Bool("progress", true, "Show download progress")
 	command.Flags().String("arch", "", "CPU architecture i.e. x86_64 or arm64")
 	command.Flags().String("os", "", "Operating system i.e. linux or darwin, leave blank to detect the client OS")
-	command.Flags().BoolP("archive-only", "a", false, "Only download the archive and do not unpack it")
+	command.Flags().BoolP("archive-only", "a", false, "Only download the archive and do not unpack it, prints the archive path to stdout")
 	command.Flags().Bool("print-version", false, "Print the resolved version to stdout and exit")
 
 	command.PreRunE = func(cmd *cobra.Command, args []string) error {
@@ -54,6 +55,12 @@ func MakeInstallActionsRunner() *cobra.Command {
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		installPath, _ := cmd.Flags().GetString("path")
 		version, _ := cmd.Flags().GetString("version")
+
+		archiveOnly, _ := cmd.Flags().GetBool("archive-only")
+		out := io.Writer(os.Stdout)
+		if archiveOnly {
+			out = os.Stderr
+		}
 
 		if version == "" {
 			v, err := get.FindGitHubRelease("actions", "runner")
@@ -70,12 +77,12 @@ func MakeInstallActionsRunner() *cobra.Command {
 			return nil
 		}
 
-		fmt.Printf("Installing Actions Runner to %s\n", installPath)
+		fmt.Fprintf(out, "Installing Actions Runner to %s\n", installPath)
 
 		installPath = strings.ReplaceAll(installPath, "$HOME", os.Getenv("HOME"))
 
 		if err := os.MkdirAll(installPath, 0755); err != nil && !os.IsExist(err) {
-			fmt.Printf("Error creating directory %s, error: %s\n", installPath, err.Error())
+			fmt.Fprintf(out, "Error creating directory %s, error: %s\n", installPath, err.Error())
 		}
 
 		arch, osVer := env.GetClientArch()
@@ -106,11 +113,11 @@ func MakeInstallActionsRunner() *cobra.Command {
 			dlArch = "arm"
 		}
 
-		fmt.Printf("Installing version: %s for: %s / %s\n", version, dlOS, dlArch)
+		fmt.Fprintf(out, "Installing version: %s for: %s / %s\n", version, dlOS, dlArch)
 
 		filename := fmt.Sprintf("actions-runner-%s-%s-%s.tar.gz", dlOS, dlArch, strings.TrimPrefix(version, "v"))
 		dlURL := fmt.Sprintf(githubDownloadTemplate, "actions", "runner", version, filename)
-		fmt.Printf("Downloading from: %s\n", dlURL)
+		fmt.Fprintf(out, "Downloading from: %s\n", dlURL)
 
 		progress, _ := cmd.Flags().GetBool("progress")
 		outPath, err := get.DownloadFileP(dlURL, progress)
@@ -119,15 +126,14 @@ func MakeInstallActionsRunner() *cobra.Command {
 		}
 		defer os.Remove(outPath)
 
-		fmt.Printf("Downloaded to: %s\n", outPath)
+		fmt.Fprintf(out, "Downloaded to: %s\n", outPath)
 
-		archiveOnly, _ := cmd.Flags().GetBool("archive-only")
 		if archiveOnly {
 			dest := path.Join(installPath, filename)
-			if _, err := get.CopyFile(outPath, dest); err != nil {
+			if _, err := get.CopyFileP(outPath, dest, readWriteExecuteEveryone); err != nil {
 				return err
 			}
-			fmt.Printf("Saved archive to: %s\n", dest)
+			fmt.Println(dest)
 			return nil
 		}
 


### PR DESCRIPTION
## Description

Follow-up to #1268. Makes `arkade system install actions-runner
--archive-only` scriptable: in archive-only mode nothing is printed to
stdout except the path of the downloaded archive, e.g.

```
cp "$(arkade system install actions-runner --archive-only)" ./path
```

All informational messages and download progress go to stderr
(download progress was already on stderr). Normal installs are
unchanged.

Also saves the archive with 0755 permissions instead of the 0700 that
`CopyFile` applied by default, so the tarball stays usable after the
command exits.

`--print-version` already printed only the resolved version to stdout;
the flag description for `--archive-only` now documents the stdout
behavior.

## Motivation and Context

An agent or script needs to fetch the runner archive and reference the
downloaded path without scraping output.

- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Built with `go build`, `go vet ./cmd/system/`, `gofmt -l` clean.

Tested on a fresh Slicer VM (e2e-10, Ubuntu x86_64) running as root:

```
# stdout carries only the archive path
$ arkade system install actions-runner --archive-only --path /opt/ar
/opt/ar/actions-runner-linux-x64-2.336.0.tar.gz

# capture pattern
$ cp "$(arkade system install actions-runner --archive-only --path /opt/ar 2>/dev/null)" /tmp/runner.tar.gz

# print-version
$ arkade system install actions-runner --print-version 2>/dev/null
2.336.0

# darwin / arm64 / short flag simulated
$ arkade system install actions-runner --os darwin --arch arm64 --archive-only --path /opt/ar
/opt/ar/actions-runner-osx-arm64-2.336.0.tar.gz

$ arkade system install actions-runner --os darwin --arch x86_64 -a --path /opt/ar
/opt/ar/actions-runner-osx-x64-2.336.0.tar.gz
```

All archives verified as gzip by magic bytes; saved archives are mode
0755. Full install (non-archive) behaviour unchanged.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [x] I have tested this on arm, or have added code to prevent deployment
