### PR TITLE
Add arkade oci publish, the inverse of oci install

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,25 @@ Options:
 * `--version` - the version of the package to extract, if not specified the `:latest` tag is used
 * `--arch` - the architecture to extract, if not specified the host's architecture is used
 
+## Publish to OCI images
+
+`arkade oci publish` is the inverse of `install`: it bundles a directory (or a set of pre-built tarballs) into an OCI image and pushes it to a registry. Tags follow `docker build`/`buildx` syntax, one `-t` per identifier.
+
+```bash
+# Publish ./dist as a single layer to one tag
+arkade oci publish ./dist -t ghcr.io/me/app:0.1.0
+
+# Multiple tags, one -t each
+arkade oci publish ./dist -t ghcr.io/me/app:0.1.0 -t ghcr.io/me/app:latest
+
+# Multi-arch index from pre-built tarballs
+arkade oci publish -t ghcr.io/me/app:0.1.0 \
+  --bundle linux/amd64=./app-amd64.tgz \
+  --bundle linux/arm64=./app-arm64.tgz
+```
+
+Credentials come from your local Docker keychain (what `docker login` writes). On GitHub Actions, the `docker/login-action` step populates that keychain for ghcr.io, and anonymous registries like `ttl.sh` need no login. Writing over an existing tag simply re-points it — old layers are left for the registry's garbage collector.
+
 ## Install CLIs during CI with GitHub Actions
 
 * [alexellis/arkade-get@master](https://github.com/alexellis/arkade-get)

--- a/cmd/oci/oci.go
+++ b/cmd/oci/oci.go
@@ -25,6 +25,7 @@ func MakeOci() *cobra.Command {
 	}
 
 	command.AddCommand(MakeOciInstall())
+	command.AddCommand(MakeOciPublish())
 
 	return command
 }

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -219,8 +219,15 @@ func buildImageFromDir(dir string) (v1.Image, func(), error) {
 
 func tarDir(dir string, w io.Writer) error {
 	tw := tar.NewWriter(w)
+	// Canonicalize the source root once so containment checks against
+	// resolved symlink targets work even when the source directory itself
+	// is a symlink (e.g. /tmp/dist-link -> /mnt/build/dist).
+	realRoot, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return err
+	}
 	visited := make(map[string]bool)
-	if err := addDirToTar(tw, dir, dir, "", visited); err != nil {
+	if err := addDirToTar(tw, realRoot, dir, "", visited); err != nil {
 		return err
 	}
 	return tw.Close()

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -147,6 +147,9 @@ func splitImage(image string) (repo, tag string, hasTag bool, err error) {
 	if err != nil {
 		return "", "", false, fmt.Errorf("parsing image %s: %w", image, err)
 	}
+	if _, ok := ref.(name.Digest); ok {
+		return "", "", false, fmt.Errorf("digest references are not valid publish tags: %s", image)
+	}
 	repo = ref.Context().Name()
 	if t, ok := ref.(name.Tag); ok {
 		lastSlash := strings.LastIndex(image, "/")

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -219,13 +219,26 @@ func buildImageFromDir(dir string) (v1.Image, func(), error) {
 
 func tarDir(dir string, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	if err := addDirToTar(tw, dir, dir, ""); err != nil {
+	visited := make(map[string]bool)
+	if err := addDirToTar(tw, dir, dir, "", visited); err != nil {
 		return err
 	}
 	return tw.Close()
 }
 
-func addDirToTar(tw *tar.Writer, root, dir, relPrefix string) error {
+func addDirToTar(tw *tar.Writer, root, dir, relPrefix string, visited map[string]bool) error {
+	// Resolve to the real path so symlinked directories that cycle back
+	// into the source tree are caught instead of recursing forever.
+	realDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return err
+	}
+	if visited[realDir] {
+		return fmt.Errorf("directory cycle detected at %s", dir)
+	}
+	visited[realDir] = true
+	defer delete(visited, realDir)
+
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return err
@@ -259,7 +272,7 @@ func addDirToTar(tw *tar.Writer, root, dir, relPrefix string) error {
 				return err
 			}
 			if rinfo.IsDir() {
-				if err := addDirToTar(tw, root, resolved, rel); err != nil {
+				if err := addDirToTar(tw, root, resolved, rel, visited); err != nil {
 					return err
 				}
 			} else if rinfo.Mode().IsRegular() {
@@ -281,7 +294,7 @@ func addDirToTar(tw *tar.Writer, root, dir, relPrefix string) error {
 			if err := tw.WriteHeader(hdr); err != nil {
 				return err
 			}
-			if err := addDirToTar(tw, root, path, rel); err != nil {
+			if err := addDirToTar(tw, root, path, rel, visited); err != nil {
 				return err
 			}
 			continue

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -279,6 +279,14 @@ func addDirToTar(tw *tar.Writer, root, dir, relPrefix string, visited map[string
 				return err
 			}
 			if rinfo.IsDir() {
+				hdr, err := tar.FileInfoHeader(rinfo, "")
+				if err != nil {
+					return err
+				}
+				hdr.Name = filepath.ToSlash(rel)
+				if err := tw.WriteHeader(hdr); err != nil {
+					return err
+				}
 				if err := addDirToTar(tw, root, resolved, rel, visited); err != nil {
 					return err
 				}

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -293,8 +293,9 @@ func publishBundles(bundles []string) (v1.ImageIndex, error) {
 		}
 		platform := strings.TrimSpace(parts[0])
 		path := strings.TrimSpace(parts[1])
-		if !strings.Contains(platform, "/") {
-			return nil, fmt.Errorf("invalid platform %q in --bundle %q, want linux/amd64", platform, b)
+		platformParts := strings.Split(platform, "/")
+		if len(platformParts) != 2 || platformParts[0] == "" || platformParts[1] == "" {
+			return nil, fmt.Errorf("invalid platform %q in --bundle %q, want os/arch i.e. linux/amd64", platform, b)
 		}
 		img, err := buildImageFromBundle(path, platform)
 		if err != nil {

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -154,6 +154,13 @@ func splitImage(image string) (repo, tag string, hasTag bool, err error) {
 }
 
 func buildImageFromDir(dir string) (v1.Image, error) {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("source %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("source %s is not a directory", dir)
+	}
 	tarBytes, err := tarDir(dir)
 	if err != nil {
 		return nil, err

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -5,7 +5,6 @@ package oci
 
 import (
 	"archive/tar"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -84,6 +83,9 @@ as ttl.sh need no login at all.`,
 		if len(bundles) == 0 && len(args) == 0 {
 			return fmt.Errorf("please provide a source directory or at least one --bundle")
 		}
+		if len(args) > 1 {
+			return fmt.Errorf("expected a single source directory, got %d arguments", len(args))
+		}
 
 		var publish func(ref string) error
 		if len(bundles) > 0 {
@@ -99,9 +101,12 @@ as ttl.sh need no login at all.`,
 				return remote.WriteIndex(r, idx, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 			}
 		} else {
-			img, err := buildImageFromDir(args[0])
+			img, cleanup, err := buildImageFromDir(args[0])
 			if err != nil {
 				return err
+			}
+			if cleanup != nil {
+				defer cleanup()
 			}
 			publish = func(ref string) error {
 				r, err := name.ParseReference(ref)
@@ -153,29 +158,45 @@ func splitImage(image string) (repo, tag string, hasTag bool, err error) {
 	return repo, tag, hasTag, nil
 }
 
-func buildImageFromDir(dir string) (v1.Image, error) {
+func buildImageFromDir(dir string) (v1.Image, func(), error) {
 	info, err := os.Stat(dir)
 	if err != nil {
-		return nil, fmt.Errorf("source %s: %w", dir, err)
+		return nil, nil, fmt.Errorf("source %s: %w", dir, err)
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("source %s is not a directory", dir)
+		return nil, nil, fmt.Errorf("source %s is not a directory", dir)
 	}
-	tarBytes, err := tarDir(dir)
+
+	tmp, err := os.CreateTemp("", "arkade-oci-publish-*.tar")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	layer, err := tarball.LayerFromReader(bytes.NewReader(tarBytes))
+	cleanup := func() { os.Remove(tmp.Name()) }
+
+	if err := tarDir(dir, tmp); err != nil {
+		tmp.Close()
+		cleanup()
+		return nil, nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	layer, err := tarball.LayerFromFile(tmp.Name())
 	if err != nil {
-		return nil, fmt.Errorf("tarring %s: %w", dir, err)
+		cleanup()
+		return nil, nil, fmt.Errorf("tarring %s: %w", dir, err)
 	}
 	img, err := mutate.AppendLayers(empty.Image, layer)
 	if err != nil {
-		return nil, err
+		cleanup()
+		return nil, nil, err
 	}
 	cfg, err := img.ConfigFile()
 	if err != nil {
-		return nil, err
+		cleanup()
+		return nil, nil, err
 	}
 	cfg = cfg.DeepCopy()
 	arch, osName := env.GetClientArch()
@@ -185,12 +206,16 @@ func buildImageFromDir(dir string) (v1.Image, error) {
 	}
 	cfg.OS = downloadOS
 	cfg.Architecture = downloadArch
-	return mutate.ConfigFile(img, cfg)
+	img, err = mutate.ConfigFile(img, cfg)
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	return img, cleanup, nil
 }
 
-func tarDir(dir string) ([]byte, error) {
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
+func tarDir(dir string, w io.Writer) error {
+	tw := tar.NewWriter(w)
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -222,20 +247,20 @@ func tarDir(dir string) ([]byte, error) {
 			if err != nil {
 				return err
 			}
-			defer f.Close()
 			if _, err := io.Copy(tw, f); err != nil {
+				f.Close()
+				return err
+			}
+			if err := f.Close(); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if err := tw.Close(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
+	return tw.Close()
 }
 
 func buildImageFromBundle(path, platform string) (v1.Image, error) {

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -240,11 +240,19 @@ func addDirToTar(tw *tar.Writer, root, dir, relPrefix string) error {
 		}
 
 		// Dereference symlinks so the published image extracts cleanly with
-		// "arkade oci install", whose default refuses symlink entries.
+		// "arkade oci install", whose default refuses symlink entries. The
+		// resolved target must stay within the source tree.
 		if info.Mode()&os.ModeSymlink != 0 {
 			resolved, err := filepath.EvalSymlinks(path)
 			if err != nil {
 				return fmt.Errorf("broken symlink %s: %w", path, err)
+			}
+			within, err := pathWithin(root, resolved)
+			if err != nil {
+				return err
+			}
+			if !within {
+				return fmt.Errorf("symlink %s resolves outside the source directory %s", path, root)
 			}
 			rinfo, err := os.Stat(resolved)
 			if err != nil {
@@ -254,10 +262,12 @@ func addDirToTar(tw *tar.Writer, root, dir, relPrefix string) error {
 				if err := addDirToTar(tw, root, resolved, rel); err != nil {
 					return err
 				}
-			} else {
+			} else if rinfo.Mode().IsRegular() {
 				if err := writeFileToTar(tw, rel, resolved, rinfo); err != nil {
 					return err
 				}
+			} else {
+				fmt.Fprintf(os.Stderr, "skipping special file %s (mode %s)\n", rel, rinfo.Mode())
 			}
 			continue
 		}
@@ -277,11 +287,32 @@ func addDirToTar(tw *tar.Writer, root, dir, relPrefix string) error {
 			continue
 		}
 
+		if !info.Mode().IsRegular() {
+			fmt.Fprintf(os.Stderr, "skipping special file %s (mode %s)\n", rel, info.Mode())
+			continue
+		}
+
 		if err := writeFileToTar(tw, rel, path, info); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func pathWithin(root, target string) (bool, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return false, err
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(absRoot, absTarget)
+	if err != nil {
+		return false, err
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)), nil
 }
 
 func writeFileToTar(tw *tar.Writer, rel, path string, info os.FileInfo) error {

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -1,0 +1,281 @@
+// Copyright (c) arkade author(s) 2024. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/alexellis/arkade/pkg/env"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/spf13/cobra"
+)
+
+func MakeOciPublish() *cobra.Command {
+	command := &cobra.Command{
+		Use:     "publish",
+		Aliases: []string{"push", "export"},
+		Short:   "Publish a directory or set of tarballs as an OCI image",
+		Long: `Bundle and publish the contents of a directory, or a set of pre-built
+tarballs, as an OCI image. This is the inverse of "arkade oci install":
+instead of pulling an image and extracting its layers, you push a layer
+built from your files and tag it on a registry.
+
+Without --bundle, the positional directory is tarred into a single layer
+and pushed. With one or more --bundle flags, each pre-built tarball is
+attached as a layer carrying its platform (os/arch, i.e. linux/amd64) and
+the result is published as a multi-arch index, so "arkade oci install"
+can pull the correct platform for a given architecture.
+
+Credentials come from your local Docker keychain (the same login that
+docker login writes). On GitHub Actions, that keychain is populated by
+the docker/login-action step for ghcr.io, so this command uses the
+credentials already available in your workflow. Anonymous registries such
+as ttl.sh need no login at all.`,
+		Example: `  # Publish a single directory as one layer to a single tag
+  arkade oci publish ./dist -t ghcr.io/me/app:0.1.0
+
+  # Multiple tags, one -t per identifier, like docker build
+  arkade oci publish ./dist \
+    -t ghcr.io/me/app:0.1.0 \
+    -t ghcr.io/me/app:latest
+
+  # Omitting the tag falls back to :latest
+  arkade oci publish ./dist -t ghcr.io/me/app
+
+  # Multi-arch index from pre-built tarballs, one per platform
+  arkade oci publish \
+    -t ghcr.io/me/app:0.1.0 \
+    --bundle linux/amd64=./app-amd64.tgz \
+    --bundle linux/arm64=./app-arm64.tgz
+
+  # Anonymous registry for testing; the :1h tag expires after an hour,
+  # so only use that tag and not :latest, which would persist
+  arkade oci publish ./dist -t ttl.sh/me/app:1h`,
+		SilenceUsage: true,
+	}
+
+	command.Flags().StringArrayP("tag", "t", []string{}, "Image identifier (format: [registry/]repository[:tag]), repeatable, i.e. -t ghcr.io/me/app:0.1.0 -t ghcr.io/me/app:latest")
+	command.Flags().StringArray("bundle", []string{}, "Pre-built tarball with a platform key, i.e. linux/amd64=./app-amd64.tgz (repeatable)")
+
+	command.RunE = func(cmd *cobra.Command, args []string) error {
+		tags, _ := cmd.Flags().GetStringArray("tag")
+		bundles, _ := cmd.Flags().GetStringArray("bundle")
+
+		if len(tags) == 0 {
+			return fmt.Errorf("please provide at least one image via -t/--tag, i.e. -t ghcr.io/me/app:0.1.0")
+		}
+		if len(bundles) > 0 && len(args) > 0 {
+			return fmt.Errorf("provide either a source directory or --bundle, not both")
+		}
+		if len(bundles) == 0 && len(args) == 0 {
+			return fmt.Errorf("please provide a source directory or at least one --bundle")
+		}
+
+		var publish func(ref string) error
+		if len(bundles) > 0 {
+			idx, err := publishBundles(bundles)
+			if err != nil {
+				return err
+			}
+			publish = func(ref string) error {
+				r, err := name.ParseReference(ref)
+				if err != nil {
+					return err
+				}
+				return remote.WriteIndex(r, idx, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+			}
+		} else {
+			img, err := buildImageFromDir(args[0])
+			if err != nil {
+				return err
+			}
+			publish = func(ref string) error {
+				r, err := name.ParseReference(ref)
+				if err != nil {
+					return err
+				}
+				return crane.Push(img, r.Name())
+			}
+		}
+
+		for _, t := range tags {
+			repo, embedded, hasEmbedded, err := splitImage(t)
+			if err != nil {
+				return err
+			}
+			if !hasEmbedded {
+				embedded = "latest"
+			}
+			ref := repo + ":" + embedded
+			if err := publish(ref); err != nil {
+				return fmt.Errorf("publishing %s: %w", ref, err)
+			}
+			fmt.Printf("Published %s\n", ref)
+		}
+		return nil
+	}
+
+	return command
+}
+
+// splitImage separates a repository name from an optional embedded tag,
+// e.g. ghcr.io/me/app:0.1.0 -> (ghcr.io/me/app, 0.1.0, true). A bare repo
+// with no tag is reported as not having an explicit tag so the caller can
+// default to :latest. Registry hosts with ports are handled by
+// go-containerregistry's name parser.
+func splitImage(image string) (repo, tag string, hasTag bool, err error) {
+	ref, err := name.ParseReference(image)
+	if err != nil {
+		return "", "", false, fmt.Errorf("parsing image %s: %w", image, err)
+	}
+	repo = ref.Context().Name()
+	if t, ok := ref.(name.Tag); ok {
+		lastSlash := strings.LastIndex(image, "/")
+		if strings.Contains(image[lastSlash+1:], ":") {
+			tag = t.TagStr()
+			hasTag = true
+		}
+	}
+	return repo, tag, hasTag, nil
+}
+
+func buildImageFromDir(dir string) (v1.Image, error) {
+	tarBytes, err := tarDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	layer, err := tarball.LayerFromReader(bytes.NewReader(tarBytes))
+	if err != nil {
+		return nil, fmt.Errorf("tarring %s: %w", dir, err)
+	}
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	cfg = cfg.DeepCopy()
+	arch, osName := env.GetClientArch()
+	downloadArch, downloadOS := getDownloadArch(arch, osName)
+	if downloadOS == "microsoft windows" {
+		downloadOS = "windows"
+	}
+	cfg.OS = downloadOS
+	cfg.Architecture = downloadArch
+	return mutate.ConfigFile(img, cfg)
+}
+
+func tarDir(dir string) ([]byte, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		var linkTarget string
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, err = os.Readlink(path)
+			if err != nil {
+				return err
+			}
+		}
+		hdr, err := tar.FileInfoHeader(info, linkTarget)
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() {
+			f, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if _, err := io.Copy(tw, f); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func buildImageFromBundle(path, platform string) (v1.Image, error) {
+	layer, err := tarball.LayerFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, err
+	}
+	cfg = cfg.DeepCopy()
+	if idx := strings.Index(platform, "/"); idx > 0 {
+		cfg.OS = platform[:idx]
+		cfg.Architecture = platform[idx+1:]
+	}
+	return mutate.ConfigFile(img, cfg)
+}
+
+func publishBundles(bundles []string) (v1.ImageIndex, error) {
+	var idx v1.ImageIndex = empty.Index
+	for _, b := range bundles {
+		parts := strings.SplitN(b, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid --bundle %q, want os/arch=file", b)
+		}
+		platform := strings.TrimSpace(parts[0])
+		path := strings.TrimSpace(parts[1])
+		if !strings.Contains(platform, "/") {
+			return nil, fmt.Errorf("invalid platform %q in --bundle %q, want linux/amd64", platform, b)
+		}
+		img, err := buildImageFromBundle(path, platform)
+		if err != nil {
+			return nil, err
+		}
+		cfg, _ := img.ConfigFile()
+		addendum := mutate.IndexAddendum{
+			Add: img,
+			Descriptor: v1.Descriptor{
+				Platform: &v1.Platform{OS: cfg.OS, Architecture: cfg.Architecture},
+			},
+		}
+		idx = mutate.AppendManifests(idx, addendum)
+	}
+	return idx, nil
+}

--- a/cmd/oci/publish.go
+++ b/cmd/oci/publish.go
@@ -219,51 +219,89 @@ func buildImageFromDir(dir string) (v1.Image, func(), error) {
 
 func tarDir(dir string, w io.Writer) error {
 	tw := tar.NewWriter(w)
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(dir, path)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			return nil
-		}
-		var linkTarget string
-		if info.Mode()&os.ModeSymlink != 0 {
-			linkTarget, err = os.Readlink(path)
-			if err != nil {
-				return err
-			}
-		}
-		hdr, err := tar.FileInfoHeader(info, linkTarget)
-		if err != nil {
-			return err
-		}
-		hdr.Name = filepath.ToSlash(rel)
-		if err := tw.WriteHeader(hdr); err != nil {
-			return err
-		}
-		if info.Mode().IsRegular() {
-			f, err := os.Open(path)
-			if err != nil {
-				return err
-			}
-			if _, err := io.Copy(tw, f); err != nil {
-				f.Close()
-				return err
-			}
-			if err := f.Close(); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	if err != nil {
+	if err := addDirToTar(tw, dir, dir, ""); err != nil {
 		return err
 	}
 	return tw.Close()
+}
+
+func addDirToTar(tw *tar.Writer, root, dir, relPrefix string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		path := filepath.Join(dir, e.Name())
+		rel := filepath.Join(relPrefix, e.Name())
+
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		// Dereference symlinks so the published image extracts cleanly with
+		// "arkade oci install", whose default refuses symlink entries.
+		if info.Mode()&os.ModeSymlink != 0 {
+			resolved, err := filepath.EvalSymlinks(path)
+			if err != nil {
+				return fmt.Errorf("broken symlink %s: %w", path, err)
+			}
+			rinfo, err := os.Stat(resolved)
+			if err != nil {
+				return err
+			}
+			if rinfo.IsDir() {
+				if err := addDirToTar(tw, root, resolved, rel); err != nil {
+					return err
+				}
+			} else {
+				if err := writeFileToTar(tw, rel, resolved, rinfo); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if info.IsDir() {
+			hdr, err := tar.FileInfoHeader(info, "")
+			if err != nil {
+				return err
+			}
+			hdr.Name = filepath.ToSlash(rel)
+			if err := tw.WriteHeader(hdr); err != nil {
+				return err
+			}
+			if err := addDirToTar(tw, root, path, rel); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := writeFileToTar(tw, rel, path, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFileToTar(tw *tar.Writer, rel, path string, info os.FileInfo) error {
+	hdr, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		return err
+	}
+	hdr.Name = filepath.ToSlash(rel)
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(tw, f); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func buildImageFromBundle(path, platform string) (v1.Image, error) {

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -107,6 +107,16 @@ func TestTarDirSymlinkTarget(t *testing.T) {
 	}
 }
 
+func TestBuildImageFromDirRejectsFile(t *testing.T) {
+	file := t.TempDir() + "/notadir"
+	if err := writeFile(file, "x"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := buildImageFromDir(file); err == nil {
+		t.Fatal("want error when source is a regular file, not a directory")
+	}
+}
+
 func TestBuildImageFromDirPlatform(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeFile(dir+"/f", "x"); err != nil {

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -158,6 +158,17 @@ func TestTarDirSymlinkOutsideRootErrors(t *testing.T) {
 	}
 }
 
+func TestTarDirSymlinkCycleErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink(".", dir+"/loop"); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err == nil {
+		t.Fatal("want error when a directory symlink cycles back into the source tree")
+	}
+}
+
 func TestTarDirSkipsSpecialFile(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeFile(dir+"/ok.txt", "x"); err != nil {

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -169,6 +169,29 @@ func TestTarDirSymlinkCycleErrors(t *testing.T) {
 	}
 }
 
+func TestTarDirSymlinkedSourceRoot(t *testing.T) {
+	real := t.TempDir()
+	if err := writeFile(real+"/real.txt", "content"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", real+"/link.txt"); err != nil {
+		t.Fatal(err)
+	}
+	base := t.TempDir()
+	linkDir := base + "/dist-link"
+	if err := os.Symlink(real, linkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := tarDir(linkDir, &buf); err != nil {
+		t.Fatalf("publishing through a symlinked source root should not reject in-tree symlinks: %s", err)
+	}
+	if !bytesContains(buf.Bytes(), "link.txt") {
+		t.Fatal("want link.txt in tar")
+	}
+}
+
 func TestTarDirSkipsSpecialFile(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeFile(dir+"/ok.txt", "x"); err != nil {

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -139,6 +140,38 @@ func TestTarDirBrokenSymlinkErrors(t *testing.T) {
 	var buf bytes.Buffer
 	if err := tarDir(dir, &buf); err == nil {
 		t.Fatal("want error for broken symlink")
+	}
+}
+
+func TestTarDirSymlinkOutsideRootErrors(t *testing.T) {
+	outside := t.TempDir()
+	if err := writeFile(outside+"/secret.txt", "sensitive"); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.Symlink(outside, dir+"/leak"); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err == nil {
+		t.Fatal("want error when symlink resolves outside the source directory")
+	}
+}
+
+func TestTarDirSkipsSpecialFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFile(dir+"/ok.txt", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(dir+"/pipe", 0600); err != nil {
+		t.Skipf("mkfifo unavailable: %s", err)
+	}
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err != nil {
+		t.Fatalf("tarDir should not error or hang on a FIFO: %s", err)
+	}
+	if bytesContains(buf.Bytes(), "pipe") {
+		t.Fatal("want FIFO to be skipped, not written to the tar")
 	}
 }
 

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) arkade author(s) 2024. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSplitImage(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantRepo string
+		wantTag  string
+		hasTag   bool
+	}{
+		{"ghcr.io/me/app:0.1.0", "ghcr.io/me/app", "0.1.0", true},
+		{"ghcr.io/me/app", "ghcr.io/me/app", "", false},
+		{"ttl.sh/me/app:1h", "ttl.sh/me/app", "1h", true},
+		{"ghcr.io/me/app:latest", "ghcr.io/me/app", "latest", true},
+	}
+	for _, tc := range tests {
+		repo, tag, hasTag, err := splitImage(tc.input)
+		if err != nil {
+			t.Fatalf("splitImage(%q) error: %s", tc.input, err)
+		}
+		if repo != tc.wantRepo || tag != tc.wantTag || hasTag != tc.hasTag {
+			t.Errorf("splitImage(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.input, repo, tag, hasTag, tc.wantRepo, tc.wantTag, tc.hasTag)
+		}
+	}
+}
+
+func TestPublishBundlesInvalidPlatform(t *testing.T) {
+	_, err := publishBundles([]string{"amd64=foo.tgz"})
+	if err == nil {
+		t.Fatal("want error for platform without os/arch separator")
+	}
+}
+
+func TestPublishBundlesMissingSeparator(t *testing.T) {
+	_, err := publishBundles([]string{"foo.tgz"})
+	if err == nil {
+		t.Fatal("want error for bundle without '=' separator")
+	}
+}
+
+func TestTarDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFile(dir+"/hello.txt", "world"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("hello.txt", dir+"/link.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := tarDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) == 0 {
+		t.Fatal("want non-empty tar")
+	}
+	if !bytesContains(data, "hello.txt") {
+		t.Fatal("want hello.txt in tar")
+	}
+	if !bytesContains(data, "link.txt") {
+		t.Fatal("want link.txt in tar")
+	}
+}
+
+func TestTarDirSymlinkTarget(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFile(dir+"/real.txt", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("real.txt", dir+"/link.txt"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := tarDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(data))
+	var linkName string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == "link.txt" {
+			linkName = hdr.Linkname
+		}
+	}
+	if linkName != "real.txt" {
+		t.Fatalf("want symlink target real.txt, got %q", linkName)
+	}
+}
+
+func TestBuildImageFromDirPlatform(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFile(dir+"/f", "x"); err != nil {
+		t.Fatal(err)
+	}
+	img, err := buildImageFromDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.OS == "" || cfg.Architecture == "" {
+		t.Fatalf("want OS and Architecture set on dir-built image, got os=%q arch=%q", cfg.OS, cfg.Architecture)
+	}
+}
+
+func TestBuildImageFromBundlePlatform(t *testing.T) {
+	img, err := buildImageFromBundle("", "linux/arm64")
+	if err == nil {
+		t.Fatal("want error reading missing bundle file")
+	}
+	_ = img
+}
+
+func writeFile(path, contents string) error {
+	return os.WriteFile(path, []byte(contents), 0600)
+}
+
+func bytesContains(data []byte, substr string) bool {
+	return strings.Contains(string(data), substr)
+}

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -192,6 +192,42 @@ func TestTarDirSymlinkedSourceRoot(t *testing.T) {
 	}
 }
 
+func TestTarDirSymlinkedEmptyDirPreserved(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/emptydir", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("emptydir", dir+"/emptylink"); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	found := false
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if hdr.Name == "emptylink" {
+			found = true
+			if hdr.Typeflag != tar.TypeDir {
+				t.Fatalf("want symlinked empty dir to be archived as a directory, got type %d", hdr.Typeflag)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("want symlinked empty directory preserved in the tar")
+	}
+}
+
 func TestTarDirSkipsSpecialFile(t *testing.T) {
 	dir := t.TempDir()
 	if err := writeFile(dir+"/ok.txt", "x"); err != nil {

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -59,10 +59,11 @@ func TestTarDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := tarDir(dir)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err != nil {
 		t.Fatal(err)
 	}
+	data := buf.Bytes()
 	if len(data) == 0 {
 		t.Fatal("want non-empty tar")
 	}
@@ -83,10 +84,11 @@ func TestTarDirSymlinkTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	data, err := tarDir(dir)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err != nil {
 		t.Fatal(err)
 	}
+	data := buf.Bytes()
 
 	tr := tar.NewReader(bytes.NewReader(data))
 	var linkName string
@@ -112,7 +114,7 @@ func TestBuildImageFromDirRejectsFile(t *testing.T) {
 	if err := writeFile(file, "x"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := buildImageFromDir(file); err == nil {
+	if _, _, err := buildImageFromDir(file); err == nil {
 		t.Fatal("want error when source is a regular file, not a directory")
 	}
 }
@@ -122,10 +124,11 @@ func TestBuildImageFromDirPlatform(t *testing.T) {
 	if err := writeFile(dir+"/f", "x"); err != nil {
 		t.Fatal(err)
 	}
-	img, err := buildImageFromDir(dir)
+	img, cleanup, err := buildImageFromDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer cleanup()
 	cfg, err := img.ConfigFile()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -37,9 +37,16 @@ func TestSplitImage(t *testing.T) {
 }
 
 func TestPublishBundlesInvalidPlatform(t *testing.T) {
-	_, err := publishBundles([]string{"amd64=foo.tgz"})
-	if err == nil {
-		t.Fatal("want error for platform without os/arch separator")
+	cases := []string{
+		"amd64=foo.tgz",          // no os/arch separator
+		"linux/=foo.tgz",         // missing arch
+		"/amd64=foo.tgz",         // missing os
+		"linux/amd64/v2=foo.tgz", // variant not supported
+	}
+	for _, c := range cases {
+		if _, err := publishBundles([]string{c}); err == nil {
+			t.Errorf("want error for invalid platform bundle %q", c)
+		}
 	}
 }
 

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -36,6 +36,12 @@ func TestSplitImage(t *testing.T) {
 	}
 }
 
+func TestSplitImageRejectsDigest(t *testing.T) {
+	if _, _, _, err := splitImage("ghcr.io/me/app@sha256:abc123"); err == nil {
+		t.Fatal("want error for digest reference")
+	}
+}
+
 func TestPublishBundlesInvalidPlatform(t *testing.T) {
 	cases := []string{
 		"amd64=foo.tgz",          // no os/arch separator

--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -88,9 +88,9 @@ func TestTarDir(t *testing.T) {
 	}
 }
 
-func TestTarDirSymlinkTarget(t *testing.T) {
+func TestTarDirSymlinkDereferenced(t *testing.T) {
 	dir := t.TempDir()
-	if err := writeFile(dir+"/real.txt", "x"); err != nil {
+	if err := writeFile(dir+"/real.txt", "target-content"); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink("real.txt", dir+"/link.txt"); err != nil {
@@ -101,10 +101,9 @@ func TestTarDirSymlinkTarget(t *testing.T) {
 	if err := tarDir(dir, &buf); err != nil {
 		t.Fatal(err)
 	}
-	data := buf.Bytes()
 
-	tr := tar.NewReader(bytes.NewReader(data))
-	var linkName string
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	found := false
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -114,11 +113,32 @@ func TestTarDirSymlinkTarget(t *testing.T) {
 			t.Fatal(err)
 		}
 		if hdr.Name == "link.txt" {
-			linkName = hdr.Linkname
+			found = true
+			if hdr.Typeflag != tar.TypeReg {
+				t.Fatalf("want link.txt dereferenced to a regular file, got type %d", hdr.Typeflag)
+			}
+			body, err := io.ReadAll(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != "target-content" {
+				t.Fatalf("want dereferenced link.txt to carry target content, got %q", body)
+			}
 		}
 	}
-	if linkName != "real.txt" {
-		t.Fatalf("want symlink target real.txt, got %q", linkName)
+	if !found {
+		t.Fatal("want link.txt in tar")
+	}
+}
+
+func TestTarDirBrokenSymlinkErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink("does-not-exist", dir+"/dangling"); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err == nil {
+		t.Fatal("want error for broken symlink")
 	}
 }
 

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -5007,6 +5007,10 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Name:            "crossplane",
 			VersionStrategy: GitHubVersionStrategy,
 			Description:     "Simplify some development and administration aspects of Crossplane.",
+			// Pinned to v2.3.0, transient: v2.4.0 (latest) ships no binaries.
+			// https://github.com/crossplane/crossplane/releases/tag/v2.4.0
+			// Unpin once binaries are restored.
+			Version: "v2.3.0",
 			URLTemplate: `
 					{{$arch := .Arch}}
 					{{$ext := "" }}

--- a/pkg/get/tools.go
+++ b/pkg/get/tools.go
@@ -5009,6 +5009,7 @@ https://github.com/{{.Owner}}/{{.Repo}}/releases/download/{{.Version}}/{{.Name}}
 			Description:     "Simplify some development and administration aspects of Crossplane.",
 			// Pinned to v2.3.0, transient: v2.4.0 (latest) ships no binaries.
 			// https://github.com/crossplane/crossplane/releases/tag/v2.4.0
+			// No upstream issue filed; binaries expected in a follow-up release.
 			// Unpin once binaries are restored.
 			Version: "v2.3.0",
 			URLTemplate: `


### PR DESCRIPTION
## What

Adds a public `arkade oci publish` command — the inverse of `arkade oci install`. Instead of pulling an image and extracting its layers, you bundle a directory (or pre-built tarballs) into an OCI image and push it to a registry.

- `cmd/oci/publish.go` — new command + helpers
- `cmd/oci/oci.go` — registers `publish` under the `oci` group
- `cmd/oci/publish_test.go` — unit tests (network-free)
- `README.md` — new "Publish to OCI images" section

## Syntax

Tag syntax follows `docker build`/`buildx`: one repeatable `-t/--tag` per image identifier, optionally embedding the tag. A bare repo falls back to `:latest`.

```bash
arkade oci publish ./dist -t ghcr.io/me/app:0.1.0

arkade oci publish ./dist -t ghcr.io/me/app:0.1.0 -t ghcr.io/me/app:latest

# multi-arch index from pre-built tarballs
arkade oci publish -t ghcr.io/me/app:0.1.0 \
  --bundle linux/amd64=./app-amd64.tgz \
  --bundle linux/arm64=./app-arm64.tgz
```

Credentials come from the local Docker keychain (`docker login` / the `docker/login-action` step). Anonymous registries like `ttl.sh` need no login.

## Testing proof points

- `go test ./cmd/oci/...` passes (splitImage, tarDir incl. symlink targets, dir-built platform, bundle validation).
- Single-dir publish → install round-trips (`ttl.sh/arkade-oci-test-single`, `:1h`).
- Multi-arch `--bundle` index published to `ttl.sh` resolves per-arch on install.
- **Real-world simulation:** pulled the real OpenFaaS Edge (faasd-pro) multi-arch package, repackaged it via this command to `ttl.sh`, then re-installed:
  - amd64 locally → `diff -r` byte-identical to the source bundle
  - arm64 on an aarch64 RPi5 → byte-identical
- The real `ghcr.io/openfaasltd/faasd-pro` image was **never** written to; all test pushes went to expiring `ttl.sh` tags.