### PR TITLE
Boot a repo release from v0.0.0 when no tags exist

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -347,7 +347,7 @@ func latestReleaseTag(ctx context.Context) (string, error) {
 
 	tag := strings.TrimSpace(res.Stdout)
 	if tag == "" {
-		return "", fmt.Errorf("no releases found in this repository")
+		return "v0.0.0", nil
 	}
 
 	return tag, nil


### PR DESCRIPTION
## Why

When a repository has no releases yet, `arkade rel` previously failed
with "no releases found in this repository". A repo being booted needs to
be able to create its first release. By treating the empty result as
`v0.0.0`, the normal bump logic produces `v0.0.1` for the first release.

## What

In `latestReleaseTag()`, return `v0.0.0` instead of an error when `gh`
returns an empty tag list. This lets `resolveNewTag()` / `bumpVersion()`
bump to the next patch version as usual. Genuine `gh` failures still error.

## Verification

Tested against a throwaway private repo in alexellis' account (deleted
afterwards):

```
Private repo detected.
Would create release:
  Tag:        v0.0.1
  Title:      Initial test commit
  Bump:       patch
  Notes:      (none)
  Prerelease: false
  Latest:     true

Private repo detected.
exec:  gh release create v0.0.1 ...
Created release: v0.0.1

# After the release exists, bump is now correct
Private repo detected.
Would create release:
  Tag:        v0.0.2
  ...
```

Confirmed both the first-release bootstrap (v0.0.1) and the subsequent
bump (v0.0.2) work.

Checklist:
- [x] commit signed off
- [x] go build passes
- [x] go test ./cmd/... passes
- [x] e2e verified (manual, private repo)