### PR TITLE
Support Prometheus and GitLab Runner on macOS

### DIFF
--- a/cmd/system/actions_runner.go
+++ b/cmd/system/actions_runner.go
@@ -19,9 +19,10 @@ import (
 func MakeInstallActionsRunner() *cobra.Command {
 
 	command := &cobra.Command{
-		Use:   "actions-runner",
-		Short: "Install GitHub Actions Runner",
-		Long:  `Install GitHub Actions Runner for self-hosted CI.`,
+		Use:     "actions-runner",
+		Short:   "Install GitHub Actions Runner",
+		Long:    `Install GitHub Actions Runner for self-hosted CI.`,
+		Aliases: []string{"github"},
 		Example: `  # Install actions-runner to the default directory
   arkade system install actions-runner
 

--- a/cmd/system/gitlab_runner.go
+++ b/cmd/system/gitlab_runner.go
@@ -16,18 +16,26 @@ import (
 
 func MakeInstallGitLabRunner() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "gitlab-runner",
-		Short: "Install GitLab Runner",
-		Long:  `Install GitLab Runner for self-hosted CI.`,
-		Example: `  arkade system install gitlab-runner
-  arkade system install gitlab-runner --version <version>`,
+		Use:     "gitlab-runner",
+		Short:   "Install GitLab Runner",
+		Long:    `Install GitLab Runner for self-hosted CI.`,
+		Aliases: []string{"gitlab"},
+		Example: `  # Install GitLab Runner to the default path
+  arkade system install gitlab-runner
+
+  # Install a specific version
+  arkade system install gitlab-runner --version <version>
+
+  # Install on macOS
+  arkade system install gitlab-runner --os darwin --arch arm64`,
 		SilenceUsage: true,
 	}
 
 	command.Flags().StringP("version", "v", "", "The version or leave blank to determine the latest available version")
 	command.Flags().String("path", "$HOME/gitlab-runner", "Installation path, where gitlab-runner binary file is downloaded")
 	command.Flags().Bool("progress", true, "Show download progress")
-	command.Flags().String("arch", "", "CPU architecture i.e. amd64")
+	command.Flags().String("arch", "", "CPU architecture i.e. x86_64 or arm64")
+	command.Flags().String("os", "", "Operating system i.e. linux or darwin, leave blank to detect the client OS")
 
 	command.PreRunE = func(cmd *cobra.Command, args []string) error {
 		return nil
@@ -42,12 +50,17 @@ func MakeInstallGitLabRunner() *cobra.Command {
 
 		arch, osVer := env.GetClientArch()
 
-		if strings.ToLower(osVer) != "linux" {
-			return fmt.Errorf("this app only supports Linux")
+		if cmd.Flags().Changed("os") {
+			osVer, _ = cmd.Flags().GetString("os")
 		}
 
 		if cmd.Flags().Changed("arch") {
 			arch, _ = cmd.Flags().GetString("arch")
+		}
+
+		dlOS := strings.ToLower(osVer)
+		if dlOS != "linux" && dlOS != "darwin" {
+			return fmt.Errorf("unsupported operating system: %q, use linux or darwin (macOS)", osVer)
 		}
 
 		dlArch := arch
@@ -65,9 +78,9 @@ func MakeInstallGitLabRunner() *cobra.Command {
 			version = "v" + version
 		}
 
-		fmt.Printf("Installing version: %s for: %s\n", version, dlArch)
+		fmt.Printf("Installing version: %s for: %s / %s\n", version, dlOS, dlArch)
 
-		dlURL := fmt.Sprintf("https://gitlab-runner-downloads.s3.amazonaws.com/%s/binaries/gitlab-runner-linux-%s", version, dlArch)
+		dlURL := fmt.Sprintf("https://gitlab-runner-downloads.s3.amazonaws.com/%s/binaries/gitlab-runner-%s-%s", version, dlOS, dlArch)
 
 		fmt.Printf("Downloading from: %s\n", dlURL)
 

--- a/cmd/system/prometheus.go
+++ b/cmd/system/prometheus.go
@@ -13,45 +13,35 @@ import (
 
 func MakeInstallPrometheus() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "prometheus",
-		Short: "Install Prometheus",
-		Long:  `Install the Prometheus monitoring system and time series database.`,
-		Example: `  arkade system install prometheus
-  arkade system install prometheus --version v2.34.0`,
+		Use:     "prometheus",
+		Short:   "Install Prometheus",
+		Long:    `Install the Prometheus monitoring system and time series database.`,
+		Aliases: []string{"prom"},
+		Example: `  # Install Prometheus to the default path
+  arkade system install prometheus
+
+  # Install a specific version
+  arkade system install prometheus --version v2.34.0
+
+  # Install on macOS
+  arkade system install prometheus --os darwin --arch arm64
+
+  # Print the resolved version to stdout and exit
+  arkade system install prometheus --print-version`,
 		SilenceUsage: true,
 	}
 
 	command.Flags().StringP("version", "v", "latest", "The version for Prometheus to install")
-	command.Flags().StringP("path", "p", "/usr/local/bin", "Installation path, where a go subfolder will be created")
+	command.Flags().StringP("path", "p", "/usr/local/bin", "Installation path for the prometheus and promtool binaries")
 	command.Flags().Bool("progress", true, "Show download progress")
-	command.Flags().String("arch", "", "CPU architecture i.e. amd64")
+	command.Flags().String("arch", "", "CPU architecture i.e. x86_64 or arm64")
+	command.Flags().String("os", "", "Operating system i.e. linux or darwin, leave blank to detect the client OS")
+	command.Flags().Bool("print-version", false, "Print the resolved version to stdout and exit")
 
 	command.RunE = func(cmd *cobra.Command, args []string) error {
 		installPath, _ := cmd.Flags().GetString("path")
 		version, _ := cmd.Flags().GetString("version")
 		progress, _ := cmd.Flags().GetBool("progress")
-
-		fmt.Printf("Installing Prometheus to %s\n", installPath)
-
-		if err := os.MkdirAll(installPath, 0755); err != nil && !os.IsExist(err) {
-			fmt.Printf("Error creating directory %s, error: %s\n", installPath, err.Error())
-		}
-
-		arch, osVer := env.GetClientArch()
-
-		if strings.ToLower(osVer) != "linux" {
-			return fmt.Errorf("this app only supports Linux")
-		}
-		if cmd.Flags().Changed("arch") {
-			arch, _ = cmd.Flags().GetString("arch")
-		}
-
-		dlArch := arch
-		if arch == "x86_64" {
-			dlArch = "amd64"
-		} else if arch == "aarch64" {
-			dlArch = "arm64"
-		}
 
 		if version == "latest" {
 			v, err := get.FindGitHubRelease("prometheus", "prometheus")
@@ -63,9 +53,41 @@ func MakeInstallPrometheus() *cobra.Command {
 			version = "v" + version
 		}
 
-		fmt.Printf("Installing version: %s for: %s\n", version, dlArch)
+		if printVersion, _ := cmd.Flags().GetBool("print-version"); printVersion {
+			fmt.Println(strings.TrimPrefix(version, "v"))
+			return nil
+		}
 
-		filename := fmt.Sprintf("prometheus-%s.linux-%s.tar.gz", strings.TrimPrefix(version, "v"), dlArch)
+		fmt.Printf("Installing Prometheus to %s\n", installPath)
+
+		if err := os.MkdirAll(installPath, 0755); err != nil && !os.IsExist(err) {
+			fmt.Printf("Error creating directory %s, error: %s\n", installPath, err.Error())
+		}
+
+		arch, osVer := env.GetClientArch()
+
+		if cmd.Flags().Changed("os") {
+			osVer, _ = cmd.Flags().GetString("os")
+		}
+		if cmd.Flags().Changed("arch") {
+			arch, _ = cmd.Flags().GetString("arch")
+		}
+
+		dlOS := strings.ToLower(osVer)
+		if dlOS != "linux" && dlOS != "darwin" {
+			return fmt.Errorf("unsupported operating system: %q, use linux or darwin (macOS)", osVer)
+		}
+
+		dlArch := arch
+		if arch == "x86_64" {
+			dlArch = "amd64"
+		} else if arch == "aarch64" {
+			dlArch = "arm64"
+		}
+
+		fmt.Printf("Installing version: %s for: %s / %s\n", version, dlOS, dlArch)
+
+		filename := fmt.Sprintf("prometheus-%s.%s-%s.tar.gz", strings.TrimPrefix(version, "v"), dlOS, dlArch)
 		dlURL := fmt.Sprintf(githubDownloadTemplate, "prometheus", "prometheus", version, filename)
 
 		fmt.Printf("Downloading from: %s\n", dlURL)


### PR DESCRIPTION
## Description

Adds macOS support to a couple of `arkade system install` apps, plus
convenience aliases.

### prometheus
- Allows installs on macOS (`prometheus-<ver>.darwin-<arch>.tar.gz`),
  with a new `--os` flag to simulate.
- Adds `--print-version` which resolves the version (when `latest`) and
  prints it to stdout before exiting, for external tooling.
- Adds `prom` as an alias.

### gitlab-runner
- Allows installs on macOS (`gitlab-runner-darwin-{amd64,arm64}` from
  the S3 download host), with `--os` to simulate.
- Adds `gitlab` as an alias.

### actions-runner
- Adds `github` as an alias (drop the `-runner` suffix).

## Motivation and Context

We need these runners/monitoring tools installable on macOS for use in
actuated going forward, and the `--print-version` pattern from
actions-runner is useful for products that track versions on a timer.

- [ ] I have raised an issue to propose this change, which has been given a label of `design/approved` by a maintainer ([required](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Built with `go build`, `go vet ./cmd/system/`, `gofmt -l` clean.

Tested on a fresh Slicer VM (e2e-11, Ubuntu x86_64) running as root.
Binary format verified with magic bytes:

| Test | Result |
|------|--------|
| `prom --print-version` | stdout `3.13.2`, stderr empty |
| prom darwin arm64 / x86_64 install | Mach-O (`prometheus`/`promtool`) |
| prom linux amd64 (pinned 2.34.0) | ELF, no regression |
| prom `--os windows` | exits 1 |
| gitlab-runner linux amd64 | ELF |
| gitlab-runner darwin arm64 / x86_64 | Mach-O |
| aliases `github`, `gitlab`, `prom` | resolve to the correct commands |

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation

- [ ] I have updated the list of tools in README.md if (required) with `./arkade get --format markdown`
- [ ] I have updated the list of apps in README.md if (required) with `./arkade install --help`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/arkade/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`

<!--- For "arkade install" or "arkade system install" -->
- [x] I have tested this on arm, or have added code to prevent deployment
