### PR TITLE
Move oci publish FIFO test into a unix-only file

### DIFF
--- a/cmd/oci/publish_test.go
+++ b/cmd/oci/publish_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"syscall"
 	"testing"
 )
 
@@ -225,23 +224,6 @@ func TestTarDirSymlinkedEmptyDirPreserved(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("want symlinked empty directory preserved in the tar")
-	}
-}
-
-func TestTarDirSkipsSpecialFile(t *testing.T) {
-	dir := t.TempDir()
-	if err := writeFile(dir+"/ok.txt", "x"); err != nil {
-		t.Fatal(err)
-	}
-	if err := syscall.Mkfifo(dir+"/pipe", 0600); err != nil {
-		t.Skipf("mkfifo unavailable: %s", err)
-	}
-	var buf bytes.Buffer
-	if err := tarDir(dir, &buf); err != nil {
-		t.Fatalf("tarDir should not error or hang on a FIFO: %s", err)
-	}
-	if bytesContains(buf.Bytes(), "pipe") {
-		t.Fatal("want FIFO to be skipped, not written to the tar")
 	}
 }
 

--- a/cmd/oci/publish_unix_test.go
+++ b/cmd/oci/publish_unix_test.go
@@ -1,0 +1,26 @@
+//go:build unix
+
+package oci
+
+import (
+	"bytes"
+	"syscall"
+	"testing"
+)
+
+func TestTarDirSkipsSpecialFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeFile(dir+"/ok.txt", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(dir+"/pipe", 0600); err != nil {
+		t.Skipf("mkfifo unavailable: %s", err)
+	}
+	var buf bytes.Buffer
+	if err := tarDir(dir, &buf); err != nil {
+		t.Fatalf("tarDir should not error or hang on a FIFO: %s", err)
+	}
+	if bytesContains(buf.Bytes(), "pipe") {
+		t.Fatal("want FIFO to be skipped, not written to the tar")
+	}
+}


### PR DESCRIPTION
## What

Small follow-up that missed the `arkade oci publish` merge: the special-file (FIFO) test used `syscall.Mkfifo` inline in `publish_test.go`, which is Unix-specific and could break Windows test compilation. Move it into `publish_unix_test.go` with a `//go:build unix` tag; the rest of the tests stay platform-neutral.

## Testing

- `go test ./cmd/oci/...` passes.
- The only diff vs `master` is this test-file split.

This resolves the last review finding from the merged PR (Windows compilation portability).